### PR TITLE
build(build.spec): 移除资源文件和图标配置[release]

### DIFF
--- a/build_conf/build.spec
+++ b/build_conf/build.spec
@@ -6,11 +6,7 @@ a = Analysis(
     ['../src/ui/pyqt6/main.py'],
     pathex=['.', '../src'],
     binaries=[],
-    datas=[
-        ('../src/ui/pyqt6/resources/app_icon.svg', 'resources'),
-        ('../src/ui/pyqt6/resources/app_icon.svg', '.'),
-        ('../src/ui/pyqt6/resources', 'resources'),
-    ],
+    datas=[],
     hiddenimports=[
         'PyQt6.QtCore',
         'PyQt6.QtGui',
@@ -140,5 +136,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon='../src/ui/pyqt6/resources/app_icon.ico' if sys.platform.startswith('win') else None
+    icon=None  # 移除平台特定的图标配置
 )


### PR DESCRIPTION
移除了PyQt6应用中的资源文件配置，包括app_icon.svg和resources目录。
同时移除了平台特定的图标配置，统一使用默认图标处理方式。