### PR TITLE
feat(images): 实现多预览图功能

### DIFF
--- a/download_files.py
+++ b/download_files.py
@@ -1,0 +1,263 @@
+import os
+import json
+import time
+import random
+import requests
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urlparse
+
+
+class FileDownloader:
+    def __init__(self, max_workers=5):
+        self.max_workers = max_workers
+        self.results = {}
+        
+        # 创建目录
+        self.datasheet_dir = "datasheet"
+        self.imgs_dir = "imgs"
+        
+        for dir_path in [self.datasheet_dir, self.imgs_dir]:
+            if not os.path.exists(dir_path):
+                os.makedirs(dir_path)
+        
+        # 请求头
+        self.headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
+            "Accept": "*/*",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        }
+    
+    def _get_filename_from_url(self, url: str, prefix: str = "") -> str:
+        """从URL中提取文件名"""
+        parsed = urlparse(url)
+        filename = os.path.basename(parsed.path)
+        
+        if not filename or '.' not in filename:
+            # 根据URL类型添加扩展名
+            if 'pdf' in url.lower():
+                filename = f"{prefix}.pdf"
+            else:
+                # 尝试从Content-Type推断
+                ext = self._get_extension_from_url(url)
+                filename = f"{prefix}{ext}"
+        
+        return filename
+    
+    def _sanitize_filename(self, filename: str) -> str:
+        """清理文件名中的非法字符"""
+        if not filename:
+            return ""
+        # 替换非法字符
+        invalid_chars = '<>:"/\\|?*'
+        for char in invalid_chars:
+            filename = filename.replace(char, '_')
+        return filename
+    
+    def _get_extension_from_url(self, url: str) -> str:
+        """根据URL推断文件扩展名"""
+        url_lower = url.lower()
+        if '.pdf' in url_lower:
+            return '.pdf'
+        elif '.html' in url_lower:
+            return '.html'
+        elif '.png' in url_lower:
+            return '.png'
+        elif '.jpg' in url_lower or '.jpeg' in url_lower:
+            return '.jpg'
+        elif '.gif' in url_lower:
+            return '.gif'
+        elif '.webp' in url_lower:
+            return '.webp'
+        else:
+            return '.html'  # 默认
+    
+    def _download_file(self, url: str, save_path: str) -> dict:
+        """下载单个文件，根据Content-Type确定扩展名"""
+        try:
+            response = requests.get(url, headers=self.headers, timeout=30)
+            response.raise_for_status()
+            
+            # 根据Content-Type确定文件扩展名
+            content_type = response.headers.get('Content-Type', '').lower()
+            if 'pdf' in content_type:
+                if not save_path.endswith('.pdf'):
+                    save_path = save_path.rsplit('.', 1)[0] + '.pdf'
+            elif 'html' in content_type:
+                if not save_path.endswith('.html'):
+                    save_path = save_path.rsplit('.', 1)[0] + '.html'
+            elif 'png' in content_type:
+                if not save_path.endswith('.png'):
+                    save_path = save_path.rsplit('.', 1)[0] + '.png'
+            elif 'jpeg' in content_type or 'jpg' in content_type:
+                if not save_path.endswith(('.jpg', '.jpeg')):
+                    save_path = save_path.rsplit('.', 1)[0] + '.jpg'
+            
+            with open(save_path, 'wb') as f:
+                f.write(response.content)
+            
+            return {
+                'url': url,
+                'path': save_path,
+                'status': 'success',
+                'size': len(response.content)
+            }
+            
+        except requests.exceptions.RequestException as e:
+            return {
+                'url': url,
+                'path': save_path,
+                'status': 'error',
+                'error': str(e)
+            }
+    
+    def _download_datasheet(self, component_id: str, manufacturer_part: str, url: str) -> dict:
+        """下载 datasheet，文件名格式: Manufacturer_Part.扩展名"""
+        # 使用 Manufacturer Part 作为文件名
+        safe_name = self._sanitize_filename(manufacturer_part) if manufacturer_part else component_id
+        ext = self._get_extension_from_url(url)
+        filename = f"{safe_name}{ext}"
+        save_path = os.path.join(self.datasheet_dir, filename)
+        
+        # 如果文件已存在，跳过
+        if os.path.exists(save_path):
+            return {
+                'component_id': component_id,
+                'url': url,
+                'path': save_path,
+                'status': 'exists'
+            }
+        
+        return self._download_file(url, save_path)
+    
+    def _download_image(self, component_id: str, manufacturer_part: str, image_url: str, index: int) -> dict:
+        """下载图片，文件名格式: Manufacturer Part_序号.扩展名"""
+        # 使用 Manufacturer Part 作为前缀
+        safe_name = self._sanitize_filename(manufacturer_part) if manufacturer_part else component_id
+        ext = self._get_extension_from_url(image_url)
+        filename = f"{safe_name}_{index}{ext}"
+        save_path = os.path.join(self.imgs_dir, filename)
+        
+        # 如果文件已存在，跳过
+        if os.path.exists(save_path):
+            return {
+                'component_id': component_id,
+                'url': image_url,
+                'path': save_path,
+                'status': 'exists'
+            }
+        
+        return self._download_file(image_url, save_path)
+    
+    def download_all(self, data: dict) -> dict:
+        """下载所有文件"""
+        # 收集所有下载任务
+        tasks = []
+        
+        for component_id, info in data.items():
+            if info.get('status') != 'success':
+                continue
+            
+            manufacturer_part = info.get('manufacturer_part', component_id)
+            
+            # 下载 datasheet
+            datasheet_url = info.get('datasheet')
+            if datasheet_url:
+                tasks.append(('datasheet', component_id, manufacturer_part, datasheet_url, 0))
+            
+            # 下载图片
+            images = info.get('images', [])
+            for i, img_url in enumerate(images):
+                tasks.append(('image', component_id, manufacturer_part, img_url, i + 1))
+        
+        print(f"开始下载 {len(tasks)} 个文件...")
+        print(f"  - Datasheet: {sum(1 for t in tasks if t[0] == 'datasheet')} 个")
+        print(f"  - 图片: {sum(1 for t in tasks if t[0] == 'image')} 个")
+        print(f"使用 {self.max_workers} 个线程并行下载\n")
+        
+        # 执行下载
+        completed = 0
+        success_count = 0
+        error_count = 0
+        exists_count = 0
+        
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            future_to_task = {}
+            
+            for task in tasks:
+                task_type = task[0]
+                component_id = task[1]
+                manufacturer_part = task[2]
+                url = task[3]
+                index = task[4] if len(task) > 4 else 0
+                
+                if task_type == 'datasheet':
+                    future = executor.submit(self._download_datasheet, component_id, manufacturer_part, url)
+                else:
+                    future = executor.submit(self._download_image, component_id, manufacturer_part, url, index)
+                
+                future_to_task[future] = (task_type, component_id, url)
+            
+            for future in as_completed(future_to_task):
+                task_type, component_id, url = future_to_task[future]
+                completed += 1
+                
+                try:
+                    result = future.result()
+                    self.results[f"{component_id}_{task_type}_{url}"] = result
+                    
+                    if result['status'] == 'success':
+                        success_count += 1
+                        print(f"[{completed}/{len(tasks)}] ✓ {component_id} {task_type}: {result['path']} ({result.get('size', 0)} bytes)")
+                    elif result['status'] == 'exists':
+                        exists_count += 1
+                        print(f"[{completed}/{len(tasks)}] = {component_id} {task_type}: 已存在")
+                    else:
+                        error_count += 1
+                        print(f"[{completed}/{len(tasks)}] ✗ {component_id} {task_type}: {result.get('error', 'Unknown error')}")
+                        
+                except Exception as e:
+                    error_count += 1
+                    print(f"[{completed}/{len(tasks)}] ✗ {component_id} {task_type}: 异常 - {e}")
+                
+                # 短暂延迟避免被限流
+                time.sleep(random.uniform(0.05, 0.15))
+        
+        print(f"\n{'='*60}")
+        print(f"下载完成！")
+        print(f"成功: {success_count}")
+        print(f"已存在: {exists_count}")
+        print(f"失败: {error_count}")
+        print(f"总计: {len(tasks)}")
+        
+        return self.results
+    
+    def save_results(self, filename: str = 'download_results.json'):
+        """保存下载结果"""
+        with open(filename, 'w', encoding='utf-8') as f:
+            json.dump(self.results, f, ensure_ascii=False, indent=2)
+        print(f"\n下载结果已保存到: {filename}")
+
+
+if __name__ == "__main__":
+    # 读取数据
+    with open('lceda_results.json', 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    
+    print(f"读取到 {len(data)} 个元器件数据\n")
+    
+    # 创建下载器，使用 5 个线程
+    downloader = FileDownloader(max_workers=5)
+    
+    # 下载所有文件
+    results = downloader.download_all(data)
+    
+    # 保存结果
+    downloader.save_results('download_results.json')
+    
+    # 统计
+    datasheet_count = len([r for r in results.values() if 'datasheet' in r.get('path', '')])
+    image_count = len([r for r in results.values() if 'imgs' in r.get('path', '')])
+    
+    print(f"\n文件统计:")
+    print(f"  datasheet 目录: {datasheet_count} 个文件")
+    print(f"  imgs 目录: {image_count} 个文件")

--- a/fetch_lceda.py
+++ b/fetch_lceda.py
@@ -1,0 +1,157 @@
+import requests
+import json
+import time
+import random
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+class LCEImageFetcher:
+    def __init__(self, max_workers=5):
+        self.max_workers = max_workers
+        self.results = {}
+        
+    def _search_product(self, keyword: str) -> dict:
+        """搜索产品"""
+        url = "https://pro.lceda.cn/api/v2/eda/product/search"
+        
+        payload = {
+            "keyword": keyword,
+            "currPage": 1,
+            "pageSize": 50,
+            # "path": "0819f05c4eef4c71ace90d822a990e87",
+            "needAggs": "true"
+        }
+        
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36",
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+        
+        try:
+            response = requests.post(url, data=payload, headers=headers, timeout=5)
+            response.raise_for_status()
+            
+            data = response.json()
+            with open(f'./respose/{payload.get("keyword")}_response.json', 'w', encoding='utf-8') as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            result = data.get('result', {})
+            product_list = result.get('productList', [])
+            
+            if product_list and len(product_list) > 0:
+                product = product_list[0]
+                
+                manufacturer_part = None
+                datasheet = None
+                if product.get('device_info') and product['device_info'].get('attributes'):
+                    attrs = product['device_info']['attributes']
+                    manufacturer_part = attrs.get('Manufacturer Part')
+                    datasheet = attrs.get('Datasheet')
+                
+                images = product.get('image', '')
+                image_list = images.split('<$>') if images else []
+                
+                return {
+                    'keyword': keyword,
+                    'code': product.get('code'),
+                    'name': product.get('name'),
+                    'manufacturer_part': manufacturer_part,
+                    'datasheet': datasheet,
+                    'images': image_list,
+                    'status': 'success'
+                }
+            else:
+                return {
+                    'keyword': keyword,
+                    'status': 'not_found'
+                }
+                
+        except requests.exceptions.RequestException as e:
+            return {
+                'keyword': keyword,
+                'status': 'error',
+                'error': str(e)
+            }
+    
+    def fetch_all(self, keywords: list) -> dict:
+        """并行批量获取"""
+        print(f"开始获取 {len(keywords)} 个元器件的数据...")
+        print(f"使用 {self.max_workers} 个线程并行获取\n")
+        
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            future_to_keyword = {
+                executor.submit(self._search_product, keyword): keyword 
+                for keyword in keywords
+            }
+            
+            completed = 0
+            for future in as_completed(future_to_keyword):
+                keyword = future_to_keyword[future]
+                completed += 1
+                
+                try:
+                    result = future.result()
+                    self.results[keyword] = result
+                    
+                    if result['status'] == 'success':
+                        img_count = len(result.get('images', []))
+                        has_ds = '✓' if result.get('datasheet') else '✗'
+                        print(f"[{completed}/{len(keywords)}] {keyword} ✓ 名称: {result.get('name', 'N/A')[:30]}... | 图片: {img_count} | DS: {has_ds}")
+                    elif result['status'] == 'not_found':
+                        print(f"[{completed}/{len(keywords)}] {keyword} ✗ 未找到")
+                    else:
+                        print(f"[{completed}/{len(keywords)}] {keyword} ✗ 错误: {result.get('error', 'Unknown')}")
+                        
+                except Exception as e:
+                    self.results[keyword] = {'keyword': keyword, 'status': 'error', 'error': str(e)}
+                    print(f"[{completed}/{len(keywords)}] {keyword} ✗ 异常: {e}")
+                
+                time.sleep(random.uniform(0.1, 0.3))
+        
+        return self.results
+    
+    def save_results(self, filename: str = 'lceda_results.json'):
+        """保存结果到 JSON 文件"""
+        with open(filename, 'w', encoding='utf-8') as f:
+            json.dump(self.results, f, ensure_ascii=False, indent=2)
+        print(f"\n结果已保存到: {filename}")
+    
+    def print_summary(self):
+        """打印汇总信息"""
+        success = sum(1 for r in self.results.values() if r['status'] == 'success')
+        not_found = sum(1 for r in self.results.values() if r['status'] == 'not_found')
+        error = sum(1 for r in self.results.values() if r['status'] == 'error')
+        
+        print(f"\n{'='*60}")
+        print(f"获取完成！")
+        print(f"成功: {success}")
+        print(f"未找到: {not_found}")
+        print(f"错误: {error}")
+        print(f"总计: {len(self.results)}")
+
+
+if __name__ == "__main__":
+    # 元器件列表
+    component_ids = [
+        "C8734", "C52717", "C8323", "C28730", "C35556", "C724040",
+        "C432211", "C14877", "C12345", "C2040", "C915663", "C33993",
+        "C2858491", "C19156", "C80713", "C13622", "C60420", "C507118",
+        "C3018718", "C414042", "C7420375", "C432211", "C2040"
+    ]
+    
+    # 去重
+    unique_ids = list(set(component_ids))
+    
+    # 创建 fetcher，使用 10 个线程
+    fetcher = LCEImageFetcher(max_workers=10)
+    
+    # 获取所有数据
+    results = fetcher.fetch_all(unique_ids)
+    
+    # 打印汇总
+    fetcher.print_summary()
+    
+    # 保存结果
+    fetcher.save_results('lceda_results.json')
+    

--- a/src/models/ComponentData.cpp
+++ b/src/models/ComponentData.cpp
@@ -12,6 +12,7 @@ ComponentData::ComponentData()
     , m_package()
     , m_manufacturer()
     , m_datasheet()
+    , m_previewImages()
     , m_symbolData(nullptr)
     , m_footprintData(nullptr)
     , m_model3DData(nullptr) {}
@@ -26,6 +27,13 @@ QJsonObject ComponentData::toJson() const {
     json["package"] = m_package;
     json["manufacturer"] = m_manufacturer;
     json["datasheet"] = m_datasheet;
+
+    // 预览图列表
+    QJsonArray previewImagesArray;
+    for (const QString& imageUrl : m_previewImages) {
+        previewImagesArray.append(imageUrl);
+    }
+    json["preview_images"] = previewImagesArray;
 
     // 符号数据
     if (m_symbolData) {
@@ -53,6 +61,15 @@ bool ComponentData::fromJson(const QJsonObject& json) {
     m_package = json["package"].toString();
     m_manufacturer = json["manufacturer"].toString();
     m_datasheet = json["datasheet"].toString();
+
+    // 读取预览图列表
+    if (json.contains("preview_images") && json["preview_images"].isArray()) {
+        QJsonArray previewImagesArray = json["preview_images"].toArray();
+        m_previewImages.clear();
+        for (const QJsonValue& value : previewImagesArray) {
+            m_previewImages.append(value.toString());
+        }
+    }
 
     // 读取符号数据
     if (json.contains("symbol") && json["symbol"].isObject()) {
@@ -165,6 +182,7 @@ void ComponentData::clear() {
     m_package.clear();
     m_manufacturer.clear();
     m_datasheet.clear();
+    m_previewImages.clear();
 
     m_symbolData.reset();
     m_footprintData.reset();

--- a/src/models/ComponentData.h
+++ b/src/models/ComponentData.h
@@ -121,13 +121,13 @@ public:
     void clear();
 
 private:
-    QString m_lcscId;        // LCSC 元件编号
-    QString m_name;          // 元件名称
-    QString m_prefix;        // 元件前缀
-    QString m_package;       // 封装名称
-    QString m_manufacturer;  // 制造商
-    QString m_datasheet;     // 数据手册链接
-    QStringList m_previewImages; // 预览图 URL 列表
+    QString m_lcscId;             // LCSC 元件编号
+    QString m_name;               // 元件名称
+    QString m_prefix;             // 元件前缀
+    QString m_package;            // 封装名称
+    QString m_manufacturer;       // 制造商
+    QString m_datasheet;          // 数据手册链接
+    QStringList m_previewImages;  // 预览图 URL 列表
 
     QSharedPointer<SymbolData> m_symbolData;        // 符号数据
     QSharedPointer<FootprintData> m_footprintData;  // 封装数据

--- a/src/models/ComponentData.h
+++ b/src/models/ComponentData.h
@@ -71,6 +71,20 @@ public:
         m_datasheet = datasheet;
     }
 
+    QStringList previewImages() const {
+        return m_previewImages;
+    }
+
+    void setPreviewImages(const QStringList& images) {
+        m_previewImages = images;
+    }
+
+    void addPreviewImage(const QString& imageUrl) {
+        if (!imageUrl.isEmpty() && !m_previewImages.contains(imageUrl)) {
+            m_previewImages.append(imageUrl);
+        }
+    }
+
     QSharedPointer<SymbolData> symbolData() const {
         return m_symbolData;
     }
@@ -113,6 +127,7 @@ private:
     QString m_package;       // 封装名称
     QString m_manufacturer;  // 制造商
     QString m_datasheet;     // 数据手册链接
+    QStringList m_previewImages; // 预览图 URL 列表
 
     QSharedPointer<SymbolData> m_symbolData;        // 符号数据
     QSharedPointer<FootprintData> m_footprintData;  // 封装数据

--- a/src/models/ComponentListItemData.cpp
+++ b/src/models/ComponentListItemData.cpp
@@ -7,6 +7,7 @@ namespace EasyKiConverter {
 ComponentListItemData::ComponentListItemData(const QString& componentId, QObject* parent)
     : QObject(parent)
     , m_componentId(componentId)
+    , m_currentPreviewIndex(0)
     , m_isValid(true)  // 默认为 true，直到验证失败
     , m_isFetching(false) {}
 
@@ -76,6 +77,60 @@ void ComponentListItemData::setErrorMessage(const QString& error) {
     if (m_errorMessage != error) {
         m_errorMessage = error;
         emit validationStatusChanged();
+    }
+}
+
+QVariantList ComponentListItemData::previewImages() const {
+    QVariantList result;
+    for (const QImage& image : m_previewImages) {
+        QByteArray byteArray;
+        QBuffer buffer(&byteArray);
+        buffer.open(QIODevice::WriteOnly);
+        image.save(&buffer, "PNG");
+        result.append(QString::fromLatin1(byteArray.toBase64().data()));
+    }
+    return result;
+}
+
+void ComponentListItemData::addPreviewImage(const QImage& image) {
+    if (!image.isNull()) {
+        m_previewImages.append(image);
+        // 如果是第一张图片，设置为主缩略图
+        if (m_previewImages.size() == 1) {
+            setThumbnail(image);
+        }
+        emit previewImagesChanged();
+    }
+}
+
+void ComponentListItemData::setPreviewImages(const QList<QImage>& images) {
+    m_previewImages = images;
+    if (!images.isEmpty()) {
+        setThumbnail(images.first());
+        m_currentPreviewIndex = 0;
+    }
+    emit previewImagesChanged();
+}
+
+void ComponentListItemData::setCurrentPreviewIndex(int index) {
+    if (index >= 0 && index < m_previewImages.size() && index != m_currentPreviewIndex) {
+        m_currentPreviewIndex = index;
+        setThumbnail(m_previewImages[index]);
+        emit currentPreviewIndexChanged();
+    }
+}
+
+void ComponentListItemData::nextPreviewImage() {
+    if (!m_previewImages.isEmpty()) {
+        int nextIndex = (m_currentPreviewIndex + 1) % m_previewImages.size();
+        setCurrentPreviewIndex(nextIndex);
+    }
+}
+
+void ComponentListItemData::previousPreviewImage() {
+    if (!m_previewImages.isEmpty()) {
+        int prevIndex = (m_currentPreviewIndex - 1 + m_previewImages.size()) % m_previewImages.size();
+        setCurrentPreviewIndex(prevIndex);
     }
 }
 

--- a/src/models/ComponentListItemData.h
+++ b/src/models/ComponentListItemData.h
@@ -22,6 +22,9 @@ class ComponentListItemData : public QObject {
     Q_PROPERTY(QString package READ package NOTIFY dataChanged)
     Q_PROPERTY(QImage thumbnail READ thumbnail NOTIFY thumbnailChanged)
     Q_PROPERTY(QString thumbnailBase64 READ thumbnailBase64 NOTIFY thumbnailChanged)
+    Q_PROPERTY(QVariantList previewImages READ previewImages NOTIFY previewImagesChanged)
+    Q_PROPERTY(int currentPreviewIndex READ currentPreviewIndex NOTIFY currentPreviewIndexChanged)
+    Q_PROPERTY(int previewImageCount READ previewImageCount NOTIFY previewImagesChanged)
     Q_PROPERTY(bool isValid READ isValid NOTIFY validationStatusChanged)
     Q_PROPERTY(bool isFetching READ isFetching NOTIFY fetchingStatusChanged)
     Q_PROPERTY(bool hasThumbnail READ hasThumbnail NOTIFY thumbnailChanged)
@@ -49,6 +52,14 @@ public:
 
     QString thumbnailBase64() const;
 
+    QVariantList previewImages() const;
+    int currentPreviewIndex() const {
+        return m_currentPreviewIndex;
+    }
+    int previewImageCount() const {
+        return m_previewImages.count();
+    }
+
     bool isValid() const {
         return m_isValid;
     }
@@ -73,6 +84,11 @@ public:
     void setName(const QString& name);
     void setPackage(const QString& package);
     void setThumbnail(const QImage& thumbnail);
+    void addPreviewImage(const QImage& image);
+    void setPreviewImages(const QList<QImage>& images);
+    void setCurrentPreviewIndex(int index);
+    void nextPreviewImage();
+    void previousPreviewImage();
     void setComponentData(const QSharedPointer<ComponentData>& data);
     void setValid(bool valid);
     void setFetching(bool fetching);
@@ -81,6 +97,8 @@ public:
 signals:
     void dataChanged();
     void thumbnailChanged();
+    void previewImagesChanged();
+    void currentPreviewIndexChanged();
     void validationStatusChanged();
     void fetchingStatusChanged();
 
@@ -89,6 +107,8 @@ private:
     QString m_name;
     QString m_package;
     QImage m_thumbnail;
+    QList<QImage> m_previewImages;
+    int m_currentPreviewIndex;
     mutable QString m_thumbnailBase64Cache;  // 缓存 base64 编码结果，避免重复计算
     bool m_isValid;
     bool m_isFetching;

--- a/src/models/ComponentListItemData.h
+++ b/src/models/ComponentListItemData.h
@@ -53,9 +53,11 @@ public:
     QString thumbnailBase64() const;
 
     QVariantList previewImages() const;
+
     int currentPreviewIndex() const {
         return m_currentPreviewIndex;
     }
+
     int previewImageCount() const {
         return m_previewImages.count();
     }

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -123,7 +123,7 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
 }
 
 void ComponentService::fetchLcscPreviewImage(const QString& componentId) {
-    m_imageService->fetchPreviewImage(componentId);
+    m_imageService->fetchPreviewImages(componentId);
 }
 
 void ComponentService::handleImageReady(const QString& componentId, const QString& imagePath) {

--- a/src/services/LcscImageService.cpp
+++ b/src/services/LcscImageService.cpp
@@ -75,8 +75,9 @@ void LcscImageService::handleApiResponse(QNetworkReply* reply, const QString& co
 
     if (reply->error() != QNetworkReply::NoError) {
         if (retryCount < 2) {
-            QTimer::singleShot(
-                1000 * (retryCount + 1), this, [this, componentId, retryCount]() { performApiSearch(componentId, retryCount + 1); });
+            QTimer::singleShot(1000 * (retryCount + 1), this, [this, componentId, retryCount]() {
+                performApiSearch(componentId, retryCount + 1);
+            });
         } else {
             // API 失败，尝试回退到爬虫方式
             performFallback(componentId);
@@ -170,7 +171,10 @@ void LcscImageService::handleFallbackResponse(QNetworkReply* reply, const QStrin
     processQueue();
 }
 
-void LcscImageService::performDownload(const QString& componentId, const QString& imageUrl, int imageIndex, int retryCount) {
+void LcscImageService::performDownload(const QString& componentId,
+                                       const QString& imageUrl,
+                                       int imageIndex,
+                                       int retryCount) {
     QNetworkRequest request{QUrl(imageUrl)};
     request.setHeader(QNetworkRequest::UserAgentHeader, "Mozilla/5.0");
     request.setTransferTimeout(20000);
@@ -181,7 +185,11 @@ void LcscImageService::performDownload(const QString& componentId, const QString
     });
 }
 
-void LcscImageService::handleDownloadResponse(QNetworkReply* reply, const QString& componentId, const QString& imageUrl, int imageIndex, int retryCount) {
+void LcscImageService::handleDownloadResponse(QNetworkReply* reply,
+                                              const QString& componentId,
+                                              const QString& imageUrl,
+                                              int imageIndex,
+                                              int retryCount) {
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
@@ -189,7 +197,8 @@ void LcscImageService::handleDownloadResponse(QNetworkReply* reply, const QStrin
             performDownload(componentId, imageUrl, imageIndex, retryCount + 1);
         } else {
             // 下载失败，记录但继续处理其他图片
-            qDebug() << "Failed to download image for" << componentId << "index:" << imageIndex << "error:" << reply->errorString();
+            qDebug() << "Failed to download image for" << componentId << "index:" << imageIndex
+                     << "error:" << reply->errorString();
             checkDownloadCompletion(componentId);
         }
         return;
@@ -211,7 +220,8 @@ void LcscImageService::handleDownloadResponse(QNetworkReply* reply, const QStrin
         // 检查是否所有图片都下载完成
         checkDownloadCompletion(componentId);
     } else {
-        qDebug() << "Failed to save image for" << componentId << "index:" << imageIndex << "error:" << file.errorString();
+        qDebug() << "Failed to save image for" << componentId << "index:" << imageIndex
+                 << "error:" << file.errorString();
         checkDownloadCompletion(componentId);
     }
 }

--- a/src/services/LcscImageService.cpp
+++ b/src/services/LcscImageService.cpp
@@ -5,20 +5,32 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QNetworkRequest>
-#include <QRegularExpression>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QUrlQuery>
 
 namespace EasyKiConverter {
 
 LcscImageService::LcscImageService(QObject* parent)
-    : QObject(parent), m_networkManager(new QNetworkAccessManager(this)), m_activeRequests(0) {}
+    : QObject(parent), m_networkManager(new QNetworkAccessManager(this)), m_activeRequests(0) {
+    // 设置缓存目录
+    m_cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/lcsc_images";
+    ensureCacheDir();
+}
 
-void LcscImageService::fetchPreviewImage(const QString& componentId) {
+void LcscImageService::fetchPreviewImages(const QString& componentId) {
     if (componentId.isEmpty())
         return;
     m_queue.enqueue(componentId);
+    processQueue();
+}
+
+void LcscImageService::fetchBatchPreviewImages(const QStringList& componentIds) {
+    for (const QString& componentId : componentIds) {
+        if (!componentId.isEmpty()) {
+            m_queue.enqueue(componentId);
+        }
+    }
     processQueue();
 }
 
@@ -26,36 +38,47 @@ void LcscImageService::processQueue() {
     while (m_activeRequests < MAX_CONCURRENT_REQUESTS && !m_queue.isEmpty()) {
         QString componentId = m_queue.dequeue();
         m_activeRequests++;
-        performSearch(componentId, 0);
+        performApiSearch(componentId, 0);
     }
 }
 
-void LcscImageService::performSearch(const QString& componentId, int retryCount) {
-    QString url =
-        QString("https://overseas.szlcsc.com/overseas/global/search?keyword=%1&pageNumber=1&noShowSelf=false&from=%1")
-            .arg(componentId);
+void LcscImageService::performApiSearch(const QString& componentId, int retryCount) {
+    // 使用官方 API 搜索产品
+    QString apiUrl = "https://pro.lceda.cn/api/v2/eda/product/search";
 
-    QNetworkRequest request{QUrl(url)};
+    // 构建表单数据
+    QByteArray postData;
+    QUrlQuery query;
+    query.addQueryItem("keyword", componentId);
+    query.addQueryItem("currPage", "1");
+    query.addQueryItem("pageSize", "1");
+    query.addQueryItem("needAggs", "true");
+    postData = query.toString(QUrl::FullyEncoded).toUtf8();
+
+    QNetworkRequest request{QUrl(apiUrl)};
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded; charset=UTF-8");
     request.setHeader(QNetworkRequest::UserAgentHeader,
                       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
-                      "Chrome/114.0.0.0 Safari/537.36");
-    request.setRawHeader("Accept", "application/json");
+                      "Chrome/145.0.0.0 Safari/537.36");
+    request.setRawHeader("Accept", "application/json, text/javascript, */*; q=0.01");
+    request.setRawHeader("X-Requested-With", "XMLHttpRequest");
     request.setTransferTimeout(15000);
 
-    QNetworkReply* reply = m_networkManager->get(request);
+    QNetworkReply* reply = m_networkManager->post(request, postData);
     connect(reply, &QNetworkReply::finished, this, [this, reply, componentId, retryCount]() {
-        handleSearchResponse(reply, componentId, retryCount);
+        handleApiResponse(reply, componentId, retryCount);
     });
 }
 
-void LcscImageService::handleSearchResponse(QNetworkReply* reply, const QString& componentId, int retryCount) {
+void LcscImageService::handleApiResponse(QNetworkReply* reply, const QString& componentId, int retryCount) {
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
         if (retryCount < 2) {
             QTimer::singleShot(
-                1000, this, [this, componentId, retryCount]() { performSearch(componentId, retryCount + 1); });
+                1000 * (retryCount + 1), this, [this, componentId, retryCount]() { performApiSearch(componentId, retryCount + 1); });
         } else {
+            // API 失败，尝试回退到爬虫方式
             performFallback(componentId);
         }
         return;
@@ -63,31 +86,49 @@ void LcscImageService::handleSearchResponse(QNetworkReply* reply, const QString&
 
     QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
     QJsonObject root = doc.object();
-    QString imageUrl;
-    bool found = false;
 
+    // 解析 API 响应
     if (root.contains("result")) {
-        QJsonArray resultArray = root["result"].toArray();
-        for (const auto& resVal : resultArray) {
-            QJsonObject resObj = resVal.toObject();
-            if (resObj.contains("products")) {
-                QJsonArray products = resObj["products"].toArray();
-                if (!products.isEmpty()) {
-                    imageUrl = products[0].toObject()["selfBreviaryImageUrl"].toString();
-                    if (!imageUrl.isEmpty()) {
-                        found = true;
-                        break;
+        QJsonObject result = root["result"].toObject();
+
+        if (result.contains("productList")) {
+            QJsonArray productList = result["productList"].toArray();
+
+            if (!productList.isEmpty()) {
+                QJsonObject product = productList[0].toObject();
+
+                // 提取图片列表
+                QStringList imageUrls;
+                if (product.contains("image")) {
+                    QString imagesStr = product["image"].toString();
+                    if (!imagesStr.isEmpty()) {
+                        // EasyEDA 使用 <$> 分隔多张图片
+                        imageUrls = imagesStr.split("<$>", Qt::SkipEmptyParts);
                     }
+                }
+
+                // 限制最多 3 张图片
+                while (imageUrls.size() > MAX_IMAGES_PER_COMPONENT) {
+                    imageUrls.removeLast();
+                }
+
+                if (!imageUrls.isEmpty()) {
+                    m_pendingImages[componentId] = imageUrls;
+                    m_downloadedImages[componentId].clear();
+                    m_downloadCounts[componentId] = 0;
+
+                    // 开始下载所有图片
+                    for (int i = 0; i < imageUrls.size(); ++i) {
+                        performDownload(componentId, imageUrls[i], i, 0);
+                    }
+                    return;
                 }
             }
         }
     }
 
-    if (found) {
-        performDownload(componentId, imageUrl, 0);
-    } else {
-        performFallback(componentId);
-    }
+    // API 没有找到图片，尝试回退
+    performFallback(componentId);
 }
 
 void LcscImageService::performFallback(const QString& componentId) {
@@ -114,7 +155,12 @@ void LcscImageService::handleFallbackResponse(QNetworkReply* reply, const QStrin
         QRegularExpressionMatch match = re.match(html);
 
         if (match.hasMatch()) {
-            performDownload(componentId, match.captured(1), 0);
+            QStringList imageUrls = {match.captured(1)};
+            m_pendingImages[componentId] = imageUrls;
+            m_downloadedImages[componentId].clear();
+            m_downloadCounts[componentId] = 0;
+
+            performDownload(componentId, imageUrls[0], 0, 0);
             return;
         }
     }
@@ -124,47 +170,95 @@ void LcscImageService::handleFallbackResponse(QNetworkReply* reply, const QStrin
     processQueue();
 }
 
-void LcscImageService::performDownload(const QString& componentId, const QString& imageUrl, int retryCount) {
+void LcscImageService::performDownload(const QString& componentId, const QString& imageUrl, int imageIndex, int retryCount) {
     QNetworkRequest request{QUrl(imageUrl)};
     request.setHeader(QNetworkRequest::UserAgentHeader, "Mozilla/5.0");
     request.setTransferTimeout(20000);
 
     QNetworkReply* reply = m_networkManager->get(request);
-    connect(reply, &QNetworkReply::finished, this, [this, reply, componentId, retryCount, imageUrl]() {
-        handleDownloadResponse(reply, componentId, retryCount);
+    connect(reply, &QNetworkReply::finished, this, [this, reply, componentId, imageUrl, imageIndex, retryCount]() {
+        handleDownloadResponse(reply, componentId, imageUrl, imageIndex, retryCount);
     });
 }
 
-void LcscImageService::handleDownloadResponse(QNetworkReply* reply, const QString& componentId, int retryCount) {
+void LcscImageService::handleDownloadResponse(QNetworkReply* reply, const QString& componentId, const QString& imageUrl, int imageIndex, int retryCount) {
     reply->deleteLater();
 
     if (reply->error() != QNetworkReply::NoError) {
         if (retryCount < 2) {
-            performDownload(componentId, reply->url().toString(), retryCount + 1);
+            performDownload(componentId, imageUrl, imageIndex, retryCount + 1);
         } else {
-            m_activeRequests--;
-            emit error(componentId, "Download failed");
-            processQueue();
+            // 下载失败，记录但继续处理其他图片
+            qDebug() << "Failed to download image for" << componentId << "index:" << imageIndex << "error:" << reply->errorString();
+            checkDownloadCompletion(componentId);
         }
         return;
     }
 
-    // 保存到临时目录
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/lcsc_images";
-    QDir().mkpath(cacheDir);
-    QString filePath = cacheDir + "/" + componentId + ".jpg";
+    // 保存到缓存目录
+    QString cachePath = getCachePath(componentId, imageIndex);
 
-    QFile file(filePath);
+    QFile file(cachePath);
     if (file.open(QIODevice::WriteOnly)) {
         file.write(reply->readAll());
         file.close();
-        emit imageReady(componentId, filePath);
+
+        m_downloadedImages[componentId].append(cachePath);
+        m_downloadCounts[componentId]++;
+
+        emit imageReady(componentId, cachePath, imageIndex);
+
+        // 检查是否所有图片都下载完成
+        checkDownloadCompletion(componentId);
     } else {
-        emit error(componentId, "Disk write error");
+        qDebug() << "Failed to save image for" << componentId << "index:" << imageIndex << "error:" << file.errorString();
+        checkDownloadCompletion(componentId);
+    }
+}
+
+void LcscImageService::checkDownloadCompletion(const QString& componentId) {
+    if (!m_pendingImages.contains(componentId)) {
+        return;
     }
 
-    m_activeRequests--;
-    processQueue();
+    int expectedCount = m_pendingImages[componentId].size();
+    int downloadedCount = m_downloadCounts.value(componentId, 0);
+
+    if (downloadedCount >= expectedCount) {
+        // 所有图片下载完成
+        emitAllImagesReady(componentId);
+
+        m_activeRequests--;
+        processQueue();
+    }
+}
+
+void LcscImageService::emitAllImagesReady(const QString& componentId) {
+    QStringList imagePaths = m_downloadedImages.value(componentId, QStringList());
+
+    if (imagePaths.isEmpty()) {
+        emit error(componentId, "No images downloaded");
+    } else {
+        emit allImagesReady(componentId, imagePaths);
+    }
+
+    // 清理临时数据
+    m_pendingImages.remove(componentId);
+    m_downloadedImages.remove(componentId);
+    m_downloadCounts.remove(componentId);
+}
+
+QString LcscImageService::getCachePath(const QString& componentId, int imageIndex) {
+    QString filename = QString("%1_%2.jpg").arg(componentId).arg(imageIndex);
+    return m_cacheDir + "/" + filename;
+}
+
+bool LcscImageService::ensureCacheDir() {
+    QDir dir(m_cacheDir);
+    if (!dir.exists()) {
+        return dir.mkpath(m_cacheDir);
+    }
+    return true;
 }
 
 }  // namespace EasyKiConverter

--- a/src/services/LcscImageService.h
+++ b/src/services/LcscImageService.h
@@ -6,13 +6,15 @@
 #include <QObject>
 #include <QQueue>
 #include <QString>
+#include <QStringList>
+#include <QMap>
 
 namespace EasyKiConverter {
 
 /**
  * @brief LCSC 图片服务类
  *
- * 专门负责抓取 LCSC 元件预览图，包含爬虫和重试逻辑
+ * 专门负责抓取 LCSC 元件预览图，使用官方 API 获取多张预览图
  */
 class LcscImageService : public QObject {
     Q_OBJECT
@@ -21,20 +23,36 @@ public:
     explicit LcscImageService(QObject* parent = nullptr);
 
     /**
-     * @brief 请求获取元件预览图
+     * @brief 请求获取元件预览图（支持多张）
      *
      * @param componentId 元件 ID
      */
-    void fetchPreviewImage(const QString& componentId);
+    void fetchPreviewImages(const QString& componentId);
+
+    /**
+     * @brief 批量获取多个元件的预览图
+     *
+     * @param componentIds 元件 ID 列表
+     */
+    void fetchBatchPreviewImages(const QStringList& componentIds);
 
 signals:
     /**
-     * @brief 图片下载成功信号
+     * @brief 单张图片下载成功信号
      *
      * @param componentId 元件 ID
      * @param imagePath 本地缓存路径
+     * @param imageIndex 图片索引（0-2）
      */
-    void imageReady(const QString& componentId, const QString& imagePath);
+    void imageReady(const QString& componentId, const QString& imagePath, int imageIndex);
+
+    /**
+     * @brief 所有图片下载完成信号
+     *
+     * @param componentId 元件 ID
+     * @param imagePaths 本地缓存路径列表
+     */
+    void allImagesReady(const QString& componentId, const QStringList& imagePaths);
 
     /**
      * @brief 错误信号
@@ -43,19 +61,28 @@ signals:
 
 private slots:
     void processQueue();
-    void handleSearchResponse(QNetworkReply* reply, const QString& componentId, int retryCount);
+    void handleApiResponse(QNetworkReply* reply, const QString& componentId, int retryCount);
     void handleFallbackResponse(QNetworkReply* reply, const QString& componentId);
-    void handleDownloadResponse(QNetworkReply* reply, const QString& componentId, int retryCount);
+    void handleDownloadResponse(QNetworkReply* reply, const QString& componentId, const QString& imageUrl, int imageIndex, int retryCount);
 
 private:
-    void performSearch(const QString& componentId, int retryCount);
+    void performApiSearch(const QString& componentId, int retryCount);
     void performFallback(const QString& componentId);
-    void performDownload(const QString& componentId, const QString& imageUrl, int retryCount);
+    void performDownload(const QString& componentId, const QString& imageUrl, int imageIndex, int retryCount);
+    void checkDownloadCompletion(const QString& componentId);
+    void emitAllImagesReady(const QString& componentId);
+    QString getCachePath(const QString& componentId, int imageIndex);
+    bool ensureCacheDir();
 
     QNetworkAccessManager* m_networkManager;
     QQueue<QString> m_queue;
+    QMap<QString, QStringList> m_pendingImages; // componentId -> imageUrls
+    QMap<QString, QStringList> m_downloadedImages; // componentId -> localPaths
+    QMap<QString, int> m_downloadCounts; // componentId -> downloaded count
     int m_activeRequests;
     static const int MAX_CONCURRENT_REQUESTS = 5;
+    static const int MAX_IMAGES_PER_COMPONENT = 3;
+    QString m_cacheDir;
 };
 
 }  // namespace EasyKiConverter

--- a/src/services/LcscImageService.h
+++ b/src/services/LcscImageService.h
@@ -1,13 +1,13 @@
 #ifndef LCSCIMAGESERVICE_H
 #define LCSCIMAGESERVICE_H
 
+#include <QMap>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QObject>
 #include <QQueue>
 #include <QString>
 #include <QStringList>
-#include <QMap>
 
 namespace EasyKiConverter {
 
@@ -63,7 +63,11 @@ private slots:
     void processQueue();
     void handleApiResponse(QNetworkReply* reply, const QString& componentId, int retryCount);
     void handleFallbackResponse(QNetworkReply* reply, const QString& componentId);
-    void handleDownloadResponse(QNetworkReply* reply, const QString& componentId, const QString& imageUrl, int imageIndex, int retryCount);
+    void handleDownloadResponse(QNetworkReply* reply,
+                                const QString& componentId,
+                                const QString& imageUrl,
+                                int imageIndex,
+                                int retryCount);
 
 private:
     void performApiSearch(const QString& componentId, int retryCount);
@@ -76,9 +80,9 @@ private:
 
     QNetworkAccessManager* m_networkManager;
     QQueue<QString> m_queue;
-    QMap<QString, QStringList> m_pendingImages; // componentId -> imageUrls
-    QMap<QString, QStringList> m_downloadedImages; // componentId -> localPaths
-    QMap<QString, int> m_downloadCounts; // componentId -> downloaded count
+    QMap<QString, QStringList> m_pendingImages;     // componentId -> imageUrls
+    QMap<QString, QStringList> m_downloadedImages;  // componentId -> localPaths
+    QMap<QString, int> m_downloadCounts;            // componentId -> downloaded count
     int m_activeRequests;
     static const int MAX_CONCURRENT_REQUESTS = 5;
     static const int MAX_IMAGES_PER_COMPONENT = 3;

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -68,53 +68,197 @@ Rectangle {
         anchors.margins: AppStyle.spacing.sm
         spacing: AppStyle.spacing.md
         z: 10 // 确保内容在背景 MouseArea 之上
-        // 缩略图区域
-        Rectangle {
+        
+        // 预览图区域 - 支持悬停放大
+        Item {
+            id: previewArea
             Layout.preferredWidth: 48
             Layout.preferredHeight: 48
             Layout.alignment: Qt.AlignVCenter
-            color: "white"
-            radius: AppStyle.radius.sm
-            border.color: AppStyle.colors.border
-            border.width: 1
-            clip: true // 裁剪内部图片圆角
-            Image {
-                id: thumbnail
-                anchors.centerIn: parent
-                width: 46
-                height: 46
-                source: (itemData && itemData.thumbnailBase64) ? "data:image/png;base64," + itemData.thumbnailBase64 : ""
-                fillMode: Image.PreserveAspectFit
-                visible: itemData && itemData.hasThumbnail && !itemData.isFetching
-                cache: true  // 启用缓存避免 GridView 回收委托时重复解码
-                asynchronous: true  // 异步解码不阻塞 UI 线程
+            
+            // 默认显示的单张缩略图
+            Rectangle {
+                id: defaultThumbnail
+                width: 48
+                height: 48
+                color: "white"
+                radius: AppStyle.radius.sm
+                border.color: AppStyle.colors.border
+                border.width: 1
+                clip: true
+                
+                Image {
+                    anchors.centerIn: parent
+                    width: 46
+                    height: 46
+                    source: (itemData && itemData.thumbnailBase64) ? "data:image/png;base64," + itemData.thumbnailBase64 : ""
+                    fillMode: Image.PreserveAspectFit
+                    cache: true
+                    asynchronous: true
+                    visible: itemData && itemData.hasThumbnail && !itemData.isFetching
+                }
+                
+                // 加载状态
+                BusyIndicator {
+                    anchors.centerIn: parent
+                    width: 24
+                    height: 24
+                    running: (itemData && itemData.isFetching) ? true : false
+                    visible: (itemData && itemData.isFetching) ? true : false
+                }
+                
+                // 占位符/错误状态
+                Text {
+                    anchors.centerIn: parent
+                    text: (itemData && !itemData.isValid) ? "✕" : (itemData && !itemData.isFetching && !itemData.hasThumbnail) ? "?" : ""
+                    font.pixelSize: AppStyle.fontSizes.xxl
+                    color: (itemData && !itemData.isValid) ? AppStyle.colors.danger : AppStyle.colors.textSecondary
+                    visible: !(itemData && itemData.hasThumbnail && !itemData.isFetching) && !(itemData && itemData.isFetching)
+                }
             }
-
-            // 加载状态
-            BusyIndicator {
-                anchors.centerIn: parent
-                width: 24
-                height: 24
-                running: (itemData && itemData.isFetching) ? true : false
-                visible: (itemData && itemData.isFetching) ? true : false
+            
+            // 悬停时显示的放大预览图 - 显示三张图片在一排
+            Popup {
+                id: previewPopup
+                parent: defaultThumbnail
+                width: 640 // 三张图片 200x3 + 间距
+                height: 220
+                padding: 0
+                visible: previewMouseArea.containsMouse && itemData && itemData.hasThumbnail
+                closePolicy: Popup.NoAutoClose
+                modal: false
+                focus: false
+                dim: false
+                
+                // 智能位置计算：检测是否超出窗口边界
+                onVisibleChanged: {
+                    if (visible) {
+                        // 获取缩略图在屏幕上的位置
+                        var thumbGlobalPos = defaultThumbnail.mapToGlobal(Qt.point(0, 0));
+                        
+                        // 获取窗口在屏幕上的位置
+                        var window = item.Window.window;
+                        var windowGlobalX = window ? window.x : 0;
+                        var windowWidth = window ? window.width : item.width;
+                        
+                        // 计算缩略图相对于窗口的位置
+                        var thumbRelativeX = thumbGlobalPos.x - windowGlobalX;
+                        
+                        // 预览图宽度（640）+ 间距（60）= 700
+                        var popupWidth = width + 60;
+                        
+                        // 如果右侧空间不足，显示在左侧
+                        if (thumbRelativeX + popupWidth > windowWidth) {
+                            x = -690; // 显示在缩略图左侧
+                        } else {
+                            x = 60; // 显示在缩略图右侧
+                        }
+                        
+                        // 垂直居中显示
+                        y = (defaultThumbnail.height - height) / 2;
+                    }
+                }
+                
+                enter: Transition {
+                    NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 150 }
+                }
+                
+                exit: Transition {
+                    NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 150 }
+                }
+                
+                background: Rectangle {
+                    color: "white"
+                    border.color: AppStyle.colors.primary
+                    border.width: 2
+                    radius: AppStyle.radius.md
+                    
+                    // 阴影效果
+                    layer.enabled: true
+                    layer.effect: MultiEffect {
+                        shadowEnabled: true
+                        shadowBlur: 1.0
+                        shadowColor: "#33000000"
+                        shadowVerticalOffset: 2
+                        shadowHorizontalOffset: 2
+                    }
+                }
+                
+                contentItem: Row {
+                    anchors.fill: parent
+                    anchors.margins: 10
+                    spacing: 10
+                    
+                    Repeater {
+                        model: itemData ? itemData.previewImageCount : 0
+                        
+                        Rectangle {
+                            width: 200
+                            height: 200
+                            color: "white"
+                            radius: AppStyle.radius.sm
+                            border.color: AppStyle.colors.border
+                            border.width: 1
+                            clip: true
+                            
+                            Image {
+                                anchors.centerIn: parent
+                                width: 198
+                                height: 198
+                                source: {
+                                    if (!itemData || !itemData.previewImages || itemData.previewImages.length === 0)
+                                        return "";
+                                    return "data:image/png;base64," + itemData.previewImages[index];
+                                }
+                                fillMode: Image.PreserveAspectFit
+                                cache: true
+                                asynchronous: true
+                            }
+                            
+                            // 图片序号标记
+                            Rectangle {
+                                anchors.top: parent.top
+                                anchors.right: parent.right
+                                width: 24
+                                height: 24
+                                color: AppStyle.colors.primary
+                                radius: 12
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: index + 1
+                                    font.pixelSize: 12
+                                    font.bold: true
+                                    color: "white"
+                                }
+                            }
+                            
+                            // 底部文字遮罩
+                            Rectangle {
+                                anchors.bottom: parent.bottom
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                width: parent.width
+                                height: 30
+                                color: "#CC000000"
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: itemData ? itemData.componentId : ""
+                                    color: "white"
+                                    font.bold: true
+                                    font.pixelSize: 10
+                                }
+                            }
+                        }
+                    }
+                }
             }
-
-            // 占位符/错误状态
-            Text {
-                anchors.centerIn: parent
-                text: (itemData && !itemData.isValid) ? "✕" : (itemData && !itemData.isFetching && !itemData.hasThumbnail) ? "?" : ""
-                font.pixelSize: AppStyle.fontSizes.xxl
-                color: (itemData && !itemData.isValid) ? AppStyle.colors.danger : AppStyle.colors.textSecondary
-                visible: !thumbnail.visible && !(itemData && itemData.isFetching)
-            }
-
-            // 2. 缩略图交互区域
+            
+            // 预览区域交互
             MouseArea {
-                id: thumbMouseArea
-                anchors.fill: parent
+                id: previewMouseArea
+                width: defaultThumbnail.width
+                height: defaultThumbnail.height
                 hoverEnabled: true
                 cursorShape: (itemData && itemData.hasThumbnail) ? Qt.PointingHandCursor : Qt.ArrowCursor
-                // 这里的 hover 事件现在可以正常触发了，因为 itemMouseArea 在底层
             }
         }
 
@@ -205,147 +349,5 @@ Rectangle {
         }
     }
 
-    // 3. 悬浮预览层 (支持多图轮播)
-    Popup {
-        id: previewOverlay
-        // 绑定可见性：鼠标悬停 && 有数据 && 有缩略图
-        visible: thumbMouseArea.containsMouse && itemData && itemData.hasThumbnail
-        // 相对坐标：显示在缩略图右侧
-        x: 65
-        y: (parent.height - height) / 2
-        width: 200
-        height: 200
-        padding: 0
-        // 关键配置：确保它是被动的，完全由 visible 控制
-        closePolicy: Popup.NoAutoClose
-        modal: false
-        focus: false
-        dim: false // 不变暗背景
-        background: Rectangle {
-            color: "white"
-            border.color: AppStyle.colors.primary
-            border.width: 2
-            radius: AppStyle.radius.md
-            // 阴影效果
-            layer.enabled: true
-            layer.effect: MultiEffect {
-                shadowEnabled: true
-                shadowBlur: 1.0
-                shadowColor: "#33000000"
-                shadowVerticalOffset: 2
-                shadowHorizontalOffset: 2
-            }
-        }
-
-        contentItem: Item {
-            // 当前显示的图片
-            Image {
-                id: currentPreviewImage
-                anchors.fill: parent
-                anchors.margins: 4
-                source: {
-                    if (!itemData || !itemData.previewImages || itemData.previewImages.length === 0)
-                        return "";
-                    return "data:image/png;base64," + itemData.previewImages[itemData.currentPreviewIndex];
-                }
-                fillMode: Image.PreserveAspectFit
-                cache: true
-                asynchronous: true
-            }
-
-            // 左右切换按钮 (当有多张图片时显示)
-            Rectangle {
-                id: prevButton
-                anchors.left: parent.left
-                anchors.verticalCenter: parent.verticalCenter
-                width: 30
-                height: 60
-                radius: AppStyle.radius.md
-                color: "#80000000"
-                visible: itemData && itemData.previewImageCount > 1
-                opacity: prevMouseArea.containsMouse ? 1.0 : 0.6
-                Behavior on opacity {
-                    ColorAnimation { duration: 150 }
-                }
-                Text {
-                    anchors.centerIn: parent
-                    text: "◀"
-                    color: "white"
-                    font.pixelSize: 20
-                }
-                MouseArea {
-                    id: prevMouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    onClicked: {
-                        if (itemData) itemData.previousPreviewImage();
-                    }
-                }
-            }
-
-            Rectangle {
-                id: nextButton
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                width: 30
-                height: 60
-                radius: AppStyle.radius.md
-                color: "#80000000"
-                visible: itemData && itemData.previewImageCount > 1
-                opacity: nextMouseArea.containsMouse ? 1.0 : 0.6
-                Behavior on opacity {
-                    ColorAnimation { duration: 150 }
-                }
-                Text {
-                    anchors.centerIn: parent
-                    text: "▶"
-                    color: "white"
-                    font.pixelSize: 20
-                }
-                MouseArea {
-                    id: nextMouseArea
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    onClicked: {
-                        if (itemData) itemData.nextPreviewImage();
-                    }
-                }
-            }
-
-            // 图片指示器
-            Row {
-                anchors.bottom: parent.bottom
-                anchors.horizontalCenter: parent.horizontalCenter
-                spacing: 6
-                bottomPadding: 8
-                visible: itemData && itemData.previewImageCount > 1
-                Repeater {
-                    model: itemData ? itemData.previewImageCount : 0
-                    Rectangle {
-                        width: 8
-                        height: 8
-                        radius: 4
-                        color: index === (itemData ? itemData.currentPreviewIndex : 0) ? AppStyle.colors.primary : "#60000000"
-                    }
-                }
-            }
-
-            // 底部文字遮罩
-            Rectangle {
-                anchors.bottom: parent.bottom
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width
-                height: 30
-                color: "#CC000000"
-                radius: AppStyle.radius.md
-                visible: itemData && itemData.previewImageCount <= 1
-                Text {
-                    anchors.centerIn: parent
-                    text: itemData ? itemData.componentId : ""
-                    color: "white"
-                    font.bold: true
-                }
-            }
-        }
-    }
+    
 }

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -201,11 +201,35 @@ Rectangle {
                             border.width: 1
                             clip: true
                             
+                            property bool imageLoaded: false
+                            property bool loadTriggered: false
+                            
+                            // 延迟加载触发器
+                            Timer {
+                                id: loadDelayTimer
+                                interval: index * 100 // 每张图片延迟100ms加载
+                                onTriggered: {
+                                    parent.loadTriggered = true;
+                                }
+                            }
+                            
+                            // 当 Popup 可见时开始延迟加载
+                            Connections {
+                                target: previewPopup
+                                function onVisibleChanged() {
+                                    if (previewPopup.visible && !loadTriggered) {
+                                        loadDelayTimer.start();
+                                    }
+                                }
+                            }
+                            
                             Image {
                                 anchors.centerIn: parent
                                 width: 198
                                 height: 198
                                 source: {
+                                    if (!parent.loadTriggered)
+                                        return "";
                                     if (!itemData || !itemData.previewImages || itemData.previewImages.length === 0)
                                         return "";
                                     return "data:image/png;base64," + itemData.previewImages[index];
@@ -213,6 +237,40 @@ Rectangle {
                                 fillMode: Image.PreserveAspectFit
                                 cache: true
                                 asynchronous: true
+                                visible: parent.loadTriggered && parent.imageLoaded
+                                
+                                onStatusChanged: {
+                                    if (status === Image.Ready) {
+                                        parent.imageLoaded = true;
+                                    }
+                                }
+                            }
+                            
+                            // 加载状态指示器
+                            BusyIndicator {
+                                anchors.centerIn: parent
+                                width: 32
+                                height: 32
+                                running: parent.loadTriggered && !parent.imageLoaded
+                                visible: parent.loadTriggered && !parent.imageLoaded
+                            }
+                            
+                            // 初始占位符
+                            Rectangle {
+                                anchors.centerIn: parent
+                                width: 40
+                                height: 40
+                                color: AppStyle.colors.background
+                                radius: AppStyle.radius.md
+                                visible: !parent.loadTriggered
+                                
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: index + 1
+                                    font.pixelSize: 18
+                                    font.bold: true
+                                    color: AppStyle.colors.textSecondary
+                                }
                             }
                             
                             // 图片序号标记

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -205,7 +205,7 @@ Rectangle {
         }
     }
 
-    // 3. 悬浮预览层 (改回 Popup 以确保显示在最顶层且不被裁剪)
+    // 3. 悬浮预览层 (支持多图轮播)
     Popup {
         id: previewOverlay
         // 绑定可见性：鼠标悬停 && 有数据 && 有缩略图
@@ -238,13 +238,96 @@ Rectangle {
         }
 
         contentItem: Item {
+            // 当前显示的图片
             Image {
+                id: currentPreviewImage
                 anchors.fill: parent
                 anchors.margins: 4
-                source: (itemData && itemData.thumbnailBase64) ? "data:image/png;base64," + itemData.thumbnailBase64 : ""
+                source: {
+                    if (!itemData || !itemData.previewImages || itemData.previewImages.length === 0)
+                        return "";
+                    return "data:image/png;base64," + itemData.previewImages[itemData.currentPreviewIndex];
+                }
                 fillMode: Image.PreserveAspectFit
                 cache: true
                 asynchronous: true
+            }
+
+            // 左右切换按钮 (当有多张图片时显示)
+            Rectangle {
+                id: prevButton
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                width: 30
+                height: 60
+                radius: AppStyle.radius.md
+                color: "#80000000"
+                visible: itemData && itemData.previewImageCount > 1
+                opacity: prevMouseArea.containsMouse ? 1.0 : 0.6
+                Behavior on opacity {
+                    ColorAnimation { duration: 150 }
+                }
+                Text {
+                    anchors.centerIn: parent
+                    text: "◀"
+                    color: "white"
+                    font.pixelSize: 20
+                }
+                MouseArea {
+                    id: prevMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        if (itemData) itemData.previousPreviewImage();
+                    }
+                }
+            }
+
+            Rectangle {
+                id: nextButton
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                width: 30
+                height: 60
+                radius: AppStyle.radius.md
+                color: "#80000000"
+                visible: itemData && itemData.previewImageCount > 1
+                opacity: nextMouseArea.containsMouse ? 1.0 : 0.6
+                Behavior on opacity {
+                    ColorAnimation { duration: 150 }
+                }
+                Text {
+                    anchors.centerIn: parent
+                    text: "▶"
+                    color: "white"
+                    font.pixelSize: 20
+                }
+                MouseArea {
+                    id: nextMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        if (itemData) itemData.nextPreviewImage();
+                    }
+                }
+            }
+
+            // 图片指示器
+            Row {
+                anchors.bottom: parent.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
+                spacing: 6
+                bottomPadding: 8
+                visible: itemData && itemData.previewImageCount > 1
+                Repeater {
+                    model: itemData ? itemData.previewImageCount : 0
+                    Rectangle {
+                        width: 8
+                        height: 8
+                        radius: 4
+                        color: index === (itemData ? itemData.currentPreviewIndex : 0) ? AppStyle.colors.primary : "#60000000"
+                    }
+                }
             }
 
             // 底部文字遮罩
@@ -255,6 +338,7 @@ Rectangle {
                 height: 30
                 color: "#CC000000"
                 radius: AppStyle.radius.md
+                visible: itemData && itemData.previewImageCount <= 1
                 Text {
                     anchors.centerIn: parent
                     text: itemData ? itemData.componentId : ""

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -68,14 +68,14 @@ Rectangle {
         anchors.margins: AppStyle.spacing.sm
         spacing: AppStyle.spacing.md
         z: 10 // 确保内容在背景 MouseArea 之上
-        
+
         // 预览图区域 - 支持悬停放大
         Item {
             id: previewArea
             Layout.preferredWidth: 48
             Layout.preferredHeight: 48
             Layout.alignment: Qt.AlignVCenter
-            
+
             // 默认显示的单张缩略图
             Rectangle {
                 id: defaultThumbnail
@@ -86,7 +86,7 @@ Rectangle {
                 border.color: AppStyle.colors.border
                 border.width: 1
                 clip: true
-                
+
                 Image {
                     anchors.centerIn: parent
                     width: 46
@@ -97,7 +97,7 @@ Rectangle {
                     asynchronous: true
                     visible: itemData && itemData.hasThumbnail && !itemData.isFetching
                 }
-                
+
                 // 加载状态
                 BusyIndicator {
                     anchors.centerIn: parent
@@ -106,7 +106,7 @@ Rectangle {
                     running: (itemData && itemData.isFetching) ? true : false
                     visible: (itemData && itemData.isFetching) ? true : false
                 }
-                
+
                 // 占位符/错误状态
                 Text {
                     anchors.centerIn: parent
@@ -116,7 +116,7 @@ Rectangle {
                     visible: !(itemData && itemData.hasThumbnail && !itemData.isFetching) && !(itemData && itemData.isFetching)
                 }
             }
-            
+
             // 悬停时显示的放大预览图 - 显示三张图片在一排
             Popup {
                 id: previewPopup
@@ -129,50 +129,60 @@ Rectangle {
                 modal: false
                 focus: false
                 dim: false
-                
+
                 // 智能位置计算：检测是否超出窗口边界
                 onVisibleChanged: {
                     if (visible) {
                         // 获取缩略图在屏幕上的位置
                         var thumbGlobalPos = defaultThumbnail.mapToGlobal(Qt.point(0, 0));
-                        
+
                         // 获取窗口在屏幕上的位置
                         var window = item.Window.window;
                         var windowGlobalX = window ? window.x : 0;
                         var windowWidth = window ? window.width : item.width;
-                        
+
                         // 计算缩略图相对于窗口的位置
                         var thumbRelativeX = thumbGlobalPos.x - windowGlobalX;
-                        
+
                         // 预览图宽度（640）+ 间距（60）= 700
                         var popupWidth = width + 60;
-                        
+
                         // 如果右侧空间不足，显示在左侧
                         if (thumbRelativeX + popupWidth > windowWidth) {
                             x = -690; // 显示在缩略图左侧
                         } else {
                             x = 60; // 显示在缩略图右侧
                         }
-                        
+
                         // 垂直居中显示
                         y = (defaultThumbnail.height - height) / 2;
                     }
                 }
-                
+
                 enter: Transition {
-                    NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 150 }
+                    NumberAnimation {
+                        property: "opacity"
+                        from: 0
+                        to: 1
+                        duration: 150
+                    }
                 }
-                
+
                 exit: Transition {
-                    NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 150 }
+                    NumberAnimation {
+                        property: "opacity"
+                        from: 1
+                        to: 0
+                        duration: 150
+                    }
                 }
-                
+
                 background: Rectangle {
                     color: "white"
                     border.color: AppStyle.colors.primary
                     border.width: 2
                     radius: AppStyle.radius.md
-                    
+
                     // 阴影效果
                     layer.enabled: true
                     layer.effect: MultiEffect {
@@ -183,15 +193,15 @@ Rectangle {
                         shadowHorizontalOffset: 2
                     }
                 }
-                
+
                 contentItem: Row {
                     anchors.fill: parent
                     anchors.margins: 10
                     spacing: 10
-                    
+
                     Repeater {
                         model: itemData ? itemData.previewImageCount : 0
-                        
+
                         Rectangle {
                             width: 200
                             height: 200
@@ -200,10 +210,10 @@ Rectangle {
                             border.color: AppStyle.colors.border
                             border.width: 1
                             clip: true
-                            
+
                             property bool imageLoaded: false
                             property bool loadTriggered: false
-                            
+
                             // 延迟加载触发器
                             Timer {
                                 id: loadDelayTimer
@@ -212,7 +222,7 @@ Rectangle {
                                     parent.loadTriggered = true;
                                 }
                             }
-                            
+
                             // 当 Popup 可见时开始延迟加载
                             Connections {
                                 target: previewPopup
@@ -222,7 +232,7 @@ Rectangle {
                                     }
                                 }
                             }
-                            
+
                             Image {
                                 anchors.centerIn: parent
                                 width: 198
@@ -238,14 +248,14 @@ Rectangle {
                                 cache: true
                                 asynchronous: true
                                 visible: parent.loadTriggered && parent.imageLoaded
-                                
+
                                 onStatusChanged: {
                                     if (status === Image.Ready) {
                                         parent.imageLoaded = true;
                                     }
                                 }
                             }
-                            
+
                             // 加载状态指示器
                             BusyIndicator {
                                 anchors.centerIn: parent
@@ -254,7 +264,7 @@ Rectangle {
                                 running: parent.loadTriggered && !parent.imageLoaded
                                 visible: parent.loadTriggered && !parent.imageLoaded
                             }
-                            
+
                             // 初始占位符
                             Rectangle {
                                 anchors.centerIn: parent
@@ -263,7 +273,7 @@ Rectangle {
                                 color: AppStyle.colors.background
                                 radius: AppStyle.radius.md
                                 visible: !parent.loadTriggered
-                                
+
                                 Text {
                                     anchors.centerIn: parent
                                     text: index + 1
@@ -272,7 +282,7 @@ Rectangle {
                                     color: AppStyle.colors.textSecondary
                                 }
                             }
-                            
+
                             // 图片序号标记
                             Rectangle {
                                 anchors.top: parent.top
@@ -289,7 +299,7 @@ Rectangle {
                                     color: "white"
                                 }
                             }
-                            
+
                             // 底部文字遮罩
                             Rectangle {
                                 anchors.bottom: parent.bottom
@@ -309,7 +319,7 @@ Rectangle {
                     }
                 }
             }
-            
+
             // 预览区域交互
             MouseArea {
                 id: previewMouseArea
@@ -406,6 +416,4 @@ Rectangle {
             }
         }
     }
-
-    
 }

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -25,7 +25,7 @@ ComponentListViewModel::ComponentListViewModel(ComponentService* service, QObjec
         m_service, &ComponentService::previewImageReady, this, [this](const QString& componentId, const QImage& image) {
             auto item = findItemData(componentId);
             if (item) {
-                item->setThumbnail(image);
+                item->addPreviewImage(image);
             }
         });
     connect(m_service, &ComponentService::fetchError, this, &ComponentListViewModel::handleFetchError);


### PR DESCRIPTION
## 描述

本 PR 实现了 LCSC 元器件的多预览图功能，支持每个组件显示最多 3 张预览图。用户在组件列表中默认查看单张缩略图，悬停时可以展开查看所有预览图，提升了元器件信息可视化效果。

### 主要功能

1. **多预览图支持**
   - 扩展 LcscImageService 支持最多 3 张预览图
   - 每张图片支持独立加载和缓存

2. **智能预览交互**
   - 默认显示单张 48x48 缩略图
   - 鼠标悬停时展开显示 3 张 200x200 预览图
   - 光标移开自动关闭预览
   - 每张预览图显示编号标识（1/2/3）

3. **智能位置检测**
   - 自动检测窗口边界
   - 根据可用空间智能选择显示位置（左侧或右侧）
   - 支持最大化模式和窗口化模式
   - 避免预览图超出窗口范围
