### PR TITLE
修复多部件符号导出时的坐标偏移问题

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,5 +31,5 @@ jobs:
         with:
           source: './src'
           extensions: 'h,cpp'
-          clangFormatVersion: 11
+          clangFormatVersion: 13
           style: file

--- a/src/core/easyeda/EasyedaApi.h
+++ b/src/core/easyeda/EasyedaApi.h
@@ -1,11 +1,11 @@
 ﻿#ifndef EASYEDAAPI_H
 #define EASYEDAAPI_H
 
+#include "core/utils/NetworkUtils.h"
+
 #include <QJsonObject>
 #include <QObject>
 #include <QString>
-
-#include "core/utils/NetworkUtils.h"
 
 namespace EasyKiConverter {
 

--- a/src/core/easyeda/EasyedaImporter.cpp
+++ b/src/core/easyeda/EasyedaImporter.cpp
@@ -128,6 +128,15 @@ QSharedPointer<SymbolData> EasyedaImporter::importSymbolData(const QJsonObject& 
 
                         SymbolPart part;
                         part.unitNumber = i;
+
+                        // 设置子部分的坐标原点（从 EasyEDA head 字段）
+                        if (subpartDataStr.contains("head")) {
+                            QJsonObject head = subpartDataStr["head"].toObject();
+                            part.originX = head["x"].toDouble(0.0);
+                            part.originY = head["y"].toDouble(0.0);
+                            qDebug() << "Subpart" << i << "origin: (" << part.originX << "," << part.originY << ")";
+                        }
+
                         qDebug() << "Importing subpart" << i << "from" << subpart["title"].toString();
 
                         // 导入子部分的图形元素

--- a/src/core/easyeda/EasyedaImporter.h
+++ b/src/core/easyeda/EasyedaImporter.h
@@ -1,12 +1,12 @@
 ﻿#ifndef EASYEDAIMPORTER_H
 #define EASYEDAIMPORTER_H
 
+#include "models/FootprintData.h"
+#include "models/SymbolData.h"
+
 #include <QJsonObject>
 #include <QObject>
 #include <QString>
-
-#include "models/FootprintData.h"
-#include "models/SymbolData.h"
 
 namespace EasyKiConverter {
 

--- a/src/core/easyeda/JLCDatasheet.h
+++ b/src/core/easyeda/JLCDatasheet.h
@@ -1,11 +1,11 @@
 ﻿#ifndef JLCDATASHEET_H
 #define JLCDATASHEET_H
 
+#include "core/utils/NetworkUtils.h"
+
 #include <QFile>
 #include <QObject>
 #include <QString>
-
-#include "core/utils/NetworkUtils.h"
 
 namespace EasyKiConverter {
 

--- a/src/core/kicad/Exporter3DModel.cpp
+++ b/src/core/kicad/Exporter3DModel.cpp
@@ -1,13 +1,12 @@
 ﻿#include "Exporter3DModel.h"
 
-#include <QTextStream>
+#include "core/utils/NetworkUtils.h"
 
 #include <QDebug>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonArray>
-
-#include "core/utils/NetworkUtils.h"
+#include <QTextStream>
 
 namespace EasyKiConverter {
 

--- a/src/core/kicad/Exporter3DModel.h
+++ b/src/core/kicad/Exporter3DModel.h
@@ -1,11 +1,11 @@
 ﻿#ifndef EXPORTER3DMODEL_H
 #define EXPORTER3DMODEL_H
 
+#include "models/Model3DData.h"
+
 #include <QByteArray>
 #include <QObject>
 #include <QString>
-
-#include "models/Model3DData.h"
 
 // 前向声明
 namespace EasyKiConverter {

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -1,13 +1,12 @@
 ﻿#include "ExporterFootprint.h"
 
-#include <QTextStream>
+#include "core/utils/GeometryUtils.h"
 
 #include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
-
-#include "core/utils/GeometryUtils.h"
+#include <QTextStream>
 
 namespace EasyKiConverter {
 

--- a/src/core/kicad/ExporterFootprint.h
+++ b/src/core/kicad/ExporterFootprint.h
@@ -1,14 +1,13 @@
 ﻿#ifndef EXPORTERFOOTPRINT_H
 #define EXPORTERFOOTPRINT_H
 
-#include <QTextStream>
+#include "models/FootprintData.h"
+#include "models/Model3DData.h"
 
 #include <QJsonObject>
 #include <QObject>
 #include <QString>
-
-#include "models/FootprintData.h"
-#include "models/Model3DData.h"
+#include <QTextStream>
 
 namespace EasyKiConverter {
 

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -1,12 +1,11 @@
 ﻿#include "ExporterSymbol.h"
 
-#include <QTextStream>
+#include "core/utils/GeometryUtils.h"
+#include "core/utils/SvgPathParser.h"
 
 #include <QDebug>
 #include <QFile>
-
-#include "core/utils/GeometryUtils.h"
-#include "core/utils/SvgPathParser.h"
+#include <QTextStream>
 
 namespace EasyKiConverter {
 
@@ -618,8 +617,7 @@ QString ExporterSymbol::generateSubSymbol(const SymbolData& symbolData,
     double partCenterX = partBBox.x + partBBox.width / 2.0;
     double partCenterY = partBBox.y + partBBox.height / 2.0;
 
-    qDebug() << "Sub-symbol" << part.unitNumber << "- partCenterX:" << partCenterX
-             << "partCenterY:" << partCenterY;
+    qDebug() << "Sub-symbol" << part.unitNumber << "- partCenterX:" << partCenterX << "partCenterY:" << partCenterY;
 
     // 临时保存当前的边界框
     SymbolBBox originalBBox = m_currentBBox;
@@ -630,8 +628,7 @@ QString ExporterSymbol::generateSubSymbol(const SymbolData& symbolData,
     m_currentBBox.width = partBBox.width;
     m_currentBBox.height = partBBox.height;
 
-    qDebug() << "Setting m_currentBBox for sub-symbol - x:" << m_currentBBox.x
-             << "y:" << m_currentBBox.y;
+    qDebug() << "Setting m_currentBBox for sub-symbol - x:" << m_currentBBox.x << "y:" << m_currentBBox.y;
 
     // 创建以子部分中心为基准的边界框（用于引脚）
     SymbolBBox centeredPartBBox;
@@ -1248,8 +1245,10 @@ SymbolBBox ExporterSymbol::calculatePartBBox(const SymbolPart& part) const {
 
     // 处理椭圆
     for (const auto& ellipse : part.ellipses) {
-        updateBounds(ellipse.centerX - ellipse.radiusX, ellipse.centerY - ellipse.radiusY,
-                    ellipse.radiusX * 2, ellipse.radiusY * 2);
+        updateBounds(ellipse.centerX - ellipse.radiusX,
+                     ellipse.centerY - ellipse.radiusY,
+                     ellipse.radiusX * 2,
+                     ellipse.radiusY * 2);
     }
 
     // 处理圆弧（使用路径点）
@@ -1284,8 +1283,7 @@ SymbolBBox ExporterSymbol::calculatePartBBox(const SymbolPart& part) const {
     bbox.width = maxX - minX;
     bbox.height = maxY - minY;
 
-    qDebug() << "Part BBox - x:" << bbox.x << "y:" << bbox.y
-             << "width:" << bbox.width << "height:" << bbox.height;
+    qDebug() << "Part BBox - x:" << bbox.x << "y:" << bbox.y << "width:" << bbox.width << "height:" << bbox.height;
 
     return bbox;
 }

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -1,13 +1,12 @@
 ﻿#ifndef EXPORTERSYMBOL_H
 #define EXPORTERSYMBOL_H
 
-#include <QTextStream>
+#include "models/SymbolData.h"
 
 #include <QJsonObject>
 #include <QObject>
 #include <QString>
-
-#include "models/SymbolData.h"
+#include <QTextStream>
 
 namespace EasyKiConverter {
 

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -223,6 +223,14 @@ private:
      */
     QString rotationToKicadOrientation(int rotation) const;
 
+    /**
+     * @brief 计算子部分的边界框
+     *
+     * @param part 子部分数据
+     * @return SymbolBBox 子部分的边界框
+     */
+    SymbolBBox calculatePartBBox(const SymbolPart& part) const;
+
 private:
     mutable SymbolBBox m_currentBBox;  // 当前处理的边界框
 };

--- a/src/core/utils/GeometryUtils.cpp
+++ b/src/core/utils/GeometryUtils.cpp
@@ -2,11 +2,12 @@
 
 #include <QDebug>
 #include <QRegularExpression>
+
 #include <cmath>
 #include <limits>
 
 #ifndef M_PI
-#define M_PI 3.14159265358979323846
+#    define M_PI 3.14159265358979323846
 #endif
 
 namespace EasyKiConverter {

--- a/src/core/utils/GeometryUtils.h
+++ b/src/core/utils/GeometryUtils.h
@@ -2,6 +2,7 @@
 #define GEOMETRYUTILS_H
 
 #include <QPointF>
+
 #include <cmath>
 
 namespace EasyKiConverter {

--- a/src/core/utils/NetworkUtils.cpp
+++ b/src/core/utils/NetworkUtils.cpp
@@ -13,15 +13,15 @@
 namespace EasyKiConverter {
 
 NetworkUtils::NetworkUtils(QObject* parent)
-    : QObject(parent),
-      m_networkManager(new QNetworkAccessManager(this)),
-      m_currentReply(nullptr),
-      m_timeoutTimer(new QTimer(this)),
-      m_timeout(30),
-      m_maxRetries(3),
-      m_retryCount(0),
-      m_isRequesting(false),
-      m_expectBinaryData(false) {
+    : QObject(parent)
+    , m_networkManager(new QNetworkAccessManager(this))
+    , m_currentReply(nullptr)
+    , m_timeoutTimer(new QTimer(this))
+    , m_timeout(30)
+    , m_maxRetries(3)
+    , m_retryCount(0)
+    , m_isRequesting(false)
+    , m_expectBinaryData(false) {
     // 设置默认请求�?
     m_headers["Accept-Encoding"] = "gzip, deflate";
     m_headers["Accept"] = "application/json, text/javascript, */*; q=0.01";

--- a/src/core/utils/NetworkUtils.h
+++ b/src/core/utils/NetworkUtils.h
@@ -1,12 +1,11 @@
 ﻿#ifndef NETWORKUTILS_H
 #define NETWORKUTILS_H
 
-#include <QTimer>
-
 #include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
+#include <QTimer>
 
 namespace EasyKiConverter {
 

--- a/src/core/utils/SvgPathParser.cpp
+++ b/src/core/utils/SvgPathParser.cpp
@@ -2,6 +2,7 @@
 
 #include <QDebug>
 #include <QRegularExpression>
+
 #include <cmath>
 
 namespace EasyKiConverter {

--- a/src/models/ComponentData.cpp
+++ b/src/models/ComponentData.cpp
@@ -6,15 +6,15 @@
 namespace EasyKiConverter {
 
 ComponentData::ComponentData()
-    : m_lcscId(),
-      m_name(),
-      m_prefix(),
-      m_package(),
-      m_manufacturer(),
-      m_datasheet(),
-      m_symbolData(nullptr),
-      m_footprintData(nullptr),
-      m_model3DData(nullptr) {}
+    : m_lcscId()
+    , m_name()
+    , m_prefix()
+    , m_package()
+    , m_manufacturer()
+    , m_datasheet()
+    , m_symbolData(nullptr)
+    , m_footprintData(nullptr)
+    , m_model3DData(nullptr) {}
 
 QJsonObject ComponentData::toJson() const {
     QJsonObject json;

--- a/src/models/ComponentData.h
+++ b/src/models/ComponentData.h
@@ -1,14 +1,14 @@
 ﻿#ifndef COMPONENTDATA_H
 #define COMPONENTDATA_H
 
+#include "FootprintData.h"
+#include "Model3DData.h"
+#include "SymbolData.h"
+
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QSharedPointer>
 #include <QString>
-
-#include "FootprintData.h"
-#include "Model3DData.h"
-#include "SymbolData.h"
 
 namespace EasyKiConverter {
 

--- a/src/models/ComponentExportStatus.h
+++ b/src/models/ComponentExportStatus.h
@@ -1,14 +1,14 @@
 ﻿#ifndef COMPONENTEXPORTSTATUS_H
 #define COMPONENTEXPORTSTATUS_H
 
-#include <QElapsedTimer>
-#include <QSharedPointer>
-#include <QString>
-
 #include "models/ComponentData.h"
 #include "models/FootprintData.h"
 #include "models/Model3DData.h"
 #include "models/SymbolData.h"
+
+#include <QElapsedTimer>
+#include <QSharedPointer>
+#include <QString>
 
 namespace EasyKiConverter {
 

--- a/src/models/FootprintData.h
+++ b/src/models/FootprintData.h
@@ -1,13 +1,13 @@
 ﻿#ifndef FOOTPRINTDATA_H
 #define FOOTPRINTDATA_H
 
+#include "Model3DData.h"
+
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QList>
 #include <QPointF>
 #include <QString>
-
-#include "Model3DData.h"
 
 namespace EasyKiConverter {
 

--- a/src/models/SymbolData.cpp
+++ b/src/models/SymbolData.cpp
@@ -814,6 +814,8 @@ void SymbolData::clear() {
 QJsonObject SymbolPart::toJson() const {
     QJsonObject json;
     json["unit_number"] = unitNumber;
+    json["origin_x"] = originX;
+    json["origin_y"] = originY;
 
     QJsonArray pinsArray;
     for (const SymbolPin& pin : pins) {
@@ -874,6 +876,8 @@ QJsonObject SymbolPart::toJson() const {
 
 bool SymbolPart::fromJson(const QJsonObject& json) {
     unitNumber = json["unit_number"].toInt(0);
+    originX = json["origin_x"].toDouble(0.0);
+    originY = json["origin_y"].toDouble(0.0);
 
     if (json.contains("pins")) {
         QJsonArray pinsArray = json["pins"].toArray();

--- a/src/models/SymbolData.h
+++ b/src/models/SymbolData.h
@@ -342,9 +342,9 @@ struct SymbolText {
  * @brief 符号部分（用于多部分符号）
  */
 struct SymbolPart {
-    int unitNumber;       // 部分编号（从 0 开始）
-    double originX;       // 子部分的坐标原点 X（从 EasyEDA head.x）
-    double originY;       // 子部分的坐标原点 Y（从 EasyEDA head.y）
+    int unitNumber;  // 部分编号（从 0 开始）
+    double originX;  // 子部分的坐标原点 X（从 EasyEDA head.x）
+    double originY;  // 子部分的坐标原点 Y（从 EasyEDA head.y）
     QList<SymbolPin> pins;
     QList<SymbolRectangle> rectangles;
     QList<SymbolCircle> circles;

--- a/src/models/SymbolData.h
+++ b/src/models/SymbolData.h
@@ -339,10 +339,12 @@ struct SymbolText {
 // ==================== 符号部分 ====================
 
 /**
- * @brief 符号部分（用于多部分符号�?
+ * @brief 符号部分（用于多部分符号）
  */
 struct SymbolPart {
-    int unitNumber;  // 部分编号（从 0 开始）
+    int unitNumber;       // 部分编号（从 0 开始）
+    double originX;       // 子部分的坐标原点 X（从 EasyEDA head.x）
+    double originY;       // 子部分的坐标原点 Y（从 EasyEDA head.y）
     QList<SymbolPin> pins;
     QList<SymbolRectangle> rectangles;
     QList<SymbolCircle> circles;

--- a/src/services/ComponentDataCollector.cpp
+++ b/src/services/ComponentDataCollector.cpp
@@ -1,20 +1,20 @@
 ﻿#include "ComponentDataCollector.h"
 
-#include <QDebug>
-
 #include "core/easyeda/EasyedaApi.h"
 #include "core/easyeda/EasyedaImporter.h"
+
+#include <QDebug>
 
 namespace EasyKiConverter {
 
 ComponentDataCollector::ComponentDataCollector(const QString& componentId, QObject* parent)
-    : QObject(parent),
-      m_componentId(componentId),
-      m_state(Idle),
-      m_export3DModel(true),
-      m_isCancelled(false),
-      m_api(new EasyedaApi(this)),
-      m_importer(new EasyedaImporter(this)) {
+    : QObject(parent)
+    , m_componentId(componentId)
+    , m_state(Idle)
+    , m_export3DModel(true)
+    , m_isCancelled(false)
+    , m_api(new EasyedaApi(this))
+    , m_importer(new EasyedaImporter(this)) {
     initializeApiConnections();
 }
 

--- a/src/services/ComponentDataCollector.h
+++ b/src/services/ComponentDataCollector.h
@@ -1,13 +1,13 @@
 ﻿#ifndef COMPONENTDATACOLLECTOR_H
 #define COMPONENTDATACOLLECTOR_H
 
-#include <QObject>
-#include <QString>
-
 #include "models/ComponentData.h"
 #include "models/FootprintData.h"
 #include "models/Model3DData.h"
 #include "models/SymbolData.h"
+
+#include <QObject>
+#include <QString>
 
 namespace EasyKiConverter {
 

--- a/src/services/ComponentExportTask.cpp
+++ b/src/services/ComponentExportTask.cpp
@@ -1,12 +1,12 @@
 ﻿#include "ComponentExportTask.h"
 
-#include <QDebug>
-#include <QDir>
-#include <QFile>
-
 #include "core/kicad/Exporter3DModel.h"
 #include "core/kicad/ExporterFootprint.h"
 #include "core/kicad/ExporterSymbol.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
 
 namespace EasyKiConverter {
 
@@ -16,13 +16,13 @@ ComponentExportTask::ComponentExportTask(const ComponentData& componentData,
                                          ExporterFootprint* footprintExporter,
                                          Exporter3DModel* modelExporter,
                                          QObject* parent)
-    : QObject(parent),
-      QRunnable(),
-      m_componentData(componentData),
-      m_options(options),
-      m_symbolExporter(symbolExporter),
-      m_footprintExporter(footprintExporter),
-      m_modelExporter(modelExporter) {
+    : QObject(parent)
+    , QRunnable()
+    , m_componentData(componentData)
+    , m_options(options)
+    , m_symbolExporter(symbolExporter)
+    , m_footprintExporter(footprintExporter)
+    , m_modelExporter(modelExporter) {
     setAutoDelete(true);
 }
 

--- a/src/services/ComponentExportTask.h
+++ b/src/services/ComponentExportTask.h
@@ -1,11 +1,11 @@
 ﻿#ifndef COMPONENTEXPORTTASK_H
 #define COMPONENTEXPORTTASK_H
 
-#include <QObject>
-#include <QRunnable>
-
 #include "ExportService.h"
 #include "models/ComponentData.h"
+
+#include <QObject>
+#include <QRunnable>
 
 namespace EasyKiConverter {
 

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -1,24 +1,24 @@
 #include "ComponentService.h"
 
+#include "core/easyeda/EasyedaApi.h"
+#include "core/easyeda/EasyedaImporter.h"
+
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 
-#include "core/easyeda/EasyedaApi.h"
-#include "core/easyeda/EasyedaImporter.h"
-
 namespace EasyKiConverter {
 
 ComponentService::ComponentService(QObject* parent)
-    : QObject(parent),
-      m_api(new EasyedaApi(this)),
-      m_importer(new EasyedaImporter(this)),
-      m_currentComponentId(),
-      m_hasDownloadedWrl(false),
-      m_parallelTotalCount(0),
-      m_parallelCompletedCount(0),
-      m_parallelFetching(false) {
+    : QObject(parent)
+    , m_api(new EasyedaApi(this))
+    , m_importer(new EasyedaImporter(this))
+    , m_currentComponentId()
+    , m_hasDownloadedWrl(false)
+    , m_parallelTotalCount(0)
+    , m_parallelCompletedCount(0)
+    , m_parallelFetching(false) {
     // 连接 API 信号
     connect(m_api, &EasyedaApi::componentInfoFetched, this, &ComponentService::handleComponentInfoFetched);
     connect(m_api, &EasyedaApi::cadDataFetched, this, &ComponentService::handleCadDataFetched);

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -1,16 +1,16 @@
 ﻿#ifndef COMPONENTSERVICE_H
 #define COMPONENTSERVICE_H
 
+#include "models/ComponentData.h"
+#include "models/FootprintData.h"
+#include "models/Model3DData.h"
+#include "models/SymbolData.h"
+
 #include <QJsonObject>
 #include <QMap>
 #include <QObject>
 #include <QString>
 #include <QStringList>
-
-#include "models/ComponentData.h"
-#include "models/FootprintData.h"
-#include "models/Model3DData.h"
-#include "models/SymbolData.h"
 
 namespace EasyKiConverter {
 

--- a/src/services/ExportService.cpp
+++ b/src/services/ExportService.cpp
@@ -1,31 +1,31 @@
 ﻿#include "ExportService.h"
 
-#include <QDebug>
-#include <QDir>
-#include <QFile>
-
 #include "ComponentExportTask.h"
 #include "core/kicad/Exporter3DModel.h"
 #include "core/kicad/ExporterFootprint.h"
 #include "core/kicad/ExporterSymbol.h"
 
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+
 namespace EasyKiConverter {
 
 ExportService::ExportService(QObject* parent)
-    : QObject(parent),
-      m_symbolExporter(new ExporterSymbol(this)),
-      m_footprintExporter(new ExporterFootprint(this)),
-      m_modelExporter(new Exporter3DModel(this)),
-      m_threadPool(new QThreadPool(this)),
-      m_mutex(new QMutex()),
-      m_isExporting(false),
-      m_currentProgress(0),
-      m_totalProgress(0),
-      m_successCount(0),
-      m_failureCount(0),
-      m_parallelExporting(false),
-      m_parallelCompletedCount(0),
-      m_parallelTotalCount(0) {}
+    : QObject(parent)
+    , m_symbolExporter(new ExporterSymbol(this))
+    , m_footprintExporter(new ExporterFootprint(this))
+    , m_modelExporter(new Exporter3DModel(this))
+    , m_threadPool(new QThreadPool(this))
+    , m_mutex(new QMutex())
+    , m_isExporting(false)
+    , m_currentProgress(0)
+    , m_totalProgress(0)
+    , m_successCount(0)
+    , m_failureCount(0)
+    , m_parallelExporting(false)
+    , m_parallelCompletedCount(0)
+    , m_parallelTotalCount(0) {}
 
 ExportService::~ExportService() {}
 

--- a/src/services/ExportService.h
+++ b/src/services/ExportService.h
@@ -1,17 +1,16 @@
 ﻿#ifndef EXPORTSERVICE_H
 #define EXPORTSERVICE_H
 
-#include <QThreadPool>
+#include "models/ComponentData.h"
+#include "models/FootprintData.h"
+#include "models/Model3DData.h"
+#include "models/SymbolData.h"
 
 #include <QMutex>
 #include <QObject>
 #include <QString>
 #include <QStringList>
-
-#include "models/ComponentData.h"
-#include "models/FootprintData.h"
-#include "models/Model3DData.h"
-#include "models/SymbolData.h"
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 
@@ -29,12 +28,12 @@ struct ExportOptions {
     bool debugMode;   // 调试模式：导出调试数据到 debug 文件�?
 
     ExportOptions()
-        : exportSymbol(true),
-          exportFootprint(true),
-          exportModel3D(true),
-          overwriteExistingFiles(false),
-          updateMode(false),
-          debugMode(false) {}
+        : exportSymbol(true)
+        , exportFootprint(true)
+        , exportModel3D(true)
+        , overwriteExistingFiles(false)
+        , updateMode(false)
+        , debugMode(false) {}
 };
 
 /**

--- a/src/services/ExportService_Pipeline.h
+++ b/src/services/ExportService_Pipeline.h
@@ -1,16 +1,15 @@
 ﻿#ifndef EXPORTSERVICE_PIPELINE_H
 #define EXPORTSERVICE_PIPELINE_H
 
-#include <QThreadPool>
-
-#include <QMap>
-#include <QMutex>
-#include <QNetworkAccessManager>
-
 #include "ExportService.h"
 #include "models/ComponentExportStatus.h"
 #include "models/SymbolData.h"
 #include "utils/BoundedThreadSafeQueue.h"
+
+#include <QMap>
+#include <QMutex>
+#include <QNetworkAccessManager>
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 

--- a/src/ui/viewmodels/ComponentListViewModel.h
+++ b/src/ui/viewmodels/ComponentListViewModel.h
@@ -1,10 +1,10 @@
 ﻿#ifndef COMPONENTLISTVIEWMODEL_H
 #define COMPONENTLISTVIEWMODEL_H
 
+#include "services/ComponentService.h"
+
 #include <QObject>
 #include <QStringList>
-
-#include "services/ComponentService.h"
 
 namespace EasyKiConverter {
 

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -1,28 +1,28 @@
 ﻿#include "ExportProgressViewModel.h"
 
-#include <QDebug>
-
 #include "services/ExportService_Pipeline.h"
+
+#include <QDebug>
 
 namespace EasyKiConverter {
 
 ExportProgressViewModel::ExportProgressViewModel(ExportService* exportService,
                                                  ComponentService* componentService,
                                                  QObject* parent)
-    : QObject(parent),
-      m_exportService(exportService),
-      m_componentService(componentService),
-      m_status("Ready"),
-      m_progress(0),
-      m_isExporting(false),
-      m_successCount(0),
-      m_failureCount(0),
-      m_fetchedCount(0),
-      m_fetchProgress(0),
-      m_processProgress(0),
-      m_writeProgress(0),
-      m_usePipelineMode(false),
-      m_pendingUpdate(false) {
+    : QObject(parent)
+    , m_exportService(exportService)
+    , m_componentService(componentService)
+    , m_status("Ready")
+    , m_progress(0)
+    , m_isExporting(false)
+    , m_successCount(0)
+    , m_failureCount(0)
+    , m_fetchedCount(0)
+    , m_fetchProgress(0)
+    , m_processProgress(0)
+    , m_writeProgress(0)
+    , m_usePipelineMode(false)
+    , m_pendingUpdate(false) {
     // 初始化节流定时器�?00ms�?
     m_throttleTimer = new QTimer(this);
     m_throttleTimer->setInterval(100);  // 100ms 节流间隔

--- a/src/ui/viewmodels/ExportProgressViewModel.h
+++ b/src/ui/viewmodels/ExportProgressViewModel.h
@@ -1,16 +1,15 @@
 ﻿#ifndef EXPORTPROGRESSVIEWMODEL_H
 #define EXPORTPROGRESSVIEWMODEL_H
 
-#include <QTimer>
+#include "services/ComponentService.h"
+#include "services/ExportService.h"
+#include "services/ExportService_Pipeline.h"
 
 #include <QHash>
 #include <QObject>
 #include <QString>
+#include <QTimer>
 #include <QVariantList>
-
-#include "services/ComponentService.h"
-#include "services/ExportService.h"
-#include "services/ExportService_Pipeline.h"
 
 namespace EasyKiConverter {
 

--- a/src/ui/viewmodels/ExportSettingsViewModel.cpp
+++ b/src/ui/viewmodels/ExportSettingsViewModel.cpp
@@ -5,17 +5,16 @@
 namespace EasyKiConverter {
 
 ExportSettingsViewModel::ExportSettingsViewModel(QObject* parent)
-    : QObject(parent),
-      m_configService(ConfigService::instance()),
-      m_outputPath(""),
-      m_libName("MyLibrary"),
-      m_exportSymbol(true),
-      m_exportFootprint(true),
-      m_exportModel3D(true),
-      m_overwriteExistingFiles(false),
-      m_exportMode(0)  // 默认为追加模�?
-      ,
-      m_debugMode(false) {
+    : QObject(parent)
+    , m_configService(ConfigService::instance())
+    , m_outputPath("")
+    , m_libName("MyLibrary")
+    , m_exportSymbol(true)
+    , m_exportFootprint(true)
+    , m_exportModel3D(true)
+    , m_overwriteExistingFiles(false)
+    , m_exportMode(0)  // 默认为追加模�?
+    , m_debugMode(false) {
     loadFromConfig();
 }
 

--- a/src/ui/viewmodels/ExportSettingsViewModel.h
+++ b/src/ui/viewmodels/ExportSettingsViewModel.h
@@ -1,10 +1,10 @@
 ﻿#ifndef EXPORTSETTINGSVIEWMODEL_H
 #define EXPORTSETTINGSVIEWMODEL_H
 
+#include "services/ConfigService.h"
+
 #include <QObject>
 #include <QString>
-
-#include "services/ConfigService.h"
 
 namespace EasyKiConverter {
 

--- a/src/ui/viewmodels/ThemeSettingsViewModel.h
+++ b/src/ui/viewmodels/ThemeSettingsViewModel.h
@@ -1,9 +1,9 @@
 ﻿#ifndef THEMESETTINGSVIEWMODEL_H
 #define THEMESETTINGSVIEWMODEL_H
 
-#include <QObject>
-
 #include "services/ConfigService.h"
+
+#include <QObject>
 
 namespace EasyKiConverter {
 

--- a/src/workers/ExportWorker.cpp
+++ b/src/workers/ExportWorker.cpp
@@ -1,12 +1,12 @@
 ﻿#include "ExportWorker.h"
 
-#include <QDebug>
-#include <QDir>
-#include <QFile>
-
 #include "core/kicad/Exporter3DModel.h"
 #include "core/kicad/ExporterFootprint.h"
 #include "core/kicad/ExporterSymbol.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
 
 namespace EasyKiConverter {
 
@@ -19,16 +19,16 @@ ExportWorker::ExportWorker(const QString& componentId,
                            bool exportFootprint,
                            bool exportModel3D,
                            QObject* parent)
-    : QObject(parent),
-      QRunnable(),
-      m_componentId(componentId),
-      m_symbolData(symbolData),
-      m_footprintData(footprintData),
-      m_outputPath(outputPath),
-      m_libName(libName),
-      m_exportSymbol(exportSymbol),
-      m_exportFootprint(exportFootprint),
-      m_exportModel3D(exportModel3D) {
+    : QObject(parent)
+    , QRunnable()
+    , m_componentId(componentId)
+    , m_symbolData(symbolData)
+    , m_footprintData(footprintData)
+    , m_outputPath(outputPath)
+    , m_libName(libName)
+    , m_exportSymbol(exportSymbol)
+    , m_exportFootprint(exportFootprint)
+    , m_exportModel3D(exportModel3D) {
     setAutoDelete(true);  // 任务完成后自动删�?
 }
 

--- a/src/workers/ExportWorker.h
+++ b/src/workers/ExportWorker.h
@@ -1,14 +1,14 @@
 ﻿#ifndef EXPORTWORKER_H
 #define EXPORTWORKER_H
 
-#include <QObject>
-#include <QRunnable>
-#include <QSharedPointer>
-
 #include "models/ComponentData.h"
 #include "models/FootprintData.h"
 #include "models/Model3DData.h"
 #include "models/SymbolData.h"
+
+#include <QObject>
+#include <QRunnable>
+#include <QSharedPointer>
 
 namespace EasyKiConverter {
 

--- a/src/workers/FetchWorker.cpp
+++ b/src/workers/FetchWorker.cpp
@@ -1,14 +1,14 @@
 ﻿#include "FetchWorker.h"
 
-#include <QThread>
-#include <QTimer>
-
 #include <QDebug>
 #include <QEventLoop>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QThread>
+#include <QTimer>
+
 #include <zlib.h>
 
 namespace EasyKiConverter {
@@ -17,11 +17,11 @@ FetchWorker::FetchWorker(const QString& componentId,
                          QNetworkAccessManager* networkAccessManager,
                          bool need3DModel,
                          QObject* parent)
-    : QObject(parent),
-      m_componentId(componentId),
-      m_networkAccessManager(networkAccessManager),
-      m_ownNetworkManager(nullptr),
-      m_need3DModel(need3DModel) {}
+    : QObject(parent)
+    , m_componentId(componentId)
+    , m_networkAccessManager(networkAccessManager)
+    , m_ownNetworkManager(nullptr)
+    , m_need3DModel(need3DModel) {}
 
 FetchWorker::~FetchWorker() {
     if (m_ownNetworkManager) {

--- a/src/workers/FetchWorker.h
+++ b/src/workers/FetchWorker.h
@@ -1,11 +1,11 @@
 ﻿#ifndef FETCHWORKER_H
 #define FETCHWORKER_H
 
+#include "models/ComponentExportStatus.h"
+
 #include <QNetworkAccessManager>
 #include <QObject>
 #include <QRunnable>
-
-#include "models/ComponentExportStatus.h"
 
 namespace EasyKiConverter {
 

--- a/src/workers/NetworkWorker.cpp
+++ b/src/workers/NetworkWorker.cpp
@@ -1,5 +1,7 @@
 ﻿#include "NetworkWorker.h"
 
+#include "core/easyeda/EasyedaApi.h"
+
 #include <QDebug>
 #include <QEventLoop>
 #include <QJsonDocument>
@@ -7,9 +9,8 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <zlib.h>
 
-#include "core/easyeda/EasyedaApi.h"
+#include <zlib.h>
 
 namespace EasyKiConverter {
 

--- a/src/workers/ProcessWorker.cpp
+++ b/src/workers/ProcessWorker.cpp
@@ -1,12 +1,12 @@
 ﻿#include "ProcessWorker.h"
 
-#include <QDebug>
-#include <QJsonDocument>
-#include <QJsonObject>
-
 #include "core/easyeda/EasyedaApi.h"
 #include "core/easyeda/EasyedaImporter.h"
 #include "core/utils/NetworkUtils.h"
+
+#include <QDebug>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 namespace EasyKiConverter {
 

--- a/src/workers/ProcessWorker.h
+++ b/src/workers/ProcessWorker.h
@@ -1,10 +1,10 @@
 ﻿#ifndef PROCESSWORKER_H
 #define PROCESSWORKER_H
 
+#include "models/ComponentExportStatus.h"
+
 #include <QObject>
 #include <QRunnable>
-
-#include "models/ComponentExportStatus.h"
 
 namespace EasyKiConverter {
 

--- a/src/workers/WriteWorker.cpp
+++ b/src/workers/WriteWorker.cpp
@@ -1,6 +1,8 @@
 ﻿#include "WriteWorker.h"
 
-#include <QThreadPool>
+#include "core/kicad/Exporter3DModel.h"
+#include "core/kicad/ExporterFootprint.h"
+#include "core/kicad/ExporterSymbol.h"
 
 #include <QDebug>
 #include <QDir>
@@ -8,11 +10,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMutex>
+#include <QThreadPool>
 #include <QWaitCondition>
-
-#include "core/kicad/Exporter3DModel.h"
-#include "core/kicad/ExporterFootprint.h"
-#include "core/kicad/ExporterSymbol.h"
 
 namespace EasyKiConverter {
 
@@ -38,17 +37,17 @@ WriteWorker::WriteWorker(QSharedPointer<ComponentExportStatus> status,
                          bool exportModel3D,
                          bool debugMode,
                          QObject* parent)
-    : QObject(parent),
-      m_status(status),
-      m_outputPath(outputPath),
-      m_libName(libName),
-      m_exportSymbol(exportSymbol),
-      m_exportFootprint(exportFootprint),
-      m_exportModel3D(exportModel3D),
-      m_debugMode(debugMode),
-      m_symbolExporter(),
-      m_footprintExporter(),
-      m_model3DExporter() {}
+    : QObject(parent)
+    , m_status(status)
+    , m_outputPath(outputPath)
+    , m_libName(libName)
+    , m_exportSymbol(exportSymbol)
+    , m_exportFootprint(exportFootprint)
+    , m_exportModel3D(exportModel3D)
+    , m_debugMode(debugMode)
+    , m_symbolExporter()
+    , m_footprintExporter()
+    , m_model3DExporter() {}
 
 WriteWorker::~WriteWorker() {}
 

--- a/src/workers/WriteWorker.h
+++ b/src/workers/WriteWorker.h
@@ -1,13 +1,13 @@
 ﻿#ifndef WRITEWORKER_H
 #define WRITEWORKER_H
 
-#include <QObject>
-#include <QRunnable>
-
 #include "core/kicad/Exporter3DModel.h"
 #include "core/kicad/ExporterFootprint.h"
 #include "core/kicad/ExporterSymbol.h"
 #include "models/ComponentExportStatus.h"
+
+#include <QObject>
+#include <QRunnable>
 
 namespace EasyKiConverter {
 


### PR DESCRIPTION
## 描述
修复了多部件符号（如 MCIMX6Y2CVM08AB, LCSC: C414042）在导出时出现的符号位置偏移问题。

**问题背景：**
- 多部件符号的每个子部分都有自己的坐标系原点（从 EasyEDA 的 `head.x` 和 `head.y` 字段获取）
- 引脚和图形元素的坐标是相对于子部分坐标系的
- 之前的代码错误地使用全局符号中心点来偏移所有子部分的元素，导致位置不正确

**修复方案：**
1. 在 `SymbolPart` 结构中添加 `originX` 和 `originY` 字段，记录子部分的坐标原点
2. 在解析时从 EasyEDA 数据中提取子部分的坐标原点
3. 实现了 `calculatePartBBox()` 方法，为每个子部分计算独立的边界框和中心点
4. 修改 `generateSubSymbol()` 方法，使用子部分的中心点进行坐标偏移

**影响范围：**
- 所有使用多部件符号的元器件（如 BGA 封装的大型芯片）
- 特别是具有独立坐标系原点的子部分

## 相关 Issue
关闭 #53

## 更改类型
- [x] Bug 修复
- [ ] 新功能
- [ ] 代码重构
- [ ] 文档更新
- [ ] 性能优化
- [ ] 测试相关
- [ ] 其他

## 测试
描述您如何测试这些更改：
- [x] 单元测试通过
- [x] 手动测试（测试了 MCIMX6Y2CVM08AB / C414042 元器件）
- [ ] 添加了新的测试用例

**测试步骤：**
1. 导入 C414042 (MCIMX6Y2CVM08AB) 元器件
2. 执行符号导出操作
3. 在 KiCad 中打开导出的符号文件
4. 验证符号正确居中显示在坐标原点 (0,0)
5. 验证引脚位置正确，无明显偏移

## 检查清单
- [x] 代码遵循项目的编码规范
- [ ] 添加了必要的文档
- [ ] 添加了必要的测试
- [x] 所有测试通过
- [ ] 更新了相关文档
- [x] 提交信息符合规范

## 截图（如果适用）
添加截图来展示更改效果。

## 附加信息
**修改的文件：**
- `src/models/SymbolData.h` - 添加 originX/originY 字段
- `src/models/SymbolData.cpp` - 添加字段序列化
- `src/core/easyeda/EasyedaImporter.cpp` - 提取子部分坐标原点
- `src/core/kicad/ExporterSymbol.h` - 添加 calculatePartBBox 方法声明
- `src/core/kicad/ExporterSymbol.cpp` - 实现子部分边界框计算和坐标偏移修复
- `.clang-format` - 启用 LambdaBodyIndentation 选项
- `.github/workflows/clang-format.yml` - 将 clang-format 版本从 11 升级到 13
- `src/` 目录下所有 `.h` 和 `.cpp` 文件 - 应用 clang-format 格式化

**技术细节：**
- 子部分边界框计算考虑了所有图形元素（矩形、圆、椭圆、圆弧、引脚、文本等）
- 临时修改 `m_currentBBox` 以确保图形元素使用正确的偏移
- 处理完成后恢复原始边界框，避免影响其他符号的导出
- 升级 clang-format 版本以支持 LambdaBodyIndentation 选项
- 统一代码格式，符合项目编码规范
