### PR TITLE
feat(core): 添加数据手册下载功能并更新相关配置

### DIFF
--- a/src/core/easyeda/easyeda_api.py
+++ b/src/core/easyeda/easyeda_api.py
@@ -91,6 +91,12 @@ class EasyedaApi:
             print(f"API响应结构: {type(api_response)}")
             print(f"响应键: {list(api_response.keys()) if isinstance(api_response, dict) else '不是字典'}")
             
+            if not api_response or (
+                "code" in api_response and api_response["success"] is False
+            ):
+                logging.debug(f"{api_response}")
+                return {}
+
             return api_response
             
         except requests.exceptions.RequestException as e:
@@ -106,14 +112,6 @@ class EasyedaApi:
             print(f"未知错误: {e}")
             logging.error(f"未知错误 (LCSC ID: {lcsc_id}): {e}")
             return {}
-
-        if not api_response or (
-            "code" in api_response and api_response["success"] is False
-        ):
-            logging.debug(f"{api_response}")
-            return {}
-
-        return r.json()
 
     def get_cad_data_of_component(self, lcsc_id: str) -> dict:
         """
@@ -131,6 +129,13 @@ class EasyedaApi:
         cp_cad_info = self.get_info_from_easyeda_api(lcsc_id=lcsc_id)
         if cp_cad_info == {}:
             return {}
+        
+        # 检查响应是否包含result键
+        if "result" not in cp_cad_info:
+            logging.error(f"API响应中缺少'result'键. 响应键: {list(cp_cad_info.keys())}")
+            print(f"API响应中缺少'result'键. 响应键: {list(cp_cad_info.keys())}")
+            return {}
+            
         return cp_cad_info["result"]
 
     def get_raw_3d_model_obj(self, uuid: str) -> str:

--- a/src/core/easyeda/jlc_datasheet.py
+++ b/src/core/easyeda/jlc_datasheet.py
@@ -12,9 +12,24 @@ class JLCDatasheet:
         Args:
             export_path: 导出路径，数据手册将保存在该路径的datasheet子目录中
         """
-        # 设置简单的请求头
+        # 设置更完整的请求头，模拟真实浏览器访问
         self.headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+            'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+            'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8',
+            'Accept-Encoding': 'gzip, deflate, br, zstd',
+            'Cache-Control': 'no-cache',
+            'Pragma': 'no-cache',
+            'Sec-Ch-Ua': '"Google Chrome";v="141", "Not?A_Brand";v="8", "Chromium";v="141"',
+            'Sec-Ch-Ua-Mobile': '?0',
+            'Sec-Ch-Ua-Platform': '"Linux"',
+            'Sec-Fetch-Dest': 'document',
+            'Sec-Fetch-Mode': 'navigate',
+            'Sec-Fetch-Site': 'same-site',
+            'Sec-Fetch-User': '?1',
+            'Upgrade-Insecure-Requests': '1',
+            'Referer': 'https://www.szlcsc.com/',
+            'Priority': 'u=0, i'
         }
         
         # 设置导出路径
@@ -61,7 +76,29 @@ class JLCDatasheet:
         try:
             # 使用BeautifulSoup解析HTML
             soup = BeautifulSoup(html_content, 'html.parser')
+            # 查找具有data-spm="n"属性的a标签
+            target_element = soup.find('a', {'data-spm': 'n'})
+            print(target_element)
+            # 如果找到了目标元素，提取href属性
+            if target_element:
+                href = target_element.get('href')
+                if href:
+                    # 只保留问号之前的部分作为完整的产品链接
+                    if '?' in href:
+                        href = href.split('?')[0]
+                        print(f"找到第一个产品的购买链接: {href}")
+                    # 如果是相对路径，转换为绝对路径
+                    if href.startswith('//'):
+                        href = 'https:' + href
+                    elif href.startswith('/'):
+                        href = 'https://item.szlcsc.com' + href
+                    elif not href.startswith('http'):
+                        # 处理其他相对路径情况
+                        href = 'https://item.szlcsc.com' + href
+                    return href
             
+            # 保持向后兼容性，如果新方法失败，使用旧方法
+            print("使用XPath方法未找到产品链接，尝试使用旧方法")
             # 查找所有<script>标签
             scripts = soup.find_all('script')
             
@@ -82,7 +119,7 @@ class JLCDatasheet:
                                 if url:
                                     return url
                     
-            print("未找到position为1的产品链接")
+            print("未找到产品链接")
             return None
         except Exception as e:
             print(f"解析产品链接时出错: {e}")
@@ -179,7 +216,6 @@ class JLCDatasheet:
                     # 只保留问号之前的部分
                     if '?' in href:
                         href = href.split('?')[0]
-                    
                     return href
             
             print("未找到PDF下载链接")

--- a/src/core/easyeda/jlc_datasheet.py
+++ b/src/core/easyeda/jlc_datasheet.py
@@ -167,10 +167,14 @@ class JLCDatasheet:
     def fetch_product_page(self, url):
         """
         获取产品页面内容
-        :param url: 产品页面URL
+        :param url: 产品页面URL或包含URL的字典
         :return: 网页内容
         """
         try:
+            # 如果url是字典，提取其中的URL
+            if isinstance(url, dict) and 'url' in url:
+                url = url['url']
+            
             # 发送GET请求
             response = requests.get(url, headers=self.headers, timeout=10)
             response.raise_for_status()

--- a/src/core/easyeda/jlc_datasheet.py
+++ b/src/core/easyeda/jlc_datasheet.py
@@ -308,13 +308,23 @@ class JLCDatasheet:
         
         print("成功获取搜索结果，正在提取产品链接:")
         
-        # 2. 提取产品链接
-        product_url = self.extract_product_url(search_result)
-        if not product_url:
+        # 2. 提取产品链接和产品名称
+        product_info = self.extract_product_url(search_result)
+        if not product_info:
             print("提取产品链接失败")
             return False
         
+        # 处理product_info可能是字典或字符串的情况
+        if isinstance(product_info, dict):
+            product_url = product_info.get('url')
+            product_name = product_info.get('name')
+        else:
+            product_url = product_info
+            product_name = None
+        
         print(f"成功提取到产品链接: {product_url}")
+        if product_name:
+            print(f"产品名称: {product_name}")
         
         # 3. 获取产品页面
         product_page = self.fetch_product_page(product_url)
@@ -334,7 +344,17 @@ class JLCDatasheet:
         
         # 5. 下载PDF
         if not filename:
-            filename = f"{keyword}.pdf"
+            # 如果有产品名称，使用产品名称作为文件名；否则使用元器件编号
+            if product_name:
+                # 清理产品名称，确保适合用作文件名
+                clean_name = re.sub(r'[<>:"/\\|?*]', '_', product_name)
+                clean_name = re.sub(r'\s+', ' ', clean_name).strip()
+                # 限制文件名长度
+                if len(clean_name) > 100:
+                    clean_name = clean_name[:100]
+                filename = f"{clean_name}.pdf"
+            else:
+                filename = f"{keyword}.pdf"
         
         print(f"正在下载PDF文件并保存为: {filename}")
         success = self.download_pdf(pdf_url, filename)

--- a/src/core/easyeda/jlc_datasheet.py
+++ b/src/core/easyeda/jlc_datasheet.py
@@ -1,0 +1,225 @@
+import requests
+from bs4 import BeautifulSoup
+import json
+from pathlib import Path
+
+
+class JLCDatasheet:
+    def __init__(self, export_path=None):
+        """
+        初始化JLC数据表下载器
+        
+        Args:
+            export_path: 导出路径，数据手册将保存在该路径的datasheet子目录中
+        """
+        # 设置简单的请求头
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+        
+        # 设置导出路径
+        self.export_path = export_path
+        
+        # 创建保存PDF的目录
+        if export_path:
+            self.pdf_dir = Path(export_path) / "datasheet"
+        else:
+            self.pdf_dir = Path("datasheet")
+            
+        # 确保目录存在
+        self.pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    def search_product(self, keyword):
+        """
+        搜索元器件
+        :param keyword: 搜索关键词(元器件编号ID)
+        :return: 网页内容
+        """
+        try:
+            # 构造URL
+            url = f"https://so.szlcsc.com/global.html?k={keyword}"
+            
+            # 发送GET请求
+            response = requests.get(url, headers=self.headers, timeout=10)
+            response.raise_for_status()
+            
+            # 返回网页内容
+            return response.text
+        except requests.RequestException as e:
+            print(f"搜索产品时出错: {e}")
+            return None
+
+    def extract_product_url(self, html_content):
+        """
+        从搜索结果中提取第一个产品的购买链接
+        :param html_content: 搜索结果页面HTML内容
+        :return: 第一个产品的购买链接
+        """
+        if not html_content:
+            return None
+        
+        try:
+            # 使用BeautifulSoup解析HTML
+            soup = BeautifulSoup(html_content, 'html.parser')
+            
+            # 查找所有<script>标签
+            scripts = soup.find_all('script')
+            
+            # 查找包含JSON-LD数据的<script>标签
+            for script in scripts:
+                if script.get('type') == 'application/ld+json' and script.string:
+                    # 解析JSON内容
+                    json_data = json.loads(script.string)
+                    
+                    # 检查是否包含itemListElement
+                    if 'itemListElement' in json_data:
+                        # 遍历itemListElement查找position为1的项目
+                        for item in json_data['itemListElement']:
+                            if item.get('position') == 1:
+                                # 提取offers中的url
+                                offers = item.get('item', {}).get('offers', {})
+                                url = offers.get('url')
+                                if url:
+                                    return url
+                    
+            print("未找到position为1的产品链接")
+            return None
+        except Exception as e:
+            print(f"解析产品链接时出错: {e}")
+            return None
+
+    def fetch_product_page(self, url):
+        """
+        获取产品页面内容
+        :param url: 产品页面URL
+        :return: 网页内容
+        """
+        try:
+            # 发送GET请求
+            response = requests.get(url, headers=self.headers, timeout=10)
+            response.raise_for_status()
+            
+            # 返回网页内容
+            return response.text
+        except requests.RequestException as e:
+            print(f"获取产品页面内容时出错: {e}")
+            return None
+
+    def extract_pdf_link(self, html_content):
+        """
+        从产品页面HTML中提取PDF下载链接
+        :param html_content: 产品页面HTML内容
+        :return: PDF下载链接
+        """
+        if not html_content:
+            return None
+        
+        try:
+            # 使用BeautifulSoup解析HTML
+            soup = BeautifulSoup(html_content, 'html.parser')
+            
+            # 查找id为"item-pdf-down"的元素
+            pdf_link_element = soup.find(id="item-pdf-down")
+            
+            if pdf_link_element:
+                # 提取href属性
+                pdf_href = pdf_link_element.get('href')
+                if pdf_href:
+                    # 如果是相对路径，需要转换为绝对路径
+                    if pdf_href.startswith('//'):
+                        pdf_href = 'https:' + pdf_href
+                    elif pdf_href.startswith('/'):
+                        pdf_href = 'https://item.szlcsc.com' + pdf_href
+                    
+                    # 只保留问号之前的部分
+                    if '?' in pdf_href:
+                        pdf_href = pdf_href.split('?')[0]
+                    
+                    return pdf_href
+            
+            print("未找到id为'item-pdf-down'的元素")
+            return None
+        except Exception as e:
+            print(f"解析PDF下载链接时出错: {e}")
+            return None
+
+    def download_pdf(self, url, filename):
+        """
+        下载PDF文件
+        :param url: PDF文件URL
+        :param filename: 保存的文件名
+        :return: 是否成功下载
+        """
+        try:
+            # 完整的文件路径
+            filepath = self.pdf_dir / filename
+            
+            # 下载文件
+            response = requests.get(url, headers=self.headers, timeout=30)
+            response.raise_for_status()
+            
+            # 保存文件
+            with open(filepath, 'wb') as f:
+                f.write(response.content)
+            
+            print(f"PDF文件已成功下载到: {filepath}")
+            return True
+        except Exception as e:
+            print(f"下载PDF文件时出错: {e}")
+            return False
+
+    def download_datasheet(self, keyword, filename=None):
+        """
+        下载元器件数据表的完整流程
+        :param keyword: 元器件编号
+        :param filename: 保存的文件名（可选）
+        :return: 是否成功下载
+        """
+        print(f"正在搜索元器件数据手册: {keyword}")
+        
+        # 1. 搜索产品
+        search_result = self.search_product(keyword)
+        if not search_result:
+            print("搜索产品失败")
+            return False
+        
+        print("成功获取搜索结果，正在提取产品链接:")
+        
+        # 2. 提取产品链接
+        product_url = self.extract_product_url(search_result)
+        if not product_url:
+            print("提取产品链接失败")
+            return False
+        
+        print(f"成功提取到产品链接: {product_url}")
+        
+        # 3. 获取产品页面
+        product_page = self.fetch_product_page(product_url)
+        if not product_page:
+            print("获取产品页面失败")
+            return False
+        
+        print("成功获取产品页面，正在提取PDF链接:")
+        
+        # 4. 提取PDF链接
+        pdf_url = self.extract_pdf_link(product_page)
+        if not pdf_url:
+            print("提取PDF链接失败")
+            return False
+        
+        print(f"成功提取到PDF链接: {pdf_url}")
+        
+        # 5. 下载PDF
+        if not filename:
+            filename = f"{keyword}.pdf"
+        
+        print(f"正在下载PDF文件并保存为: {filename}")
+        success = self.download_pdf(pdf_url, filename)
+        
+        if success:
+            print(f"数据手册 {filename} 下载成功")
+        else:
+            print(f"数据手册 {filename} 下载失败")
+            
+        return success
+

--- a/src/ui/pyqt6/main.py
+++ b/src/ui/pyqt6/main.py
@@ -6,6 +6,12 @@ EasyKiConverter PyQt6 UI - 主程序入口
 import sys
 import os
 
+# 添加src目录到Python路径，确保可以导入EasyKiConverter模块
+current_dir = os.path.dirname(os.path.abspath(__file__))
+src_dir = os.path.join(current_dir, "..", "..", "..")
+if src_dir not in sys.path:
+    sys.path.insert(0, src_dir)
+
 import traceback
 from PyQt6.QtWidgets import QApplication, QMessageBox, QListWidgetItem, QFileDialog
 from PyQt6.QtGui import QIcon

--- a/src/ui/pyqt6/main.py
+++ b/src/ui/pyqt6/main.py
@@ -14,10 +14,7 @@ from src.ui.pyqt6.modern_main_window import ModernMainWindow
 from src.ui.pyqt6.utils.config_manager import ConfigManager
 from src.ui.pyqt6.utils.bom_parser import BOMParser
 from src.ui.pyqt6.utils.component_validator import ComponentValidator
-
-# 从workers目录导入新的ExportWorker类
 from src.ui.pyqt6.workers.export_worker import ExportWorker
-# 导入转换结果详情组件
 from src.ui.pyqt6.widgets.conversion_results_widget import ConversionResultsWidget
 
 class EasyKiConverterApp(ModernMainWindow):
@@ -243,12 +240,18 @@ class EasyKiConverterApp(ModernMainWindow):
         else:
             # 提取错误信息中的元件ID
             error_msg = result.get('error', 'Unknown error')
-            if component_id == 'Unknown' and 'Unknown' in error_msg:
-                # 尝试从错误信息中提取元件ID
-                import re
-                match = re.search(r'[C]\d+', error_msg)
-                if match:
-                    component_id = match.group(0)
+            # 如果componentId是Unknown，尝试从result中获取原始输入
+            if component_id == 'Unknown':
+                # 优先使用message字段作为元件ID
+                if 'message' in result and result['message'] != 'Unknown':
+                    component_id = result['message']
+                # 如果仍然无法获取，尝试从错误信息中提取元件ID
+                if component_id == 'Unknown':
+                    import re
+                    # 尝试从错误信息中提取元件ID
+                    match = re.search(r'[C]\d+', error_msg)
+                    if match:
+                        component_id = match.group(0)
             self.conversion_results["failed"].append({
                 "id": component_id,
                 "error": error_msg

--- a/src/ui/pyqt6/main.py
+++ b/src/ui/pyqt6/main.py
@@ -252,6 +252,9 @@ class EasyKiConverterApp(ModernMainWindow):
                     match = re.search(r'[C]\d+', error_msg)
                     if match:
                         component_id = match.group(0)
+                # 如果仍然无法获取，使用current_component作为备选
+                if component_id == 'Unknown' and hasattr(self, 'export_worker'):
+                    component_id = getattr(self.export_worker, 'current_component', 'Unknown')
             self.conversion_results["failed"].append({
                 "id": component_id,
                 "error": error_msg

--- a/src/ui/pyqt6/main.py
+++ b/src/ui/pyqt6/main.py
@@ -286,6 +286,9 @@ class EasyKiConverterApp(ModernMainWindow):
         """导出完成"""
         self.export_btn.setEnabled(True)
         
+        # 设置进度条为100%
+        self.progress_bar.set_progress(100)
+        
         # 计算详细统计信息
         failed_count = total - success_count
         success_rate = f"{(success_count / total * 100):.1f}%" if total > 0 else "0%"

--- a/src/ui/pyqt6/main.py
+++ b/src/ui/pyqt6/main.py
@@ -6,12 +6,6 @@ EasyKiConverter PyQt6 UI - 主程序入口
 import sys
 import os
 
-# 添加src目录到Python路径，确保可以导入EasyKiConverter模块
-current_dir = os.path.dirname(os.path.abspath(__file__))
-src_dir = os.path.join(current_dir, "..", "..", "..")
-if src_dir not in sys.path:
-    sys.path.insert(0, src_dir)
-
 import traceback
 from PyQt6.QtWidgets import QApplication, QMessageBox, QListWidgetItem, QFileDialog
 from PyQt6.QtGui import QIcon

--- a/src/ui/pyqt6/modern_main_window.py
+++ b/src/ui/pyqt6/modern_main_window.py
@@ -227,7 +227,7 @@ class ModernMainWindow(QMainWindow):
         welcome_layout.setContentsMargins(0, 0, 0, 20)
         welcome_layout.setSpacing(10)
         
-        title = QLabel("🚀 开始您的EDA转换之旅")
+        title = QLabel("✌️✌️✌️✌️✌️")
         title.setStyleSheet("""
             font-size: 32px;
             font-weight: 700;

--- a/src/ui/pyqt6/user_config.json
+++ b/src/ui/pyqt6/user_config.json
@@ -2,8 +2,8 @@
   "export_path": "/home/dennis/Desktop/test",
   "file_prefix": "test",
   "export_options": {
-    "symbol": true,
-    "footprint": true,
+    "symbol": false,
+    "footprint": false,
     "model3d": true,
     "datasheet": false
   },

--- a/src/ui/pyqt6/user_config.json
+++ b/src/ui/pyqt6/user_config.json
@@ -2,10 +2,10 @@
   "export_path": "/home/dennis/Desktop/test",
   "file_prefix": "test",
   "export_options": {
-    "symbol": false,
+    "symbol": true,
     "footprint": true,
-    "model3d": false,
-    "datasheet": false
+    "model3d": true,
+    "datasheet": true
   },
   "component_ids": [],
   "window_geometry": null,

--- a/src/ui/pyqt6/user_config.json
+++ b/src/ui/pyqt6/user_config.json
@@ -3,8 +3,8 @@
   "file_prefix": "test",
   "export_options": {
     "symbol": false,
-    "footprint": false,
-    "model3d": true,
+    "footprint": true,
+    "model3d": false,
     "datasheet": false
   },
   "component_ids": [],

--- a/src/ui/pyqt6/user_config.json
+++ b/src/ui/pyqt6/user_config.json
@@ -5,7 +5,7 @@
     "symbol": true,
     "footprint": true,
     "model3d": true,
-    "manual": false
+    "datasheet": true
   },
   "component_ids": [],
   "window_geometry": null,

--- a/src/ui/pyqt6/user_config.json
+++ b/src/ui/pyqt6/user_config.json
@@ -5,7 +5,7 @@
     "symbol": true,
     "footprint": true,
     "model3d": true,
-    "datasheet": true
+    "datasheet": false
   },
   "component_ids": [],
   "window_geometry": null,

--- a/src/ui/pyqt6/utils/config_manager.py
+++ b/src/ui/pyqt6/utils/config_manager.py
@@ -30,7 +30,8 @@ class ConfigManager:
             "export_options": {  # 导出选项
                 "symbol": True,
                 "footprint": True,
-                "model3d": True
+                "model3d": True,
+                "datasheet": False
             },
             "component_ids": [],  # 最近使用的元件编号
             "window_geometry": None,  # 窗口几何信息
@@ -123,7 +124,7 @@ class ConfigManager:
             # 确保导出选项是有效的
             export_options = config['export_options']
             if isinstance(export_options, dict):
-                for option in ['symbol', 'footprint', 'model3d']:
+                for option in ['symbol', 'footprint', 'model3d', 'datasheet']:
                     if option in export_options:
                         validated_config['export_options'][option] = bool(export_options[option])
                         

--- a/src/ui/pyqt6/widgets/modern_export_options_widget.py
+++ b/src/ui/pyqt6/widgets/modern_export_options_widget.py
@@ -150,231 +150,256 @@ class AnimatedExportOption(QWidget):
             
     def paintEvent(self, event):
         """绘制事件"""
-        painter = QPainter(self)
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        
-        # 移除缩放变换
-        # if hasattr(self, '_scale_factor') and self._scale_factor != 1.0:
-        #     center_x = self.width() / 2
-        #     center_y = self.height() / 2
-        #     painter.translate(center_x, center_y)
-        #     painter.scale(self._scale_factor, self._scale_factor)
-        #     painter.translate(-center_x, -center_y)
-        
-        # 绘制背景
-        self.draw_background(painter)
-        
-        # 移除涟漪效果绘制
-        # self.draw_ripples(painter)
-        
-        # 绘制边框
-        self.draw_border(painter)
-        
-        # 绘制图标
-        self.draw_icon(painter)
-        
-        # 绘制文本
-        self.draw_text(painter)
-        
-        # 绘制选中指示器
-        self.draw_check_indicator(painter)
-        
+        try:
+            painter = QPainter(self)
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+            
+            # 绘制背景
+            self.draw_background(painter)
+            
+            # 绘制边框
+            self.draw_border(painter)
+            
+            # 绘制图标
+            self.draw_icon(painter)
+            
+            # 绘制文本
+            self.draw_text(painter)
+            
+            # 绘制选中指示器
+            self.draw_check_indicator(painter)
+        except Exception as e:
+            # 如果绘制过程中出现异常，至少绘制一个简单的背景
+            try:
+                painter = QPainter(self)
+                painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+                painter.setBrush(QBrush(QColor(240, 240, 240)))
+                painter.setPen(Qt.PenStyle.NoPen)
+                painter.drawRoundedRect(self.rect(), 16, 16)
+            except Exception:
+                # 如果创建painter也失败，调用父类方法
+                super().paintEvent(event)
+            
     def draw_background(self, painter):
         """绘制背景"""
-        # 背景渐变
-        gradient = QLinearGradient(0, 0, 0, self.height())
-        if self._checked:
-            # 选中状态的渐变
-            gradient.setColorAt(0, QColor(59, 130, 246, 230))  # 蓝色
-            gradient.setColorAt(1, QColor(37, 99, 235, 230))  # 深蓝色
-        else:
-            # 未选中状态的渐变
-            gradient.setColorAt(0, QColor(255, 255, 255, 230))  # 白色
-            gradient.setColorAt(1, QColor(248, 250, 252, 230))  # 浅灰色
-            
-        # 悬停效果
-        if self._hovered:
-            # 增加悬停亮度
-            # 使用固定颜色而不是尝试获取渐变颜色
+        try:
+            # 背景渐变
+            gradient = QLinearGradient(0, 0, 0, self.height())
             if self._checked:
-                hover_color = QColor(79, 150, 255, 230)  # 更亮的蓝色
+                # 选中状态的渐变
+                gradient.setColorAt(0, QColor(59, 130, 246, 230))  # 蓝色
+                gradient.setColorAt(1, QColor(37, 99, 235, 230))  # 深蓝色
             else:
-                hover_color = QColor(255, 255, 255, 250)  # 更亮的白色
-            gradient.setColorAt(0, hover_color)
+                # 未选中状态的渐变
+                gradient.setColorAt(0, QColor(255, 255, 255, 230))  # 白色
+                gradient.setColorAt(1, QColor(248, 250, 252, 230))  # 浅灰色
+                
+            # 悬停效果
+            if self._hovered:
+                # 增加悬停亮度
+                # 使用固定颜色而不是尝试获取渐变颜色
+                if self._checked:
+                    hover_color = QColor(79, 150, 255, 230)  # 更亮的蓝色
+                else:
+                    hover_color = QColor(255, 255, 255, 250)  # 更亮的白色
+                gradient.setColorAt(0, hover_color)
+                
+            painter.setBrush(QBrush(gradient))
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.drawRoundedRect(self.rect(), 16, 16)
             
-        painter.setBrush(QBrush(gradient))
-        painter.setPen(Qt.PenStyle.NoPen)
-        painter.drawRoundedRect(self.rect(), 16, 16)
-        
-        # 添加内阴影效果
-        if self._checked:
-            painter.setPen(QPen(QColor(0, 0, 0, 30), 1))
-            painter.setBrush(Qt.BrushStyle.NoBrush)
-            painter.drawRoundedRect(1, 1, self.width() - 2, self.height() - 2, 16, 16)
+            # 添加内阴影效果
+            if self._checked:
+                painter.setPen(QPen(QColor(0, 0, 0, 30), 1))
+                painter.setBrush(Qt.BrushStyle.NoBrush)
+                painter.drawRoundedRect(1, 1, self.width() - 2, self.height() - 2, 16, 16)
+        except Exception as e:
+            # 如果渐变绘制失败，绘制简单背景
+            painter.setBrush(QBrush(QColor(255, 255, 255) if not self._checked else QColor(59, 130, 246)))
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.drawRoundedRect(self.rect(), 16, 16)
         
     def draw_border(self, painter):
         """绘制边框"""
-        # 基础边框
-        painter.setPen(QPen(QColor(226, 232, 240), 1))
-        painter.setBrush(Qt.BrushStyle.NoBrush)
-        painter.drawRoundedRect(1, 1, self.width() - 2, self.height() - 2, 16, 16)
-        
-        # 选中时的高亮边框
-        if self._checked:
-            highlight_gradient = QLinearGradient(0, 0, self.width(), 0)
-            highlight_gradient.setColorAt(0, QColor(96, 165, 250))
-            highlight_gradient.setColorAt(0.5, QColor(59, 130, 246))
-            highlight_gradient.setColorAt(1, QColor(37, 99, 235))
-            
-            pen = QPen(highlight_gradient, 2)
-            painter.setPen(pen)
+        try:
+            # 基础边框
+            painter.setPen(QPen(QColor(226, 232, 240), 1))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRoundedRect(1, 1, self.width() - 2, self.height() - 2, 16, 16)
             
-            # 添加发光效果
-            glow_pen = QPen(QColor(59, 130, 246, 80), 4)
-            glow_pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
-            painter.setPen(glow_pen)
-            painter.drawRoundedRect(3, 3, self.width() - 6, self.height() - 6, 14, 14)
+            # 选中时的高亮边框
+            if self._checked:
+                highlight_gradient = QLinearGradient(0, 0, self.width(), 0)
+                highlight_gradient.setColorAt(0, QColor(96, 165, 250))
+                highlight_gradient.setColorAt(0.5, QColor(59, 130, 246))
+                highlight_gradient.setColorAt(1, QColor(37, 99, 235))
+                
+                pen = QPen(highlight_gradient, 2)
+                painter.setPen(pen)
+                painter.drawRoundedRect(1, 1, self.width() - 2, self.height() - 2, 16, 16)
+                
+                # 添加发光效果
+                glow_pen = QPen(QColor(59, 130, 246, 80), 4)
+                glow_pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+                painter.setPen(glow_pen)
+                painter.drawRoundedRect(3, 3, self.width() - 6, self.height() - 6, 14, 14)
+        except Exception as e:
+            # 简单边框作为备选
+            painter.setPen(QPen(QColor(226, 232, 240), 1))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRoundedRect(1, 1, self.width() - 2, self.height() - 2, 16, 16)
             
     def draw_icon(self, painter):
         """绘制图标"""
-        if not self.icon:
-            return
+        try:
+            if not self.icon:
+                return
+                
+            # 图标位置和大小
+            icon_size = 40
+            icon_x = 25
+            icon_y = (self.height() - icon_size) // 2
             
-        # 图标位置和大小
-        icon_size = 40
-        icon_x = 25
-        icon_y = (self.height() - icon_size) // 2
-        
-        # 绘制图标背景圆
-        painter.setPen(Qt.PenStyle.NoPen)
-        if self._checked:
-            # 选中时的渐变背景
-            gradient = QLinearGradient(icon_x, icon_y, icon_x + icon_size, icon_y + icon_size)
-            gradient.setColorAt(0, QColor(255, 255, 255, 230))
-            gradient.setColorAt(1, QColor(241, 245, 249, 230))
-            painter.setBrush(QBrush(gradient))
-        else:
-            painter.setBrush(QBrush(QColor(226, 232, 240, 200)))
-        painter.drawEllipse(icon_x, icon_y, icon_size, icon_size)
-        
-        # 绘制图标文字
-        painter.setPen(QColor(30, 41, 59) if self._checked else QColor(100, 116, 139))
-        font = QFont("Segoe UI", 16, QFont.Weight.Bold)
-        painter.setFont(font)
-        painter.drawText(QRect(icon_x, icon_y, icon_size, icon_size), 
-                        Qt.AlignmentFlag.AlignCenter, self.icon)
-                        
-        # 选中时添加发光效果
-        if self._checked:
-            painter.setPen(QPen(QColor(255, 255, 255, 100), 2))
-            painter.setBrush(Qt.BrushStyle.NoBrush)
-            painter.drawEllipse(icon_x + 2, icon_y + 2, icon_size - 4, icon_size - 4)
+            # 绘制图标背景圆
+            painter.setPen(Qt.PenStyle.NoPen)
+            if self._checked:
+                # 选中时的渐变背景
+                gradient = QLinearGradient(icon_x, icon_y, icon_x + icon_size, icon_y + icon_size)
+                gradient.setColorAt(0, QColor(255, 255, 255, 230))
+                gradient.setColorAt(1, QColor(241, 245, 249, 230))
+                painter.setBrush(QBrush(gradient))
+            else:
+                painter.setBrush(QBrush(QColor(226, 232, 240, 200)))
+            painter.drawEllipse(icon_x, icon_y, icon_size, icon_size)
+            
+            # 绘制图标文字
+            painter.setPen(QColor(30, 41, 59) if self._checked else QColor(100, 116, 139))
+            font = QFont("Segoe UI", 16, QFont.Weight.Bold)
+            painter.setFont(font)
+            painter.drawText(QRect(icon_x, icon_y, icon_size, icon_size), 
+                            Qt.AlignmentFlag.AlignCenter, self.icon)
+                            
+            # 选中时添加发光效果
+            if self._checked:
+                painter.setPen(QPen(QColor(255, 255, 255, 100), 2))
+                painter.setBrush(Qt.BrushStyle.NoBrush)
+                painter.drawEllipse(icon_x + 2, icon_y + 2, icon_size - 4, icon_size - 4)
+        except Exception as e:
+            # 简单图标作为备选
+            pass
             
     def draw_text(self, painter):
         """绘制文本"""
-        # 标题
-        if self._checked:
-            # 选中时使用白色文字
-            painter.setPen(QColor(255, 255, 255))
-        else:
-            # 未选中时使用深色文字
-            painter.setPen(QColor(15, 23, 42))
+        try:
+            # 标题
+            if self._checked:
+                # 选中时使用白色文字
+                painter.setPen(QColor(255, 255, 255))
+            else:
+                # 未选中时使用深色文字
+                painter.setPen(QColor(15, 23, 42))
+                
+            font = QFont("Segoe UI", 12, QFont.Weight.Bold)
+            painter.setFont(font)
             
-        font = QFont("Segoe UI", 12, QFont.Weight.Bold)
-        painter.setFont(font)
-        
-        title_x = 80
-        title_y = 35
-        painter.drawText(title_x, title_y, self.title)
-        
-        # 描述
-        if self._checked:
-            # 选中时使用浅灰色文字
-            painter.setPen(QColor(241, 245, 249, 200))
-        else:
-            # 未选中时使用中灰色文字
-            painter.setPen(QColor(100, 116, 139))
+            title_x = 80
+            title_y = 35
+            painter.drawText(title_x, title_y, self.title)
             
-        font = QFont("Segoe UI", 9, QFont.Weight.Normal)
-        painter.setFont(font)
-        
-        desc_x = 80
-        desc_y = 60
-        # 自动换行
-        metrics = QFontMetrics(font)
-        elided_text = metrics.elidedText(self.description, Qt.TextElideMode.ElideRight, 180)
-        painter.drawText(desc_x, desc_y, elided_text)
-        
+            # 描述
+            if self._checked:
+                # 选中时使用浅灰色文字
+                painter.setPen(QColor(241, 245, 249, 200))
+            else:
+                # 未选中时使用中灰色文字
+                painter.setPen(QColor(100, 116, 139))
+                
+            font = QFont("Segoe UI", 9, QFont.Weight.Normal)
+            painter.setFont(font)
+            
+            desc_x = 80
+            desc_y = 60
+            # 自动换行
+            metrics = QFontMetrics(font)
+            elided_text = metrics.elidedText(self.description, Qt.TextElideMode.ElideRight, 180)
+            painter.drawText(desc_x, desc_y, elided_text)
+        except Exception as e:
+            # 简单文本作为备选
+            pass
+            
     def draw_check_indicator(self, painter):
         """绘制选中指示器"""
-        if not self._checked:
-            return
+        try:
+            if not self._checked:
+                return
+                
+            # 选中指示器位置
+            indicator_size = 24
+            indicator_x = self.width() - indicator_size - 20
+            indicator_y = 20
             
-        # 选中指示器位置
-        indicator_size = 24
-        indicator_x = self.width() - indicator_size - 20
-        indicator_y = 20
-        
-        # 绘制背景圆（带动画效果）
-        painter.setPen(Qt.PenStyle.NoPen)
-        
-        # 背景圆的动画效果
-        if self.check_animation.state() == QPropertyAnimation.State.Running:
-            # 动画进行中，根据进度调整透明度
-            alpha = int(230 * self.animation_progress)
-            painter.setBrush(QBrush(QColor(255, 255, 255, alpha)))
-        else:
-            painter.setBrush(QBrush(QColor(255, 255, 255, 230)))
+            # 绘制背景圆（带动画效果）
+            painter.setPen(Qt.PenStyle.NoPen)
             
-        painter.drawEllipse(indicator_x, indicator_y, indicator_size, indicator_size)
-        
-        # 绘制对勾
-        painter.setPen(QPen(QColor(37, 99, 235), 3, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
-        painter.setBrush(Qt.BrushStyle.NoBrush)
-        
-        # 对勾的三个点
-        center_x = indicator_x + indicator_size // 2
-        center_y = indicator_y + indicator_size // 2
-        
-        # 第一个点
-        p1_x = center_x - 6
-        p1_y = center_y + 0
-        
-        # 第二个点
-        p2_x = center_x - 1
-        p2_y = center_y + 5
-        
-        # 第三个点
-        p3_x = center_x + 6
-        p3_y = center_y - 6
-        
-        # 绘制对勾（带动画效果）
-        progress = self.animation_progress if self.check_animation.state() == QPropertyAnimation.State.Running else 1.0
-        
-        if progress > 0.3:
-            # 绘制第一段
-            end_progress = min(1.0, (progress - 0.3) / 0.7)
-            end_x = int(p1_x + (p2_x - p1_x) * end_progress)
-            end_y = int(p1_y + (p2_y - p1_y) * end_progress)
-            painter.drawLine(QPoint(int(p1_x), int(p1_y)), QPoint(end_x, end_y))
+            # 背景圆的动画效果
+            if self.check_animation and self.check_animation.state() == QPropertyAnimation.State.Running:
+                # 动画进行中，根据进度调整透明度
+                alpha = int(230 * self.animation_progress)
+                painter.setBrush(QBrush(QColor(255, 255, 255, alpha)))
+            else:
+                painter.setBrush(QBrush(QColor(255, 255, 255, 230)))
+                
+            painter.drawEllipse(indicator_x, indicator_y, indicator_size, indicator_size)
             
-        if progress > 0.6:
-            # 绘制第二段
-            end_progress = min(1.0, (progress - 0.6) / 0.4)
-            start_x = int(p2_x)
-            start_y = int(p2_y)
-            end_x = int(p2_x + (p3_x - p2_x) * end_progress)
-            end_y = int(p2_y + (p3_y - p2_y) * end_progress)
-            painter.drawLine(QPoint(start_x, start_y), QPoint(end_x, end_y))
-            
-        # 添加发光效果
-        if self.check_animation.state() != QPropertyAnimation.State.Running:
-            glow_pen = QPen(QColor(37, 99, 235, 100), 6)
-            glow_pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
-            painter.setPen(glow_pen)
+            # 绘制对勾
+            painter.setPen(QPen(QColor(37, 99, 235), 3, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap))
             painter.setBrush(Qt.BrushStyle.NoBrush)
-            painter.drawEllipse(indicator_x - 2, indicator_y - 2, indicator_size + 4, indicator_size + 4)
+            
+            # 对勾的三个点
+            center_x = indicator_x + indicator_size // 2
+            center_y = indicator_y + indicator_size // 2
+            
+            # 第一个点
+            p1_x = center_x - 6
+            p1_y = center_y + 0
+            
+            # 第二个点
+            p2_x = center_x - 1
+            p2_y = center_y + 5
+            
+            # 第三个点
+            p3_x = center_x + 6
+            p3_y = center_y - 6
+            
+            # 绘制对勾（带动画效果）
+            progress = self.animation_progress if self.check_animation and self.check_animation.state() == QPropertyAnimation.State.Running else 1.0
+            
+            if progress > 0.3:
+                # 绘制第一段
+                end_progress = min(1.0, (progress - 0.3) / 0.7)
+                end_x = int(p1_x + (p2_x - p1_x) * end_progress)
+                end_y = int(p1_y + (p2_y - p1_y) * end_progress)
+                painter.drawLine(QPoint(int(p1_x), int(p1_y)), QPoint(end_x, end_y))
+                
+            if progress > 0.6:
+                # 绘制第二段
+                end_progress = min(1.0, (progress - 0.6) / 0.4)
+                start_x = int(p2_x)
+                start_y = int(p2_y)
+                end_x = int(p2_x + (p3_x - p2_x) * end_progress)
+                end_y = int(p2_y + (p3_y - p2_y) * end_progress)
+                painter.drawLine(QPoint(start_x, start_y), QPoint(end_x, end_y))
+                
+            # 添加发光效果
+            if not self.check_animation or self.check_animation.state() != QPropertyAnimation.State.Running:
+                glow_pen = QPen(QColor(37, 99, 235, 100), 6)
+                glow_pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+                painter.setPen(glow_pen)
+                painter.setBrush(Qt.BrushStyle.NoBrush)
+                painter.drawEllipse(indicator_x - 2, indicator_y - 2, indicator_size + 4, indicator_size + 4)
+        except Exception as e:
+            # 简单对勾作为备选
+            pass
             
     @pyqtProperty(float)
     def animation_progress(self):

--- a/src/ui/pyqt6/widgets/modern_export_options_widget.py
+++ b/src/ui/pyqt6/widgets/modern_export_options_widget.py
@@ -33,9 +33,10 @@ class AnimatedExportOption(QWidget):
         self.hover_animation = None
         self.check_animation = None
         self.pulse_animation = None
-        self.scale_animation = None
-        self.ripple_effect = None
-        self.ripples = []
+        # 移除不需要的动画效果
+        # self.scale_animation = None
+        # self.ripple_effect = None
+        # self.ripples = []
         
         self.setup_ui()
         self.setup_animations()
@@ -64,8 +65,8 @@ class AnimatedExportOption(QWidget):
         self.pulse_animation.setStartValue(0.0)
         self.pulse_animation.setEndValue(1.0)
         
-        # 初始化缩放因子
-        self._scale_factor = 1.0
+        # 移除初始化缩放因子
+        # self._scale_factor = 1.0
         
     def isChecked(self):
         """获取选中状态"""
@@ -93,19 +94,19 @@ class AnimatedExportOption(QWidget):
         super().mousePressEvent(event)
         self.setChecked(not self._checked)
         
-        # 添加涟漪效果
-        self.add_ripple(event.pos())
+        # 移除涟漪效果
+        # self.add_ripple(event.pos())
         
-        # 添加按下缩放效果
-        self._scale_factor = 0.95
+        # 移除按下缩放效果
+        # self._scale_factor = 0.95
         self.update()
             
     def mouseReleaseEvent(self, event: QMouseEvent):
         """鼠标释放事件"""
         super().mouseReleaseEvent(event)
         
-        # 恢复原始大小
-        self._scale_factor = 1.0
+        # 移除恢复原始大小
+        # self._scale_factor = 1.0
         self.update()
             
     def enterEvent(self, event):
@@ -123,8 +124,8 @@ class AnimatedExportOption(QWidget):
         if self._checked and self.pulse_animation:
             self.pulse_animation.start()
             
-        # 添加悬停缩放效果
-        self._scale_factor = 1.05
+        # 移除悬停缩放效果
+        # self._scale_factor = 1.05
         self.update()
             
     def leaveEvent(self, event):
@@ -143,54 +144,28 @@ class AnimatedExportOption(QWidget):
             self.pulse_animation.stop()
             self.animation_progress = 0.0
             
-        # 恢复原始大小
-        self._scale_factor = 1.0
+        # 移除恢复原始大小
+        # self._scale_factor = 1.0
         self.update()
             
-    def add_ripple(self, pos):
-        """添加涟漪效果"""
-        ripple = {
-            'pos': pos,
-            'radius': 0,
-            'max_radius': 50,
-            'opacity': 1.0
-        }
-        self.ripples.append(ripple)
-        
-        # 创建动画
-        def update_ripple():
-            if ripple in self.ripples:
-                ripple['radius'] += 2
-                ripple['opacity'] -= 0.05
-                if ripple['opacity'] <= 0:
-                    self.ripples.remove(ripple)
-                self.update()
-                
-        timer = QTimer(self)
-        timer.timeout.connect(update_ripple)
-        timer.start(20)
-        
-        # 1秒后自动清理
-        QTimer.singleShot(1000, lambda: timer.stop() if ripple in self.ripples else None)
-        
     def paintEvent(self, event):
         """绘制事件"""
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
         
-        # 应用缩放变换
-        if hasattr(self, '_scale_factor') and self._scale_factor != 1.0:
-            center_x = self.width() / 2
-            center_y = self.height() / 2
-            painter.translate(center_x, center_y)
-            painter.scale(self._scale_factor, self._scale_factor)
-            painter.translate(-center_x, -center_y)
+        # 移除缩放变换
+        # if hasattr(self, '_scale_factor') and self._scale_factor != 1.0:
+        #     center_x = self.width() / 2
+        #     center_y = self.height() / 2
+        #     painter.translate(center_x, center_y)
+        #     painter.scale(self._scale_factor, self._scale_factor)
+        #     painter.translate(-center_x, -center_y)
         
         # 绘制背景
         self.draw_background(painter)
         
-        # 绘制涟漪效果
-        self.draw_ripples(painter)
+        # 移除涟漪效果绘制
+        # self.draw_ripples(painter)
         
         # 绘制边框
         self.draw_border(painter)
@@ -237,14 +212,6 @@ class AnimatedExportOption(QWidget):
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRoundedRect(1, 1, self.width() - 2, self.height() - 2, 16, 16)
         
-    def draw_ripples(self, painter):
-        """绘制涟漪效果"""
-        for ripple in self.ripples:
-            if ripple['radius'] > 0 and ripple['opacity'] > 0:
-                painter.setPen(QPen(QColor(255, 255, 255, int(255 * ripple['opacity'] * 0.3)), 2))
-                painter.setBrush(QBrush(QColor(255, 255, 255, int(255 * ripple['opacity'] * 0.1))))
-                painter.drawEllipse(ripple['pos'], ripple['radius'], ripple['radius'])
-                
     def draw_border(self, painter):
         """绘制边框"""
         # 基础边框

--- a/src/ui/pyqt6/widgets/modern_export_options_widget.py
+++ b/src/ui/pyqt6/widgets/modern_export_options_widget.py
@@ -441,13 +441,13 @@ class ModernExportOptionsWidget(QFrame):
             'symbol': True,
             'footprint': True,
             'model3d': True,
-            'manual': False  # 手册下载选项（暂时禁用）
+            'datasheet': False  # 数据手册下载选项
         }
         
         self.symbol_option = None
         self.footprint_option = None
         self.model3d_option = None
-        self.manual_option = None  # 手册选项
+        self.datasheet_option = None  # 数据手册选项
         
         self.setup_ui()
         self.setup_connections()
@@ -498,15 +498,14 @@ class ModernExportOptionsWidget(QFrame):
         self.model3d_option.setChecked(True)
         options_layout.addWidget(self.model3d_option)
         
-        # 手册下载选项（暂时禁用）
-        self.manual_option = AnimatedExportOption(
-            title="手册下载",
-            description="下载元件技术手册（即将推出）",
+        # 数据手册下载选项
+        self.datasheet_option = AnimatedExportOption(
+            title="数据手册",
+            description="下载元件技术手册PDF文件",
             icon="📖"
         )
-        self.manual_option.setChecked(False)
-        self.manual_option.setEnabled(False)  # 暂时禁用
-        options_layout.addWidget(self.manual_option)
+        self.datasheet_option.setChecked(False)
+        options_layout.addWidget(self.datasheet_option)
         
         options_layout.addStretch()
         layout.addLayout(options_layout)
@@ -519,14 +518,11 @@ class ModernExportOptionsWidget(QFrame):
             lambda checked: self.on_option_changed('footprint', checked))
         self.model3d_option.stateChanged.connect(
             lambda checked: self.on_option_changed('model3d', checked))
-        # 手册选项暂时不连接信号，因为功能未实现
+        self.datasheet_option.stateChanged.connect(
+            lambda checked: self.on_option_changed('datasheet', checked))
             
     def on_option_changed(self, option_name, checked):
         """选项改变处理"""
-        # 手册选项暂时不处理
-        if option_name == 'manual':
-            return
-            
         self.options[option_name] = checked
         self.exportOptionsChanged.emit(self.options.copy())
         
@@ -544,7 +540,8 @@ class ModernExportOptionsWidget(QFrame):
             self.footprint_option.setChecked(self.options.get('footprint', True))
         if self.model3d_option:
             self.model3d_option.setChecked(self.options.get('model3d', True))
-        # 手册选项暂时不设置
+        if self.datasheet_option:
+            self.datasheet_option.setChecked(self.options.get('datasheet', False))
             
     def setEnabled(self, enabled):
         """设置启用状态"""
@@ -555,6 +552,5 @@ class ModernExportOptionsWidget(QFrame):
             self.footprint_option.setEnabled(enabled)
         if self.model3d_option:
             self.model3d_option.setEnabled(enabled)
-        # 手册选项保持禁用状态
-        if self.manual_option:
-            self.manual_option.setEnabled(False)
+        if self.datasheet_option:
+            self.datasheet_option.setEnabled(enabled)

--- a/src/ui/pyqt6/workers/export_worker.py
+++ b/src/ui/pyqt6/workers/export_worker.py
@@ -258,9 +258,6 @@ class ExportWorker(QThread):
                     'exportPath': None
                 }
             
-            # 更新进度，显示正在处理当前元件
-            self.update_progress(f"{component_input}")
-            
             # 调用真实的转换函数
             result = self.export_component_real(lcsc_id, self.export_path, self.options, self.file_prefix)
             

--- a/src/ui/pyqt6/workers/export_worker.py
+++ b/src/ui/pyqt6/workers/export_worker.py
@@ -279,12 +279,12 @@ class ExportWorker(QThread):
     
     def export_component_real(self, lcsc_id: str, export_path: str, export_options: Dict[str, bool], file_prefix: str = None) -> Dict[str, Any]:
         """使用EasyKiConverter工具链导出元器件 - 线程安全版本"""
+        # 保存lcsc_id以便在错误处理中使用
+        self.current_lcsc_id = lcsc_id
+        
         try:
             files_created = []
             kicad_version = KicadVersion.v6
-            
-            # 保存lcsc_id以便在错误处理中使用
-            self.current_lcsc_id = lcsc_id
             
             # 初始化EasyEDA API
             easyeda_api = EasyedaApi()

--- a/src/ui/pyqt6/workers/export_worker.py
+++ b/src/ui/pyqt6/workers/export_worker.py
@@ -294,10 +294,12 @@ class ExportWorker(QThread):
             component_data = easyeda_api.get_cad_data_of_component(lcsc_id=lcsc_id)
             
             if not component_data:
+                error_msg = f"无法获取元件数据: {lcsc_id}。可能是元件ID无效或网络连接问题。"
+                self.logger.error(error_msg)
                 return {
                     "success": False,
                     "componentId": lcsc_id,
-                    "message": f"无法获取元件数据: {lcsc_id}",
+                    "message": error_msg,
                     "files": [],
                     "export_path": None
                 }


### PR DESCRIPTION
- 在导出选项中新增 `datasheet` 配置项，替换原有的 `manual` 选项
- 更新配置管理器和导出选项组件以支持数据手册下载开关
- 在导出工作线程中实现数据手册的下载逻辑
- 修复 Python 模块导入路径问题，确保核心模块正确加载
- 调整用户配置文件结构，启用数据手册导出默认值为 true
- 新增多种方式解析JLC元件页面中的PDF数据手册链接，提高兼容性和稳定性。
  方法1：保持原有通过id="item-pdf-down"查找的方式（向后兼容）；
  方法2：解析script标签中的pdfUrl变量获取链接；
- 移除不必要的动画和缩放效果
  移除了 AnimatedExportOption 组件中不再需要的缩放动画、涟漪效果以及相关的_scale_factor 属性。同时删除了对应的绘制逻辑和事件处理代码，简化了组件结构。