### PR TITLE
feat(export): 优化重试导出功能并修复图标显示问题

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -29,12 +29,16 @@ int main(int argc, char* argv[]) {
     QQuickStyle::setStyle("Basic");
 
     // 尝试设置应用程序图标
-    QStringList iconPaths = {":/resources/app_icon.png", "resources/app_icon.png", "../resources/app_icon.png"};
+    QStringList iconPaths = {":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/app_icon.png",
+                             ":/resources/icons/app_icon.png",
+                             "resources/icons/app_icon.png",
+                             "../resources/icons/app_icon.png"};
 
     for (const QString& iconPath : iconPaths) {
-        if (QFile::exists(iconPath)) {
-            app.setWindowIcon(QIcon(iconPath));
-            qDebug() << "Application icon set:" << iconPath;
+        QIcon icon(iconPath);
+        if (!icon.isNull()) {
+            app.setWindowIcon(icon);
+            qDebug() << "Application icon set from:" << iconPath;
             break;
         }
     }

--- a/src/services/ExportService_Pipeline.h
+++ b/src/services/ExportService_Pipeline.h
@@ -76,7 +76,9 @@ public:
      * @param componentIds 元件ID列表
      * @param options 导出选项
      */
-    void executeExportPipelineWithStages(const QStringList& componentIds, const ExportOptions& options);
+    void executeExportPipelineWithStages(const QStringList& componentIds,
+                                         const ExportOptions& options,
+                                         bool isRetry = false);
     void retryExport(const QStringList& componentIds, const ExportOptions& options) override;
 
     /**
@@ -219,8 +221,20 @@ private:
     // 完整的状态列表（用于生成统计报告?
     QVector<QSharedPointer<ComponentExportStatus>> m_completedStatuses;
 
-    // 导出开始时间（用于计算总耗时?
+    // 导出开始时间（用于计算总耗时）
     qint64 m_exportStartTimeMs;
+
+    // 原始导出开始时间（用于统计包括重试在内的总时间）
+    qint64 m_originalExportStartTimeMs;
+
+    // 原始导出总元器件数量（用于统计包括重试在内的总数）
+    int m_originalTotalTasks;
+
+    // 原始导出统计信息（用于在重试模式下保留时间数据）
+    ExportStatistics m_originalStatistics;
+
+    // 是否处于重试模式（用于区分新的导出流程和重试）
+    bool m_isRetryMode;
 };
 
 }  // namespace EasyKiConverter

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -1593,26 +1593,6 @@ Item {
                                 spacing: AppStyle.spacing.md
                                 visible: true
 
-                                // 工具栏（显示重试按钮）
-                                RowLayout {
-                                    Layout.fillWidth: true
-                                    visible: exportProgressController.failureCount > 0 && !exportProgressController.isExporting
-
-                                    Item {
-                                        Layout.fillWidth: true
-                                    } // Spacer
-
-                                    ModernButton {
-                                        text: qsTr("重试失败项")
-                                        iconName: "play"
-                                        backgroundColor: AppStyle.colors.warning
-                                        hoverColor: AppStyle.colors.warningDark
-                                        pressedColor: AppStyle.colors.warning
-                                        font.pixelSize: 14
-
-                                        onClicked: exportProgressController.retryFailedComponents()
-                                    }
-                                }
                                 // 结果列表（使用 GridView 实现五列显示）
                                 GridView {
                                     id: resultsList

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -997,6 +997,7 @@ Item {
                                 onClicked: {
                                     searchInput.text = ""; // 清空搜索
                                     componentListController.clearComponentList();
+                                    exportProgressController.resetExport(); // 重置导出状态
                                 }
                             }
                         }
@@ -1583,6 +1584,7 @@ Item {
                         id: resultsLoader
                         Layout.fillWidth: true
                         active: exportProgressController.isExporting || exportProgressController.resultsList.length > 0
+                        visible: active  // ✅ 确保 Loader 在没有结果时不占用空间
                         sourceComponent: Card {
                             title: qsTr("转换结果")
                             ColumnLayout {
@@ -1618,6 +1620,7 @@ Item {
                                     Layout.minimumHeight: 200
                                     Layout.preferredHeight: Math.min(resultsList.contentHeight + 20, 500)
                                     Layout.topMargin: AppStyle.spacing.md
+                                    visible: exportProgressController.resultsList.length > 0
                                     clip: true
                                     cellWidth: {
                                         var w = width - AppStyle.spacing.md;

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -171,6 +171,49 @@ void ExportProgressViewModel::cancelExport() {
     });
 }
 
+void ExportProgressViewModel::resetExport() {
+    qDebug() << "ExportProgressViewModel::resetExport() called";
+
+    // 重置所有导出状态
+    m_progress = 0;
+    m_status = "";
+    m_isExporting = false;
+    m_isStopping = false;
+    m_successCount = 0;
+    m_successSymbolCount = 0;
+    m_successFootprintCount = 0;
+    m_successModel3DCount = 0;
+    m_failureCount = 0;
+    m_fetchProgress = 0;
+    m_processProgress = 0;
+    m_writeProgress = 0;
+
+    // 清空结果列表
+    m_resultsList.clear();
+    m_idToIndexMap.clear();
+
+    // 清空统计信息
+    m_hasStatistics = false;
+    m_statisticsReportPath = "";
+    m_statisticsSummary = "";
+    m_statistics = ExportStatistics();
+
+    // 触发所有相关的信号更新
+    emit progressChanged();
+    emit statusChanged();
+    emit isExportingChanged();
+    emit isStoppingChanged();
+    emit successCountChanged();
+    emit failureCountChanged();
+    emit resultsListChanged();
+    emit statisticsChanged();
+    emit fetchProgressChanged();
+    emit processProgressChanged();
+    emit writeProgressChanged();
+
+    qDebug() << "Export status reset completed";
+}
+
 void ExportProgressViewModel::handleExportProgress(int current, int total) {
     int newProgress = total > 0 ? (current * 100 / total) : 0;
     if (m_progress != newProgress) {

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -648,16 +648,14 @@ void ExportProgressViewModel::initializeSystemTrayIcon() {
                              ":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/app_icon.png",
                              ":/resources/icons/app_icon.ico",
                              ":/resources/icons/app_icon.png",
-                             ":/icons/app_icon.ico",
-                             ":/icons/app_icon.png"};
+                             "resources/icons/app_icon.ico",
+                             "resources/icons/app_icon.png"};
 
     for (const QString& path : iconPaths) {
         appIcon = QIcon(path);
         if (!appIcon.isNull()) {
-            qDebug() << "Icon loaded successfully from:" << path;
+            qDebug() << "System tray icon loaded successfully from:" << path;
             break;
-        } else {
-            qDebug() << "Failed to load icon from:" << path;
         }
     }
 
@@ -673,7 +671,7 @@ void ExportProgressViewModel::initializeSystemTrayIcon() {
     }
 
     m_systemTrayIcon->setIcon(appIcon);
-    qDebug() << "System tray icon set";
+    qDebug() << "System tray icon set successfully";
 
     // 设置工具提示
     m_systemTrayIcon->setToolTip(QObject::tr("EasyKiConverter - LCSC 转换工具"));

--- a/src/ui/viewmodels/ExportProgressViewModel.h
+++ b/src/ui/viewmodels/ExportProgressViewModel.h
@@ -155,6 +155,7 @@ public slots:
     Q_INVOKABLE void retryFailedComponents();
     Q_INVOKABLE void retryComponent(const QString& componentId);
     Q_INVOKABLE void cancelExport();
+    Q_INVOKABLE void resetExport();
 
 signals:
     void progressChanged();


### PR DESCRIPTION

## 变更概述

本次更新主要优化了重试导出功能，包括重试模式支持、统计信息处理优化、UI 布局改进以及应用图标显示修复。

## 主要变更

### 1. 重试模式支持

**问题：**
- 重试导出时会覆盖原始导出的统计时间信息
- 重试的元器件会被重复计算
- 缺少明确的重试模式标识

**解决方案：**
- 新增 `m_isRetryMode` 标志区分新导出和重试
- 添加 `m_originalStatistics` 保存原始统计信息
- 实现组件 ID 去重统计，避免重复计算
- 重构 `executeExportPipelineWithStages` 方法支持重试参数

**影响文件：**
- `src/services/ExportService_Pipeline.h`
- `src/services/ExportService_Pipeline.cpp`

### 2. 导出状态重置

**问题：**
- 用户清空元器件列表后，"开始导出"按钮仍显示为"重试失败项"
- 导出结果列表为空时仍占据大量空间
- 导出状态未正确重置

**解决方案：**
- 添加 `resetExport()` 方法重置所有导出状态
- 在"清空列表"按钮中调用重置方法
- 为结果列表添加 `visible` 绑定，空列表时隐藏
- 为 Loader 添加 `visible` 绑定，确保不占用布局空间

**影响文件：**
- `src/ui/viewmodels/ExportProgressViewModel.h`
- `src/ui/viewmodels/ExportProgressViewModel.cpp`
- `src/ui/qml/MainWindow.qml`

### 3. UI 优化

**问题：**
- 转换结果卡片中有重复的"重试所有失败项"按钮
- 导出按钮组和结果列表中的重试按钮功能重复

**解决方案：**
- 移除转换结果卡片中的工具栏和重试按钮
- 保留导出按钮组中的重试功能（主要入口）
- 保留结果列表中的单个重试功能（灵活操作）

**影响文件：**
- `src/ui/qml/MainWindow.qml`

### 4. 应用图标修复

**问题：**
- 应用图标路径不正确
- 系统托盘图标初始化路径不完整
- Windows 系统通知显示默认图标而非应用图标

**解决方案：**
- 更新 `main.cpp` 中的应用图标路径
- 改进图标加载检查逻辑，使用 `QIcon::isNull()`
- 优化系统托盘图标初始化过程
- 统一图标路径格式，确保跨平台兼容性

**影响文件：**
- `main.cpp`
- `src/ui/viewmodels/ExportProgressViewModel.cpp`

## 技术细节

### 重试模式实现

```cpp
// 重试模式标志
bool m_isRetryMode;

// 原始统计信息（用于保留时间数据）
ExportStatistics m_originalStatistics;

// 重试时保留原始时间统计
if (!m_isRetryMode) {
    m_originalStatistics = statistics;
} else {
    statistics.totalDurationMs = m_originalStatistics.totalDurationMs;
    statistics.avgFetchTimeMs = m_originalStatistics.avgFetchTimeMs;
    // ...
}
```

### 组件去重统计

```cpp
QSet<QString> uniqueComponentIds;
for (const auto& status : m_completedStatuses) {
    QString componentId = status->componentId;
    if (uniqueComponentIds.contains(componentId)) {
        continue; // 跳过重复的元器件
    }
    uniqueComponentIds.insert(componentId);
    // 统计最新状态
}
```

### UI 布局优化

```qml
// 结果列表为空时隐藏
GridView {
    visible: exportProgressController.resultsList.length > 0
    Layout.preferredHeight: Math.min(resultsList.contentHeight + 20, 500)
}

// Loader 不占用空间
Loader {
    active: exportProgressController.isExporting || exportProgressController.resultsList.length > 0
    visible: active
}
```

## 预期效果

### 重试导出
- 基本统计正确更新（成功数、失败数）
- 时间统计保留原始数据
- 不重复计算重试的元器件
- 生成新的统计报告文件

### UI 交互
- 清空列表后导出状态正确重置
- 结果列表为空时不占用空间
- 布局紧凑，无多余空白
- 重试功能入口清晰，无重复

### 图标显示
- 应用图标正确设置
- 系统托盘图标正确显示
- Windows 系统通知使用应用图标

## 测试建议

1. **重试导出测试**
   - 导出一批元器件（部分失败）
   - 点击"重试失败项"
   - 验证统计信息正确更新
   - 验证时间统计保留原始数据

2. **UI 状态重置测试**
   - 导出元器件后点击"清空列表"
   - 添加新元器件
   - 验证"开始导出"按钮正确显示
   - 验证无多余空白区域

3. **图标显示测试**
   - 编译并运行程序
   - 触发导出操作
   - 验证系统通知图标正确显示

## 相关 Issue


## 破坏性变更

无

## 截图
