### PR TITLE
feat(ui): 启动时自动聚焦到元器件ID输入框

### DIFF
--- a/src/ui/qml/components/ComponentInputCard.qml
+++ b/src/ui/qml/components/ComponentInputCard.qml
@@ -22,7 +22,7 @@ Card {
 
             // 组件加载完成后自动设置焦点
             Component.onCompleted: {
-                Qt.callLater(function() {
+                Qt.callLater(function () {
                     forceActiveFocus();
                 });
             }

--- a/src/ui/qml/components/ComponentInputCard.qml
+++ b/src/ui/qml/components/ComponentInputCard.qml
@@ -13,11 +13,19 @@ Card {
         spacing: 12
         TextField {
             id: componentInput
+            objectName: "componentInputField"
             Layout.fillWidth: true
             placeholderText: qsTranslate("MainWindow", "输入LCSC元件编号 (例如: C2040)")
             font.pixelSize: AppStyle.fontSizes.md
             color: AppStyle.colors.textPrimary
             placeholderTextColor: AppStyle.colors.textSecondary
+
+            // 组件加载完成后自动设置焦点
+            Component.onCompleted: {
+                Qt.callLater(function() {
+                    forceActiveFocus();
+                });
+            }
             background: Rectangle {
                 color: componentInput.enabled ? AppStyle.colors.surface : AppStyle.colors.background
                 border.color: componentInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border


### PR DESCRIPTION
## 概述

本 PR 实现了应用程序启动时自动聚焦到元器件ID输入框的功能，用户打开软件后可以直接开始输入元器件ID，无需先点击输入框，从而提升用户体验和工作效率。

## 问题背景

**当前问题：**
- 用户启动软件后需要手动点击输入框才能开始输入
- 增加了不必要的操作步骤
- 影响用户的工作流畅度
- 对于频繁使用软件的用户来说，每次都需要额外的点击操作

## 解决方案

### 实现方式
在 `ComponentInputCard.qml` 的 `TextField` 组件中添加 `Component.onCompleted` 处理器，使用 `Qt.callLater()` 延迟调用 `forceActiveFocus()` 方法。

### 技术细节

1. **添加对象名称**：
   - 为输入框设置 `objectName: "componentInputField"`
   - 便于后续可能需要引用该组件

2. **自动聚焦逻辑**：
   ```qml
   Component.onCompleted: {
       Qt.callLater(function () {
           forceActiveFocus();
       });
   }
   ```

3. **使用 Qt.callLater 的原因**：
   - 确保所有组件都已完全加载和初始化
   - 避免在组件还未准备好时就设置焦点
   - 保证焦点设置的可靠性