### PR TITLE
build(workflow): 重命名 GitHub Actions 构建与发布工作流[release]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r output/requirements_app.txt    # ✅ 使用你的实际依赖文件
-          pip install pyinstaller                       # 确保安装 PyInstaller
+          pip install -r output/requirements_app.txt    
+          pip install pyinstaller                       # 安装 PyInstaller
 
       - name: Build with PyInstaller
-        run: pyinstaller output/build.spec --noconfirm  # ✅ spec 路径也正确
+        run: pyinstaller output/build.spec --noconfirm 
 
       - name: Rename executable
         shell: bash
@@ -87,4 +87,4 @@ jobs:
           files: |
             release-assets/*/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # 自动权限，无需额外 token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
重命名位于 `.github/workflows/main.yml` 的多平台构建与自动发布工作流配置文件。 该工作流原本用于在 push 到 main 分支时，构建 Windows、Linux 和 macOS 平台的可执行文件， 并自动创建 GitHub Release 发布版本。

- test release