### PR TITLE
build(workflow): 修复 tar.gz 文件重命名逻辑[release]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
             cd dist
             tar -czf ${{ matrix.asset_name }}.tar.gz EasyKiConverter-linux
             cd ..
+            # 重命名tar.gz文件以匹配asset_name
+            mv dist/${{ matrix.asset_name }}.tar.gz dist/${{ matrix.asset_name }}
           else
             mv dist/EasyKiConverter dist/${{ matrix.asset_name }}
           fi


### PR DESCRIPTION
在构建工作流中添加重命名步骤，确保 tar.gz 文件名称与 asset_name 匹配，
避免发布时出现文件名不一致的问题。