### PR TITLE
fix(workflow): 修复构建工作流中的归档文件移动路径错误[release]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
             # 创建tar.gz归档
             cd dist
             tar -czf ${{ matrix.asset_name }}.tar.gz EasyKiConverter-linux
-            mv ${{ matrix.asset_name }}.tar.gz ../dist/${{ matrix.asset_name }}.tar.gz
+            cd ..
           else
             mv dist/EasyKiConverter dist/${{ matrix.asset_name }}
           fi


### PR DESCRIPTION
在 Linux 平台的构建流程中，创建 tar.gz 归档文件后，文件移动路径存在错误。
原先的路径拼接方式导致文件无法正确移动到目标位置。此修复通过调整
目录切换逻辑，确保归档文件能够正确地从 dist 目录移动到上级目录的
指定位置。