### PR TITLE
ci(build): 添加os模块导入[release]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build and Release Multi-Platform Binaries
 
+imports: os
+
 on:
   push:
     branches:


### PR DESCRIPTION
在GitHub Actions工作流配置中添加了os模块的导入语句，以支持后续的多平台构建和发布流程。