### PR TITLE
refactor: 重命名UI模块文件以提高命名清晰度

### DIFF
--- a/build_conf/build.spec
+++ b/build_conf/build.spec
@@ -53,7 +53,7 @@ else:
     icon_path = None
 
 a = Analysis(
-    ['../src/ui/pyqt6/main.py'],
+    ['../src/ui/pyqt6/app_main.py'],
     pathex=['.', '../src'],
     binaries=[],
     datas=icon_files,

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -27,12 +27,12 @@ pip install -r build_conf/requirements_app.txt
 
 ```bash
 # 启动PyQt6 UI
-python -m src.ui.pyqt6.main
+python app_main.py
 ```
 
 **UI开发：**
-- 修改 `main.py` - 主程序入口和业务逻辑
-- 修改 `modern_main_window.py` - 主窗口界面
+- 修改 `app_main.py` - 主程序入口和业务逻辑
+- 修改 `base_main_window.py` - 基础窗口界面
 - 修改 `widgets/` 目录下的各种UI组件
 - 修改 `utils/` 目录下的工具类和样式管理
 

--- a/docs/development_guide_en.md
+++ b/docs/development_guide_en.md
@@ -21,12 +21,12 @@ pip install -r build_conf/requirements_app.txt
 ```bash
 # Start PyQt6 UI
 cd src/ui/pyqt6
-python main.py
+python app_main.py
 ```
 
 **UI Development:**
-- Modify `main.py` - Main program entry and business logic
-- Modify `modern_main_window.py` - Main window interface
+- Modify `app_main.py` - Main program entry and business logic
+- Modify `base_main_window.py` - Base window interface
 - Modify various UI components in the `widgets/` directory
 - Modify utility classes and style management in the `utils/` directory
 
@@ -40,11 +40,11 @@ python main.py
 ```bash
 # Run basic conversion test
 cd src
-python main.py --lcsc_id C13377 --symbol --debug
+python app_main.py --lcsc_id C13377 --symbol --debug
 
 # Test different component types
-python main.py --lcsc_id C25804 --footprint --debug  # Test footprints
-python main.py --lcsc_id C13377 --model3d --debug    # Test 3D models
+python app_main.py --lcsc_id C25804 --footprint --debug  # Test footprints
+python app_main.py --lcsc_id C13377 --model3d --debug    # Test 3D models
 ```
 
 ## 🔧 Code Structure
@@ -59,7 +59,7 @@ python main.py --lcsc_id C13377 --model3d --debug    # Test 3D models
 ## 🔧 Command Line Options
 
 ```bash
-python main.py [options]
+python app_main.py [options]
 
 Required parameters:
   --lcsc_id TEXT         LCSC part number to convert (e.g., C13377)
@@ -82,14 +82,14 @@ Optional parameters:
 
 ```bash
 # Export all content to default directory
-python main.py --lcsc_id C13377 --symbol --footprint --model3d
+python app_main.py --lcsc_id C13377 --symbol --footprint --model3d
 
 # Export symbols only to specified directory
-python main.py --lcsc_id C13377 --symbol --output_dir ./my_symbols
+python app_main.py --lcsc_id C13377 --symbol --output_dir ./my_symbols
 
 # Export to custom library name
-python main.py --lcsc_id C13377 --symbol --footprint --lib_name MyComponents
+python app_main.py --lcsc_id C13377 --symbol --footprint --lib_name MyComponents
 
 # Enable debug mode
-python main.py --lcsc_id C13377 --symbol --debug
+python app_main.py --lcsc_id C13377 --symbol --debug
 ```

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -43,8 +43,8 @@ EasyKiConverter/
 │       ├── __init__.py             # Python包初始化文件
 │       └── pyqt6/                  # PyQt6 桌面应用
 │           ├── __init__.py        # Python包初始化文件
-│           ├── main.py            # PyQt6 UI主程序入口
-│           ├── modern_main_window.py # 现代化主窗口
+│           ├── app_main.py        # PyQt6 UI主程序入口
+│           ├── base_main_window.py # 基础主窗口
 │           ├── user_config.json   # 用户配置文件
 │           ├── utils/             # UI工具函数
 │           │   ├── __init__.py    # Python包初始化文件
@@ -83,8 +83,8 @@ EasyKiConverter/
 ### 🖥️ PyQt6 UI 界面
 | 文件 | 功能描述 |
 |------|----------|
-| **src/ui/pyqt6/main.py** | PyQt6 UI主程序入口，包含主要业务逻辑 |
-| **src/ui/pyqt6/modern_main_window.py** | 现代化主窗口界面 |
+| **src/ui/pyqt6/app_main.py** | PyQt6 UI主程序入口，包含主要业务逻辑 |
+| **src/ui/pyqt6/base_main_window.py** | 基础主窗口界面 |
 | **src/ui/pyqt6/widgets/** | 各种UI组件 |
 | **src/ui/pyqt6/utils/** | UI工具函数和样式管理 |
 

--- a/docs/project_structure_en.md
+++ b/docs/project_structure_en.md
@@ -43,8 +43,8 @@ EasyKiConverter/
 │       ├── __init__.py             # Python package initialization file
 │       └── pyqt6/                  # PyQt6 desktop application
 │           ├── __init__.py        # Python package initialization file
-│           ├── main.py            # PyQt6 UI main entry
-│           ├── modern_main_window.py # Modern main window
+│           ├── app_main.py        # PyQt6 UI main entry
+│           ├── base_main_window.py # Base main window
 │           ├── user_config.json   # User configuration file
 │           ├── utils/             # UI utility functions
 │           │   ├── __init__.py    # Python package initialization file
@@ -83,8 +83,8 @@ EasyKiConverter/
 ### 🖥️ PyQt6 UI Interface
 | File | Function Description |
 |------|----------------------|
-| **src/ui/pyqt6/main.py** | PyQt6 UI main entry, contains main business logic |
-| **src/ui/pyqt6/modern_main_window.py** | Modern main window interface |
+| **src/ui/pyqt6/app_main.py** | PyQt6 UI main entry, contains main business logic |
+| **src/ui/pyqt6/base_main_window.py** | Base main window interface |
 | **src/ui/pyqt6/widgets/** | Various UI components |
 | **src/ui/pyqt6/utils/** | UI utility functions and style management |
 

--- a/src/ui/pyqt6/app_main.py
+++ b/src/ui/pyqt6/app_main.py
@@ -10,14 +10,14 @@ import traceback
 from PyQt6.QtWidgets import QApplication, QMessageBox, QListWidgetItem, QFileDialog
 from PyQt6.QtGui import QIcon
 
-from src.ui.pyqt6.modern_main_window import ModernMainWindow
+from src.ui.pyqt6.base_main_window import BaseMainWindow
 from src.ui.pyqt6.utils.config_manager import ConfigManager
 from src.ui.pyqt6.utils.bom_parser import BOMParser
 from src.ui.pyqt6.utils.component_validator import ComponentValidator
 from src.ui.pyqt6.workers.export_worker import ExportWorker
 from src.ui.pyqt6.widgets.conversion_results_widget import ConversionResultsWidget
 
-class EasyKiConverterApp(ModernMainWindow):
+class EasyKiConverterApp(BaseMainWindow):
     """EasyKiConverter应用主窗口"""
     
     def __init__(self, config_manager: ConfigManager, parent=None):

--- a/src/ui/pyqt6/base_main_window.py
+++ b/src/ui/pyqt6/base_main_window.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-主窗口 - 界面设计
+基础主窗口 - 界面设计
 采用从上至下的清晰布局
 """
 
@@ -16,8 +16,8 @@ from src.ui.pyqt6.utils.config_manager import ConfigManager
 from src.ui.pyqt6.utils.modern_ui_components import ModernCard, ModernProgressBar
 
 
-class ModernMainWindow(QMainWindow):
-    """主窗口"""
+class BaseMainWindow(QMainWindow):
+    """基础主窗口"""
     
     def __init__(self, config_manager: ConfigManager, parent=None):
         super().__init__(parent)


### PR DESCRIPTION
- 将 modern_main_window.py 重命名为 base_main_window.py，更准确反映其作为基础窗口类的角色
- 将 main.py 重命名为 app_main.py，明确表示这是应用程序主入口
- 更新所有相关引用，包括导入语句、文档和构建配置
- 同步更新了文档中的文件引用和命令示例

此更改使文件命名更加语义化，便于理解各模块的职责。