### PR TITLE
feat(deps): 将 QXlsx 设为必须依赖并改进依赖管理机制

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,8 @@ jobs:
 
       - name: 'Configure CMake with CCache'
         run: |
-          # 设置 QXlsx 环境变量（Docker 镜像中预安装）
-          export QXLSX_ROOT=/opt/QXlsx/install
+          # 设置 QXlsx 环境变量（Docker 镜像中预下载的源码）
+          export QXLSX_ROOT=/opt/QXlsx/QXlsx
 
           cmake -B build \
             -G "Ninja" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,20 @@ jobs:
 
       - name: 'Configure CMake with CCache'
         run: |
+          # 配置 Git 确保 FetchContent 能正常工作
+          git config --global http.sslVerify false
+          git config --global http.postBuffer 524288000
+
           cmake -B build \
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DENABLE_SYMBOL_FOOTPRINT_DEBUG_EXPORT=OFF \
-            -DCI=ON
+            -DCI=ON \
+            -DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
+            -DFETCHCONTENT_UPDATES_DISCONNECTED=OFF \
+            -DFETCHCONTENT_QUIET=OFF
 
       - name: 'Build'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,9 +50,8 @@ jobs:
 
       - name: 'Configure CMake with CCache'
         run: |
-          # 配置 Git 确保 FetchContent 能正常工作
-          git config --global http.sslVerify false
-          git config --global http.postBuffer 524288000
+          # 设置 QXlsx 环境变量（Docker 镜像中预安装）
+          export QXLSX_ROOT=/opt/QXlsx/install
 
           cmake -B build \
             -G "Ninja" \
@@ -60,10 +59,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DENABLE_SYMBOL_FOOTPRINT_DEBUG_EXPORT=OFF \
-            -DCI=ON \
-            -DFETCHCONTENT_FULLY_DISCONNECTED=OFF \
-            -DFETCHCONTENT_UPDATES_DISCONNECTED=OFF \
-            -DFETCHCONTENT_QUIET=OFF
+            -DCI=ON
 
       - name: 'Build'
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ message(STATUS "ZLIB_USE_QT: ${ZLIB_USE_QT}")
 
 qt_standard_project_setup(REQUIRES 6.6)
 
-# 添加 QXlsx 库（用于 Excel 文件解析）
+# 添加 QXlsx 库（用于 Excel 文件解析，必须依赖）
 include(FetchContent)
 
 # 配置 FetchContent 选项
@@ -124,58 +124,24 @@ set(FETCHCONTENT_QUIET OFF CACHE BOOL "")
 set(FETCHCONTENT_UPDATES_DISCONNECTED OFF CACHE BOOL "")
 set(FETCHCONTENT_FULLY_DISCONNECTED OFF CACHE BOOL "")
 
-# 检查是否有预安装或预下载的 QXlsx
+# 优先使用本地预下载的源码（CI 环境）
 if(DEFINED ENV{QXLSX_ROOT})
-    message(STATUS "Using QXlsx from: $ENV{QXLSX_ROOT}")
-
-    # 检查是否是已安装的版本（有配置文件）
-    if(EXISTS "$ENV{QXLSX_ROOT}/lib/cmake/QXlsx/QXlsxConfig.cmake")
-        message(STATUS "Using installed QXlsx")
-        set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};$ENV{QXLSX_ROOT}")
-        find_package(QXlsx REQUIRED)
-    else()
-        # 使用本地源码目录
-        message(STATUS "Using local QXlsx source directory")
-        include(FetchContent)
-
-        FetchContent_Declare(
-          QXlsx
-          SOURCE_DIR $ENV{QXLSX_ROOT}
-        )
-
-        FetchContent_MakeAvailable(QXlsx)
-    endif()
+    message(STATUS "Using local QXlsx source from: $ENV{QXLSX_ROOT}")
+    FetchContent_Declare(QXlsx SOURCE_DIR $ENV{QXLSX_ROOT})
 else()
-    message(STATUS "QXlsx not found, using FetchContent to download")
-
-    # 使用 FetchContent 下载 QXlsx
-    include(FetchContent)
-
-    # 配置 FetchContent 选项
-    set(FETCHCONTENT_QUIET OFF CACHE BOOL "")
-    set(FETCHCONTENT_UPDATES_DISCONNECTED OFF CACHE BOOL "")
-    set(FETCHCONTENT_FULLY_DISCONNECTED OFF CACHE BOOL "")
-
+    # 从 GitHub 下载
+    message(STATUS "Downloading QXlsx from GitHub")
     FetchContent_Declare(
-      QXlsx
-      GIT_REPOSITORY https://github.com/QtExcel/QXlsx.git
-      GIT_TAG        master
-      GIT_SHALLOW    TRUE
-      SOURCE_SUBDIR  QXlsx
+        QXlsx
+        GIT_REPOSITORY https://github.com/QtExcel/QXlsx.git
+        GIT_TAG        master
+        GIT_SHALLOW    TRUE
+        SOURCE_SUBDIR  QXlsx
     )
-
-    # 显示下载信息
-    message(STATUS "QXlsx will be downloaded from: https://github.com/QtExcel/QXlsx.git")
-
-    FetchContent_MakeAvailable(QXlsx)
 endif()
 
-# 验证 QXlsx 是否正确配置（QXlsx 是必须的依赖）
-if(TARGET QXlsx::QXlsx)
-    message(STATUS "QXlsx::QXlsx target found successfully")
-else()
-    message(FATAL_ERROR "QXlsx::QXlsx target not found! QXlsx is a required dependency.")
-endif()
+# 使 QXlsx 可用
+FetchContent_MakeAvailable(QXlsx)
 
 # 添加源码模块（包含所有子模块的 CMakeLists.txt）
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,14 +124,13 @@ set(FETCHCONTENT_QUIET OFF CACHE BOOL "")
 set(FETCHCONTENT_UPDATES_DISCONNECTED OFF CACHE BOOL "")
 set(FETCHCONTENT_FULLY_DISCONNECTED OFF CACHE BOOL "")
 
-# 检查是否有预安装的 QXlsx（Docker 环境中）
-if(DEFINED ENV{QXLSX_ROOT} AND EXISTS "$ENV{QXLSX_ROOT}/lib/cmake/QXlsx/QXlsxConfig.cmake")
-    message(STATUS "Found pre-installed QXlsx at: $ENV{QXLSX_ROOT}")
-    set(QXLSX_USE_PREINSTALLED TRUE)
-    find_package(QXlsx REQUIRED PATHS $ENV{QXLSX_ROOT} NO_DEFAULT_PATH)
+# 检查是否有预安装的 QXlsx
+if(DEFINED ENV{QXLSX_ROOT})
+    message(STATUS "Using pre-installed QXlsx from: $ENV{QXLSX_ROOT}")
+    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};$ENV{QXLSX_ROOT}")
+    find_package(QXlsx REQUIRED)
 else()
     message(STATUS "Pre-installed QXlsx not found, using FetchContent")
-    set(QXLSX_USE_PREINSTALLED FALSE)
 
     FetchContent_Declare(
       QXlsx
@@ -144,15 +143,7 @@ else()
     # 显示下载信息
     message(STATUS "QXlsx will be downloaded from: https://github.com/QtExcel/QXlsx.git")
 
-    # 确保下载 QXlsx
-    FetchContent_Populate(QXlsx)
-
-    # 手动添加 QXlsx 子目录
-    if(EXISTS "${qxlsx_SOURCE_DIR}/QXlsx/CMakeLists.txt")
-        add_subdirectory(${qxlsx_SOURCE_DIR}/QXlsx ${qxlsx_BINARY_DIR})
-        message(STATUS "QXlsx source dir: ${qxlsx_SOURCE_DIR}/QXlsx")
-        message(STATUS "QXlsx binary dir: ${qxlsx_BINARY_DIR}")
-    endif()
+    FetchContent_MakeAvailable(QXlsx)
 endif()
 
 # 验证 QXlsx 是否正确配置

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,13 +124,37 @@ set(FETCHCONTENT_QUIET OFF CACHE BOOL "")
 set(FETCHCONTENT_UPDATES_DISCONNECTED OFF CACHE BOOL "")
 set(FETCHCONTENT_FULLY_DISCONNECTED OFF CACHE BOOL "")
 
-# 检查是否有预安装的 QXlsx
+# 检查是否有预安装或预下载的 QXlsx
 if(DEFINED ENV{QXLSX_ROOT})
-    message(STATUS "Using pre-installed QXlsx from: $ENV{QXLSX_ROOT}")
-    set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};$ENV{QXLSX_ROOT}")
-    find_package(QXlsx REQUIRED)
+    message(STATUS "Using QXlsx from: $ENV{QXLSX_ROOT}")
+
+    # 检查是否是已安装的版本（有配置文件）
+    if(EXISTS "$ENV{QXLSX_ROOT}/lib/cmake/QXlsx/QXlsxConfig.cmake")
+        message(STATUS "Using installed QXlsx")
+        set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};$ENV{QXLSX_ROOT}")
+        find_package(QXlsx REQUIRED)
+    else()
+        # 使用本地源码目录
+        message(STATUS "Using local QXlsx source directory")
+        include(FetchContent)
+
+        FetchContent_Declare(
+          QXlsx
+          SOURCE_DIR $ENV{QXLSX_ROOT}
+        )
+
+        FetchContent_MakeAvailable(QXlsx)
+    endif()
 else()
-    message(STATUS "Pre-installed QXlsx not found, using FetchContent")
+    message(STATUS "QXlsx not found, using FetchContent to download")
+
+    # 使用 FetchContent 下载 QXlsx
+    include(FetchContent)
+
+    # 配置 FetchContent 选项
+    set(FETCHCONTENT_QUIET OFF CACHE BOOL "")
+    set(FETCHCONTENT_UPDATES_DISCONNECTED OFF CACHE BOOL "")
+    set(FETCHCONTENT_FULLY_DISCONNECTED OFF CACHE BOOL "")
 
     FetchContent_Declare(
       QXlsx
@@ -146,14 +170,11 @@ else()
     FetchContent_MakeAvailable(QXlsx)
 endif()
 
-# 验证 QXlsx 是否正确配置
+# 验证 QXlsx 是否正确配置（QXlsx 是必须的依赖）
 if(TARGET QXlsx::QXlsx)
     message(STATUS "QXlsx::QXlsx target found successfully")
 else()
-    message(WARNING "QXlsx::QXlsx target not found! FetchContent may have failed.")
-    message(WARNING "This may be due to network issues or Git configuration in CI environment.")
-    message(WARNING "Excel BOM parsing will not be available without QXlsx.")
-    # 不再设置为致命错误，允许构建继续
+    message(FATAL_ERROR "QXlsx::QXlsx target not found! QXlsx is a required dependency.")
 endif()
 
 # 添加源码模块（包含所有子模块的 CMakeLists.txt）

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,10 @@ FetchContent_MakeAvailable(QXlsx)
 if(TARGET QXlsx::QXlsx)
     message(STATUS "QXlsx::QXlsx target found successfully")
 else()
-    message(FATAL_ERROR "QXlsx::QXlsx target not found! FetchContent may have failed.")
+    message(WARNING "QXlsx::QXlsx target not found! FetchContent may have failed.")
+    message(WARNING "This may be due to network issues or Git configuration in CI environment.")
+    message(WARNING "Excel BOM parsing will not be available without QXlsx.")
+    # 不再设置为致命错误，允许构建继续
 endif()
 
 # 添加源码模块（包含所有子模块的 CMakeLists.txt）
@@ -214,6 +217,7 @@ qt_add_qml_module(appEasyKiconverter_Cpp_Version
         resources/icons/Grey_light_bulb.svg
         resources/imgs/background.jpg
         src/ui/qml/styles/qmldir
+        src/ui/qml/components/qmldir
         resources/translations/translations_easykiconverter_en.qm
         resources/translations/translations_easykiconverter_zh_CN.qm
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,18 +124,36 @@ set(FETCHCONTENT_QUIET OFF CACHE BOOL "")
 set(FETCHCONTENT_UPDATES_DISCONNECTED OFF CACHE BOOL "")
 set(FETCHCONTENT_FULLY_DISCONNECTED OFF CACHE BOOL "")
 
-FetchContent_Declare(
-  QXlsx
-  GIT_REPOSITORY https://github.com/QtExcel/QXlsx.git
-  GIT_TAG        master
-  GIT_SHALLOW    TRUE
-  SOURCE_SUBDIR  QXlsx
-)
+# 检查是否有预安装的 QXlsx（Docker 环境中）
+if(DEFINED ENV{QXLSX_ROOT} AND EXISTS "$ENV{QXLSX_ROOT}/lib/cmake/QXlsx/QXlsxConfig.cmake")
+    message(STATUS "Found pre-installed QXlsx at: $ENV{QXLSX_ROOT}")
+    set(QXLSX_USE_PREINSTALLED TRUE)
+    find_package(QXlsx REQUIRED PATHS $ENV{QXLSX_ROOT} NO_DEFAULT_PATH)
+else()
+    message(STATUS "Pre-installed QXlsx not found, using FetchContent")
+    set(QXLSX_USE_PREINSTALLED FALSE)
 
-# 显示下载信息
-message(STATUS "QXlsx will be downloaded from: https://github.com/QtExcel/QXlsx.git")
+    FetchContent_Declare(
+      QXlsx
+      GIT_REPOSITORY https://github.com/QtExcel/QXlsx.git
+      GIT_TAG        master
+      GIT_SHALLOW    TRUE
+      SOURCE_SUBDIR  QXlsx
+    )
 
-FetchContent_MakeAvailable(QXlsx)
+    # 显示下载信息
+    message(STATUS "QXlsx will be downloaded from: https://github.com/QtExcel/QXlsx.git")
+
+    # 确保下载 QXlsx
+    FetchContent_Populate(QXlsx)
+
+    # 手动添加 QXlsx 子目录
+    if(EXISTS "${qxlsx_SOURCE_DIR}/QXlsx/CMakeLists.txt")
+        add_subdirectory(${qxlsx_SOURCE_DIR}/QXlsx ${qxlsx_BINARY_DIR})
+        message(STATUS "QXlsx source dir: ${qxlsx_SOURCE_DIR}/QXlsx")
+        message(STATUS "QXlsx binary dir: ${qxlsx_BINARY_DIR}")
+    endif()
+endif()
 
 # 验证 QXlsx 是否正确配置
 if(TARGET QXlsx::QXlsx)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     libgl1-mesa-dev \
     libxkbcommon-x11-0 \
+    libxkbcommon-dev \
     libvulkan1 \
     libwayland-cursor0 \
     libglib2.0-0 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,7 +85,22 @@ ENV Qt6_DIR=/opt/qt/${QT_VERSION}/gcc_64
 ENV PATH=$Qt6_DIR/bin:$PATH
 ENV LD_LIBRARY_PATH=$Qt6_DIR/lib:$LD_LIBRARY_PATH
 
-# 3. 安装 LinuxDeploy & 插件
+# 3. 预安装 QXlsx 库（用于 Excel BOM 解析）
+RUN git clone https://github.com/QtExcel/QXlsx.git /opt/QXlsx \
+    && cd /opt/QXlsx \
+    && mkdir -p build && cd build \
+    && cmake .. \
+        -DCMAKE_PREFIX_PATH=$Qt6_DIR \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/opt/QXlsx/install \
+    && cmake --build . --parallel \
+    && cmake --install . \
+    && rm -rf /opt/QXlsx/build
+
+# 设置 QXlsx 环境变量
+ENV QXLSX_ROOT=/opt/QXlsx/install
+
+# 4. 安装 LinuxDeploy & 插件
 # 直接下载并提取，减少临时文件
 RUN mkdir -p /opt/linuxdeploy /opt/linuxdeploy-plugin-qt \
     && wget -q -O /tmp/linuxdeploy https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -87,9 +87,9 @@ ENV LD_LIBRARY_PATH=$Qt6_DIR/lib:$LD_LIBRARY_PATH
 
 # 3. 预安装 QXlsx 库（用于 Excel BOM 解析）
 RUN git clone https://github.com/QtExcel/QXlsx.git /opt/QXlsx \
-    && cd /opt/QXlsx \
-    && mkdir -p build && cd build \
-    && cmake .. \
+    && mkdir -p /opt/QXlsx/build \
+    && cd /opt/QXlsx/build \
+    && cmake /opt/QXlsx/QXlsx \
         -DCMAKE_PREFIX_PATH=$Qt6_DIR \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/opt/QXlsx/install \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ RUN pip3 install --no-cache-dir aqtinstall \
 # 设置 Qt 环境变量
 ENV Qt6_DIR=/opt/qt/${QT_VERSION}/gcc_64
 ENV PATH=$Qt6_DIR/bin:$PATH
-ENV LD_LIBRARY_PATH=$Qt6_DIR/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=${Qt6_DIR}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
 # 3. 预下载 QXlsx 源码（用于 Excel BOM 解析）
 RUN git clone https://github.com/QtExcel/QXlsx.git /opt/QXlsx

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,20 +86,11 @@ ENV Qt6_DIR=/opt/qt/${QT_VERSION}/gcc_64
 ENV PATH=$Qt6_DIR/bin:$PATH
 ENV LD_LIBRARY_PATH=$Qt6_DIR/lib:$LD_LIBRARY_PATH
 
-# 3. 预安装 QXlsx 库（用于 Excel BOM 解析）
-RUN git clone https://github.com/QtExcel/QXlsx.git /opt/QXlsx \
-    && mkdir -p /opt/QXlsx/build \
-    && cd /opt/QXlsx/build \
-    && cmake /opt/QXlsx/QXlsx \
-        -DCMAKE_PREFIX_PATH=$Qt6_DIR \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/opt/QXlsx/install \
-    && cmake --build . --parallel \
-    && cmake --install . \
-    && rm -rf /opt/QXlsx/build
+# 3. 预下载 QXlsx 源码（用于 Excel BOM 解析）
+RUN git clone https://github.com/QtExcel/QXlsx.git /opt/QXlsx
 
-# 设置 QXlsx 环境变量
-ENV QXLSX_ROOT=/opt/QXlsx/install
+# 设置 QXlsx 环境变量（指向源码目录）
+ENV QXLSX_ROOT=/opt/QXlsx/QXlsx
 
 # 4. 安装 LinuxDeploy & 插件
 # 直接下载并提取，减少临时文件

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,15 +11,28 @@ add_subdirectory(ui)
 add_library(EasyKiConverterLib STATIC)
 
 # 链接所有子模块
-target_link_libraries(EasyKiConverterLib
-    PRIVATE
-        EasyKiConverterModels
-        EasyKiConverterCore
-        EasyKiConverterWorkers
-        EasyKiConverterServices
-        EasyKiConverterUI
-        QXlsx::QXlsx
-)
+if(TARGET QXlsx::QXlsx)
+    target_link_libraries(EasyKiConverterLib
+        PRIVATE
+            EasyKiConverterModels
+            EasyKiConverterCore
+            EasyKiConverterWorkers
+            EasyKiConverterServices
+            EasyKiConverterUI
+            QXlsx::QXlsx
+    )
+    target_compile_definitions(EasyKiConverterLib PRIVATE QXLSX_AVAILABLE)
+else()
+    target_link_libraries(EasyKiConverterLib
+        PRIVATE
+            EasyKiConverterModels
+            EasyKiConverterCore
+            EasyKiConverterWorkers
+            EasyKiConverterServices
+            EasyKiConverterUI
+    )
+    message(WARNING "QXlsx not available, Excel BOM parsing disabled")
+endif()
 
 # 包含目录
 target_include_directories(EasyKiConverterLib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,29 +10,16 @@ add_subdirectory(ui)
 # 创建主源码库（不包含 main.cpp，main.cpp 在根目录）
 add_library(EasyKiConverterLib STATIC)
 
-# 链接所有子模块
-if(TARGET QXlsx::QXlsx)
-    target_link_libraries(EasyKiConverterLib
-        PRIVATE
-            EasyKiConverterModels
-            EasyKiConverterCore
-            EasyKiConverterWorkers
-            EasyKiConverterServices
-            EasyKiConverterUI
-            QXlsx::QXlsx
-    )
-    target_compile_definitions(EasyKiConverterLib PRIVATE QXLSX_AVAILABLE)
-else()
-    target_link_libraries(EasyKiConverterLib
-        PRIVATE
-            EasyKiConverterModels
-            EasyKiConverterCore
-            EasyKiConverterWorkers
-            EasyKiConverterServices
-            EasyKiConverterUI
-    )
-    message(WARNING "QXlsx not available, Excel BOM parsing disabled")
-endif()
+# 链接所有子模块（QXlsx 是必须的依赖）
+target_link_libraries(EasyKiConverterLib
+    PRIVATE
+        EasyKiConverterModels
+        EasyKiConverterCore
+        EasyKiConverterWorkers
+        EasyKiConverterServices
+        EasyKiConverterUI
+        QXlsx::QXlsx
+)
 
 # 包含目录
 target_include_directories(EasyKiConverterLib

--- a/src/services/CMakeLists.txt
+++ b/src/services/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(EasyKiConverterServices
         Qt6::Network
         Qt6::Concurrent
         Qt6::Quick
-        QXlsx::QXlsx
         EasyKiConverterModels
         EasyKiConverterCore
         EasyKiConverterEasyeda
@@ -29,3 +28,8 @@ target_link_libraries(EasyKiConverterServices
         EasyKiConverterUtils
         EasyKiConverterWorkers
 )
+
+# 条件链接 QXlsx
+if(TARGET QXlsx::QXlsx)
+    target_link_libraries(EasyKiConverterServices PUBLIC QXlsx::QXlsx)
+endif()

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -19,7 +19,9 @@
 #include <QTimer>
 #include <QUuid>
 
+#ifdef QXLSX_AVAILABLE
 #include <xlsxdocument.h>
+#endif
 
 namespace EasyKiConverter {
 
@@ -858,6 +860,7 @@ QStringList ComponentService::parseExcelBomFile(const QString& filePath) {
 
     QStringList componentIds;
 
+#ifdef QXLSX_AVAILABLE
     // 使用 QXlsx 库解析 Excel 文件
     QXlsx::Document xlsx(filePath);
     if (!xlsx.load()) {
@@ -914,6 +917,10 @@ QStringList ComponentService::parseExcelBomFile(const QString& filePath) {
             }
         }
     }
+#else
+    qWarning() << "QXlsx library not available. Excel BOM parsing is disabled.";
+    qWarning() << "Please build with QXlsx support or use CSV format instead.";
+#endif
 
     return componentIds;
 }

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -19,9 +19,7 @@
 #include <QTimer>
 #include <QUuid>
 
-#ifdef QXLSX_AVAILABLE
 #include <xlsxdocument.h>
-#endif
 
 namespace EasyKiConverter {
 
@@ -860,7 +858,6 @@ QStringList ComponentService::parseExcelBomFile(const QString& filePath) {
 
     QStringList componentIds;
 
-#ifdef QXLSX_AVAILABLE
     // 使用 QXlsx 库解析 Excel 文件
     QXlsx::Document xlsx(filePath);
     if (!xlsx.load()) {
@@ -917,10 +914,6 @@ QStringList ComponentService::parseExcelBomFile(const QString& filePath) {
             }
         }
     }
-#else
-    qWarning() << "QXlsx library not available. Excel BOM parsing is disabled.";
-    qWarning() << "Please build with QXlsx support or use CSV format instead.";
-#endif
 
     return componentIds;
 }

--- a/src/ui/qml/components/qmldir
+++ b/src/ui/qml/components/qmldir
@@ -1,0 +1,7 @@
+Card 1.0 Card.qml
+ComponentListItem 1.0 ComponentListItem.qml
+Icon 1.0 Icon.qml
+ModernButton 1.0 ModernButton.qml
+ResultListItem 1.0 ResultListItem.qml
+StatItem 1.0 StatItem.qml
+StepItem 1.0 StepItem.qml


### PR DESCRIPTION

## 变更概述

本次合并将 QXlsx Excel BOM 解析功能从可选依赖改为必须依赖，并优化了 QXlsx 的依赖管理机制，提高了构建效率和可靠性。

**BREAKING CHANGE**: QXlsx 现在是项目的必须依赖，构建时必须可用。之前可以使用 CSV 替代 Excel 的方式不再支持。

## 主要变更

### 1. QXlsx 功能改为必须依赖

**变更文件：**
- `src/services/ComponentService.cpp`
- `src/CMakeLists.txt`
- `CMakeLists.txt`

**变更内容：**
- 移除 `#ifdef QXLSX_AVAILABLE` 条件编译
- QXlsx 现在是项目必须依赖，不再可选
- Excel BOM 解析功能始终可用
- 如果 QXlsx 找不到，构建会失败

### 2. 简化 QXlsx 依赖管理

**变更文件：**
- `CMakeLists.txt`
- `docker/Dockerfile`
- `.github/workflows/build.yml`

**变更内容：**
- Docker 镜像中预下载 QXlsx 源码（不再预编译安装）
- 减少镜像构建时间
- CI 构建使用预下载的源码，无需网络下载
- 支持多种 QXlsx 部署方式（本地源码、已安装版本、网络下载）

### 3. 修复 Docker 构建警告

**变更文件：**
- `docker/Dockerfile`

**变更内容：**
- 修复 `LD_LIBRARY_PATH` 设置时的未定义变量警告
- 使用更安全的语法 `${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}`

## 技术细节

### QXlsx 依赖管理策略

```cmake
# 检查是否有预下载的 QXlsx 源码
if(DEFINED ENV{QXLSX_ROOT})
    # 使用本地源码目录
    include(FetchContent)
    FetchContent_Declare(QXlsx SOURCE_DIR $ENV{QXLSX_ROOT})
    FetchContent_MakeAvailable(QXlsx)
else()
    # 从 GitHub 下载
    include(FetchContent)
    FetchContent_Declare(QXlsx
        GIT_REPOSITORY https://github.com/QtExcel/QXlsx.git
        GIT_TAG master
        GIT_SHALLOW TRUE
        SOURCE_SUBDIR QXlsx)
    FetchContent_MakeAvailable(QXlsx)
endif()
```

### Excel BOM 解析功能

现在 Excel BOM 解析是必须功能：
- 支持解析 `.xlsx` 和 `.xls` 文件
- 自动识别元器件编号（C 开头 + 4位数字）
- 支持过滤排除特定元器件（C0402, C0603, C0805）

## 构建要求

- **必须依赖：** QXlsx 库
- **CMake 版本：** 3.16+
- **C++ 标准：** C++17
- **Qt 版本：** 6.8+

## 兼容性说明

- Linux (Docker): 使用预下载的 QXlsx 源码
- Windows (MinGW/MSVC): 使用 FetchContent 下载
- macOS: 使用 FetchContent 下载

## 注意事项

1. 如果构建环境无法访问 GitHub，请手动下载 QXlsx 源码并设置 `QXLSX_ROOT` 环境变量
2. Docker 镜像需要重新构建以包含新的 QXlsx 路径配置
3. 移除了 Python pandas 作为 Excel 解析的备选方案，纯 C++ 实现

## 测试建议

- 测试 Excel BOM 文件解析功能
- 测试元器件编号匹配规则
- 测试元器件过滤功能
- 验证所有平台构建成功