### PR TITLE
feat(dialog): 优化退出对话框键盘导航和焦点管理

### DIFF
--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -408,6 +408,21 @@ ApplicationWindow {
         }
     }
 
+    // 键盘事件处理
+    Keys.onPressed: event => {
+        if (event.key === Qt.Key_Escape) {
+            // ESC 键：调出关闭对话框
+            event.accepted = true;
+            if (!closeConfirmDialog.visible && !exitOptionDialog.visible) {
+                if (exportProgressViewModel.isExporting) {
+                    closeConfirmDialog.open();
+                } else {
+                    exitOptionDialog.open();
+                }
+            }
+        }
+    }
+
     // 在启动时设置窗口位置
     Component.onCompleted: {
         // 窗口位置由 QML 属性直接控制

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -8,6 +8,11 @@ ApplicationWindow {
     // 默认窗口大小为屏幕的 65%（如果配置中没有保存的值）
     property int defaultWidth: Math.max(800, Screen.desktopAvailableWidth * 0.65)
     property int defaultHeight: Math.max(600, Screen.desktopAvailableHeight * 0.65)
+    property int windowRadius: 10
+
+    // 状态锁：防止重复触发关闭/最小化动画
+    property bool isClosing: false
+    property bool isMinimizing: false
 
     width: configService ? (configService.getWindowWidth() > 0 ? configService.getWindowWidth() : defaultWidth) : defaultWidth
     height: configService ? (configService.getWindowHeight() > 0 ? configService.getWindowHeight() : defaultHeight) : defaultHeight
@@ -19,7 +24,17 @@ ApplicationWindow {
     visible: true
     title: "EasyKiConverter - 元器件转换工具"
     color: "transparent"
-    flags: Qt.Window | Qt.FramelessWindowHint | Qt.WindowMinimizeButtonHint | Qt.WindowMaximizeButtonHint | Qt.WindowCloseButtonHint | Qt.CustomizeWindowHint
+    // 使用自定义标题栏，移除无效的系统按钮标志
+    flags: Qt.Window | Qt.FramelessWindowHint | Qt.CustomizeWindowHint
+
+    // 监听窗口可见性变化
+    onVisibleChanged: {
+        if (visible) {
+            // 窗口显示时，重置状态锁
+            isClosing = false;
+            isMinimizing = false;
+        }
+    }
 
     // 保存窗口大小和位置的函数
     function saveWindowPosition() {
@@ -31,8 +46,8 @@ ApplicationWindow {
 
             configService.setWindowWidth(width);
             configService.setWindowHeight(height);
-            // 只在窗口不是最大化或全屏时保存位置
-            if (visibility !== Window.Maximized && visibility !== Window.FullScreen) {
+            // 只在窗口不是最大化、全屏或最小化时保存位置
+            if (visibility !== Window.Maximized && visibility !== Window.FullScreen && visibility !== Window.Minimized) {
                 configService.setWindowX(x);
                 configService.setWindowY(y);
                 console.log("已保存窗口位置: (" + x + ", " + y + ") 大小: (" + width + ", " + height + ")");
@@ -63,6 +78,260 @@ ApplicationWindow {
         }
     }
 
+    // 退出动画层 - 向下滑动缩小（与最小化效果一致）
+
+    Rectangle {
+        id: exitAnimationLayer
+
+        width: appWindow.width
+
+        height: appWindow.height
+
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        y: 0
+
+        opacity: 0
+
+        z: 1000
+
+        visible: opacity > 0
+
+        color: themeSettingsViewModel && themeSettingsViewModel.isDarkMode ? "#1a1a1a" : "#f5f5f5"
+
+        radius: appWindow.windowRadius
+
+        // 添加尺寸绑定，确保窗口大小改变时动画层同步更新
+        Binding on width {
+            when: exitAnimationLayer.opacity > 0
+            value: appWindow.width
+            restoreMode: Binding.RestoreBinding
+        }
+
+        Binding on height {
+            when: exitAnimationLayer.opacity > 0
+            value: appWindow.height
+            restoreMode: Binding.RestoreBinding
+        }
+
+        transform: Scale {
+            id: exitScale
+
+            origin.x: (exitAnimationLayer.width || 800) / 2
+
+            origin.y: exitAnimationLayer.height || 600
+
+            xScale: 1.0
+
+            yScale: 1.0
+        }
+
+        // 显式动画
+
+        ParallelAnimation {
+            id: exitWindowAnim
+
+            running: false
+
+            NumberAnimation {
+
+                target: exitAnimationLayer
+
+                property: "y"
+
+                to: appWindow.height
+
+                duration: 400
+
+                easing.type: Easing.InOutQuad
+            }
+
+            NumberAnimation {
+
+                target: exitScale
+
+                property: "xScale"
+
+                to: 0.1
+
+                duration: 400
+
+                easing.type: Easing.InOutQuad
+            }
+
+            NumberAnimation {
+
+                target: exitScale
+
+                property: "yScale"
+
+                to: 0.1
+
+                duration: 400
+
+                easing.type: Easing.InOutQuad
+            }
+        }
+
+        // 退出动画计时器
+
+        Timer {
+            id: exitAnimTimer
+
+            interval: 450
+
+            onTriggered: {
+
+                // 清理动画层
+
+                exitAnimationLayer.opacity = 0;
+
+                exitAnimationLayer.y = 0;
+
+                exitScale.xScale = 1.0;
+
+                exitScale.yScale = 1.0;
+
+                // 执行退出
+
+                saveWindowPosition();
+
+                exportProgressViewModel.handleCloseRequest();
+
+                // 重置状态锁
+                isClosing = false;
+
+                Qt.quit();
+            }
+        }
+    }
+
+    // 最小化动画层 - 向下滑动缩小
+
+    Rectangle {
+        id: minimizeAnimationLayer
+
+        width: appWindow.width
+
+        height: appWindow.height
+
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        y: 0
+
+        opacity: 0
+
+        z: 1000
+
+        visible: opacity > 0
+
+        color: themeSettingsViewModel && themeSettingsViewModel.isDarkMode ? "#1a1a1a" : "#f5f5f5"
+
+        radius: appWindow.windowRadius
+
+        // 添加尺寸绑定，确保窗口大小改变时动画层同步更新
+        Binding on width {
+            when: minimizeAnimationLayer.opacity > 0
+            value: appWindow.width
+            restoreMode: Binding.RestoreBinding
+        }
+
+        Binding on height {
+            when: minimizeAnimationLayer.opacity > 0
+            value: appWindow.height
+            restoreMode: Binding.RestoreBinding
+        }
+
+        transform: Scale {
+            id: minimizeScale
+
+            origin.x: (minimizeAnimationLayer.width || 800) / 2
+
+            origin.y: minimizeAnimationLayer.height || 600
+
+            xScale: 1.0
+
+            yScale: 1.0
+        }
+
+        // 显式动画
+
+        ParallelAnimation {
+            id: minimizeWindowAnim
+
+            running: false
+
+            NumberAnimation {
+
+                target: minimizeAnimationLayer
+
+                property: "y"
+
+                to: appWindow.height
+
+                duration: 400
+
+                easing.type: Easing.InOutQuad
+            }
+
+            NumberAnimation {
+
+                target: minimizeScale
+
+                property: "xScale"
+
+                to: 0.1
+
+                duration: 400
+
+                easing.type: Easing.InOutQuad
+            }
+
+            NumberAnimation {
+
+                target: minimizeScale
+
+                property: "yScale"
+
+                to: 0.1
+
+                duration: 400
+
+                easing.type: Easing.InOutQuad
+            }
+        }
+
+        // 最小化动画计时器
+
+        Timer {
+            id: minimizeAnimTimer
+
+            interval: 450
+
+            onTriggered: {
+
+                // 清理动画层
+
+                minimizeAnimationLayer.opacity = 0;
+
+                minimizeAnimationLayer.y = 0;
+
+                minimizeScale.xScale = 1.0;
+
+                minimizeScale.yScale = 1.0;
+
+                // 执行最小化
+
+                saveWindowPosition();
+
+                appWindow.showMinimized();
+
+                // 重置状态锁
+                isMinimizing = false;
+            }
+        }
+    }
+
     // 退出选项对话框
     ExitDialog {
         id: exitOptionDialog
@@ -71,21 +340,46 @@ ApplicationWindow {
             if (remember && configService) {
                 configService.setExitPreference("minimize");
             }
-            saveWindowPosition();
-            showMinimized();
+
+            // 立即隐藏对话框，直接最小化
+            exitOptionDialog.visible = false;
+            playMinimizeAnimation();
         }
         onExitApp: function (remember) {
             // 如果选择了记住，保存退出偏好
             if (remember && configService) {
                 configService.setExitPreference("exit");
             }
-            saveWindowPosition();
-            exportProgressViewModel.handleCloseRequest();
-            Qt.quit();
+
+            // 立即隐藏对话框，直接退出
+            exitOptionDialog.visible = false;
+            playExitAnimation();
+        }
+        onCanceled: {
+            // 用户点击取消
         }
     }
 
+    // 播放退出动画 - 直接退出
+    function playExitAnimation() {
+        saveWindowPosition();
+        exportProgressViewModel.handleCloseRequest();
+        Qt.quit();
+    }
+
+    // 播放最小化动画 - 直接最小化
+    function playMinimizeAnimation() {
+        saveWindowPosition();
+        appWindow.showMinimized();
+    }
+
     onClosing: close => {
+        // 如果对话框正在显示，阻止关闭
+        if (closeConfirmDialog.visible || exitOptionDialog.visible) {
+            close.accepted = false;
+            return;
+        }
+
         if (exportProgressViewModel.isExporting) {
             close.accepted = false;
             closeConfirmDialog.open();
@@ -94,15 +388,13 @@ ApplicationWindow {
             if (configService) {
                 var exitPreference = configService.getExitPreference();
                 if (exitPreference === "minimize") {
-                    // 直接最小化到托盘
+                    // 直接最小化
                     close.accepted = false;
-                    saveWindowPosition();
-                    showMinimized();
+                    playMinimizeAnimation();
                 } else if (exitPreference === "exit") {
-                    // 直接退出前保存窗口位置
-                    saveWindowPosition();
-                    close.accepted = true;
-                    exportProgressViewModel.handleCloseRequest();
+                    // 直接退出
+                    close.accepted = false;
+                    playExitAnimation();
                 } else {
                     // 没有记住的偏好，显示退出选项对话框
                     close.accepted = false;
@@ -122,8 +414,15 @@ ApplicationWindow {
     }
 
     // 加载主窗口内容
-    Loader {
+    Item {
+        id: windowContent
         anchors.fill: parent
-        source: "qrc:/qt/qml/EasyKiconverter_Cpp_Version/src/ui/qml/MainWindow.qml"
+
+        // 加载主窗口内容
+        Loader {
+            id: mainWindowLoader
+            anchors.fill: parent
+            source: "qrc:/qt/qml/EasyKiconverter_Cpp_Version/src/ui/qml/MainWindow.qml"
+        }
     }
 }

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -5,6 +5,7 @@ import "styles"
 
 ApplicationWindow {
     id: appWindow
+    focus: true  // 确保窗口能够接收键盘事件
     // 默认窗口大小为屏幕的 65%（如果配置中没有保存的值）
     property int defaultWidth: Math.max(800, Screen.desktopAvailableWidth * 0.65)
     property int defaultHeight: Math.max(600, Screen.desktopAvailableHeight * 0.65)

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -412,8 +412,15 @@ ApplicationWindow {
     Shortcut {
         sequence: "Esc"
         onActivated: {
-            // ESC 键：调出关闭对话框
-            if (!closeConfirmDialog.visible && !exitOptionDialog.visible) {
+            // ESC 键：打开或关闭对话框
+            if (closeConfirmDialog.visible) {
+                // 如果 ConfirmDialog 可见，关闭它
+                closeConfirmDialog.close();
+            } else if (exitOptionDialog.visible) {
+                // 如果 ExitDialog 可见，关闭它
+                exitOptionDialog.close();
+            } else {
+                // 如果没有对话框可见，打开相应的对话框
                 if (exportProgressViewModel.isExporting) {
                     closeConfirmDialog.open();
                 } else {

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -5,7 +5,6 @@ import "styles"
 
 ApplicationWindow {
     id: appWindow
-    focus: true  // 确保窗口能够接收键盘事件
     // 默认窗口大小为屏幕的 65%（如果配置中没有保存的值）
     property int defaultWidth: Math.max(800, Screen.desktopAvailableWidth * 0.65)
     property int defaultHeight: Math.max(600, Screen.desktopAvailableHeight * 0.65)
@@ -409,11 +408,11 @@ ApplicationWindow {
         }
     }
 
-    // 键盘事件处理
-    Keys.onPressed: event => {
-        if (event.key === Qt.Key_Escape) {
+    // ESC 键快捷键处理
+    Shortcut {
+        sequence: "Esc"
+        onActivated: {
             // ESC 键：调出关闭对话框
-            event.accepted = true;
             if (!closeConfirmDialog.visible && !exitOptionDialog.visible) {
                 if (exportProgressViewModel.isExporting) {
                     closeConfirmDialog.open();

--- a/src/ui/qml/components/ConfirmDialog.qml
+++ b/src/ui/qml/components/ConfirmDialog.qml
@@ -5,9 +5,19 @@ import QtQuick.Effects
 import "../styles"
 
 /**
- * @brief 自定义美化的确认对话框
+ * @brief 转换进行中强制退出确认对话框
  *
- * 包含圆角、主题适配、模糊背景遮罩及平滑动画。
+ * **用途**：当用户尝试关闭窗口且转换任务正在进行时显示
+ * **场景**：用户点击关闭按钮 → 检测到 exportProgressViewModel.isExporting 为 true → 显示此对话框
+ * **提示信息**："转换正在进行中。退出将取消当前转换，已导出的文件会保留。确定要退出吗？"
+ * **按钮**：
+ *   - 确定（强制退出）：停止转换任务，关闭程序
+ *   - 取消（继续转换）：关闭对话框，继续执行转换任务
+ * **动画**：取消按钮点击后向下滑动消失（fade out + slide down + scale down）
+ *
+ * **注意**：不要与 ExitDialog 混淆
+ * - ExitDialog：无任务时显示，提供"最小化到托盘"/"退出程序"/"取消"选项
+ * - ConfirmDialog：有任务时显示，提供"强制退出"/"继续转换"选项
  */
 Item {
     id: root
@@ -19,7 +29,7 @@ Item {
     // 监听 Escape 键
     Keys.onEscapePressed: {
         root.rejected();
-        root.close();
+        root.closeWithAnimation();
     }
 
     // 暴露属性和信号
@@ -31,15 +41,24 @@ Item {
     property int radius: AppStyle.radius.lg
     signal accepted
     signal rejected
-    // 打开/关闭动画
+    // 打开/关闭
     function open() {
         visible = true;
+        // 重置对话框位置和 transform
+        dialogBox.y = 0;
+        dialogBoxTranslate.y = 0;
         showAnim.start();
         // 自动聚焦到取消按钮，确保键盘操作安全性
         cancelButton.forceActiveFocus();
     }
 
     function close() {
+        // 直接隐藏对话框，不播放动画
+        visible = false;
+    }
+
+    function closeWithAnimation() {
+        // 播放消失动画
         hideAnim.start();
     }
 
@@ -67,6 +86,13 @@ Item {
         radius: AppStyle.radius.xl
         scale: 0.9
         opacity: 0
+        y: 0
+
+        transform: Translate {
+            id: dialogBoxTranslate
+            y: 0
+        }
+
         // 阴影效果
         layer.enabled: true
         layer.effect: MultiEffect {
@@ -117,7 +143,7 @@ Item {
                     hoverColor: AppStyle.isDarkMode ? "#334155" : "#f1f5f9"
                     onClicked: {
                         root.rejected();
-                        root.close();
+                        root.closeWithAnimation();
                     }
                 }
 
@@ -173,6 +199,7 @@ Item {
                 from: 0.6
                 to: 0
                 duration: 200
+                easing.type: Easing.OutQuad
             }
             NumberAnimation {
                 target: dialogBox
@@ -180,6 +207,15 @@ Item {
                 from: 1
                 to: 0
                 duration: 200
+                easing.type: Easing.OutQuad
+            }
+            NumberAnimation {
+                target: dialogBoxTranslate
+                property: "y"
+                from: 0
+                to: root.height
+                duration: 200
+                easing.type: Easing.OutQuad
             }
             NumberAnimation {
                 target: dialogBox
@@ -187,6 +223,7 @@ Item {
                 from: 1
                 to: 0.9
                 duration: 200
+                easing.type: Easing.OutQuad
             }
         }
         PropertyAction {

--- a/src/ui/qml/components/ExitDialog.qml
+++ b/src/ui/qml/components/ExitDialog.qml
@@ -75,6 +75,8 @@ Item {
         dialogBoxTranslate.y = 0;
         // 设置默认选中为退出按钮
         selectedButton = exitButton;
+        // 设置滑块默认聚焦在退出选项上
+        updateSlider(exitButton, AppStyle.colors.danger);
         // 强制焦点到 root 以便键盘导航
         root.forceActiveFocus();
     }
@@ -442,30 +444,39 @@ Item {
             // 向上/左导航
             if (selectedButton === exitButton) {
                 selectedButton = minimizeButton;
+                updateSlider(minimizeButton, AppStyle.colors.primary);
             } else if (selectedButton === cancelButton) {
                 selectedButton = exitButton;
+                updateSlider(exitButton, AppStyle.colors.danger);
             } else if (selectedButton === minimizeButton) {
                 selectedButton = cancelButton;
+                updateSlider(cancelButton, AppStyle.colors.textSecondary);
             }
             event.accepted = true;
         } else if (event.key === Qt.Key_Down || event.key === Qt.Key_Right) {
             // 向下/右导航
             if (selectedButton === minimizeButton) {
                 selectedButton = exitButton;
+                updateSlider(exitButton, AppStyle.colors.danger);
             } else if (selectedButton === exitButton) {
                 selectedButton = cancelButton;
+                updateSlider(cancelButton, AppStyle.colors.textSecondary);
             } else if (selectedButton === cancelButton) {
                 selectedButton = minimizeButton;
+                updateSlider(minimizeButton, AppStyle.colors.primary);
             }
             event.accepted = true;
         } else if (event.key === Qt.Key_Tab) {
             // Tab 键循环导航
             if (selectedButton === minimizeButton) {
                 selectedButton = exitButton;
+                updateSlider(exitButton, AppStyle.colors.danger);
             } else if (selectedButton === exitButton) {
                 selectedButton = cancelButton;
+                updateSlider(cancelButton, AppStyle.colors.textSecondary);
             } else if (selectedButton === cancelButton) {
                 selectedButton = minimizeButton;
+                updateSlider(minimizeButton, AppStyle.colors.primary);
             }
             event.accepted = true;
         } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {

--- a/src/ui/qml/components/ExitDialog.qml
+++ b/src/ui/qml/components/ExitDialog.qml
@@ -262,8 +262,8 @@ Item {
                                 }
                             }
 
-                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大
-                            scale: (root.activeButton === minimizeButton || root.selectedButton === minimizeButton) ? 1.05 : 1.0
+                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大，按下时缩小
+                            scale: pressed ? 0.95 : (root.activeButton === minimizeButton || root.selectedButton === minimizeButton) ? 1.05 : 1.0
                             Behavior on scale {
                                 NumberAnimation {
                                     duration: 150
@@ -274,7 +274,8 @@ Item {
                             onHoveredChanged: {
                                 if (hovered) {
                                     root.updateSlider(this, AppStyle.colors.primary);
-                                } else if (!exitButton.hovered && !cancelButton.hovered) {
+                                } else if (!exitButton.hovered && !cancelButton.hovered && !pressed) {
+                                    // 只在没有按下且没有悬停在其他按钮上时隐藏滑块
                                     root.hideSlider();
                                 }
                             }
@@ -314,8 +315,8 @@ Item {
                                 }
                             }
 
-                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大
-                            scale: (root.activeButton === exitButton || root.selectedButton === exitButton) ? 1.05 : 1.0
+                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大，按下时缩小
+                            scale: pressed ? 0.95 : (root.activeButton === exitButton || root.selectedButton === exitButton) ? 1.05 : 1.0
                             Behavior on scale {
                                 NumberAnimation {
                                     duration: 150
@@ -326,7 +327,8 @@ Item {
                             onHoveredChanged: {
                                 if (hovered) {
                                     root.updateSlider(this, AppStyle.colors.danger);
-                                } else if (!minimizeButton.hovered && !cancelButton.hovered) {
+                                } else if (!minimizeButton.hovered && !cancelButton.hovered && !pressed) {
+                                    // 只在没有按下且没有悬停在其他按钮上时隐藏滑块
                                     root.hideSlider();
                                 }
                             }
@@ -366,8 +368,8 @@ Item {
                                 }
                             }
 
-                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大
-                            scale: (root.activeButton === cancelButton || root.selectedButton === cancelButton) ? 1.05 : 1.0
+                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大，按下时缩小
+                            scale: pressed ? 0.95 : (root.activeButton === cancelButton || root.selectedButton === cancelButton) ? 1.05 : 1.0
                             Behavior on scale {
                                 NumberAnimation {
                                     duration: 150
@@ -378,7 +380,8 @@ Item {
                             onHoveredChanged: {
                                 if (hovered) {
                                     root.updateSlider(this, AppStyle.colors.textSecondary);
-                                } else if (!minimizeButton.hovered && !exitButton.hovered) {
+                                } else if (!minimizeButton.hovered && !exitButton.hovered && !pressed) {
+                                    // 只在没有按下且没有悬停在其他按钮上时隐藏滑块
                                     root.hideSlider();
                                 }
                             }

--- a/src/ui/qml/components/ExitDialog.qml
+++ b/src/ui/qml/components/ExitDialog.qml
@@ -249,7 +249,7 @@ Item {
                             text: qsTr("最小化到托盘")
                             backgroundColor: "transparent"
                             // 动态文本颜色：当滑块在上方时变亮，键盘选中时使用不同颜色
-                            textColor: root.activeButton === minimizeButton ? Qt.lighter(AppStyle.colors.primary, 1.3) : (root.selectedButton === minimizeButton ? AppStyle.colors.primary : AppStyle.colors.text)
+                            textColor: root.activeButton === minimizeButton ? Qt.lighter(AppStyle.colors.primary, 1.3) : (root.selectedButton === minimizeButton ? AppStyle.colors.primary : AppStyle.colors.textPrimary)
                             hoverColor: "transparent"
 
                             // 文本颜色渐变动画
@@ -301,7 +301,7 @@ Item {
                             text: qsTr("退出程序")
                             backgroundColor: "transparent"
                             // 动态文本颜色：当滑块在上方时变亮
-                            textColor: root.activeButton === exitButton ? Qt.lighter(AppStyle.colors.danger, 1.3) : (root.selectedButton === exitButton ? AppStyle.colors.danger : AppStyle.colors.text)
+                            textColor: root.activeButton === exitButton ? Qt.lighter(AppStyle.colors.danger, 1.3) : (root.selectedButton === exitButton ? AppStyle.colors.danger : AppStyle.colors.textPrimary)
                             hoverColor: "transparent"
 
                             // 文本颜色渐变动画
@@ -353,7 +353,7 @@ Item {
                             text: qsTr("取消")
                             backgroundColor: "transparent"
                             // 动态文本颜色：当滑块在上方时变亮
-                            textColor: root.activeButton === cancelButton ? Qt.lighter(AppStyle.colors.textSecondary, 1.5) : (root.selectedButton === cancelButton ? AppStyle.colors.textSecondary : AppStyle.colors.text)
+                            textColor: root.activeButton === cancelButton ? Qt.lighter(AppStyle.colors.textSecondary, 1.5) : (root.selectedButton === cancelButton ? AppStyle.colors.textSecondary : AppStyle.colors.textPrimary)
                             hoverColor: "transparent"
 
                             // 文本颜色渐变动画
@@ -437,7 +437,7 @@ Item {
     }
 
     // 键盘事件处理
-    Keys.onPressed: (event) => {
+    Keys.onPressed: event => {
         if (event.key === Qt.Key_Up || event.key === Qt.Key_Left) {
             // 向上/左导航
             if (selectedButton === exitButton) {

--- a/src/ui/qml/components/ExitDialog.qml
+++ b/src/ui/qml/components/ExitDialog.qml
@@ -20,11 +20,12 @@ import "../styles"
  * - ExitDialog：无任务时显示，提供"最小化到托盘"/"退出程序"/"取消"选项
  * - ConfirmDialog：有任务时显示，提供"强制退出"/"继续转换"选项
  */
-Item {
+FocusScope {
     id: root
     anchors.fill: parent
     visible: false
     z: 9999
+    focus: visible  // 当对话框可见时接收焦点
 
     // 常量
     readonly property int buttonHeight: 48
@@ -34,6 +35,7 @@ Item {
     property bool rememberChoice: false
     property Item activeButton: null  // 当前活跃的按钮
     property Item selectedButton: exitButton  // 当前键盘选中的按钮，默认为退出按钮
+    property string focusArea: "button"  // 当前聚焦区域："button" 或 "checkbox"，默认为按钮
 
     // 信号
     signal minimizeToTray(bool remember)
@@ -77,6 +79,8 @@ Item {
         selectedButton = exitButton;
         // 设置滑块默认聚焦在退出选项上
         updateSlider(exitButton, AppStyle.colors.danger);
+        // 重置聚焦区域为按钮
+        focusArea = "button";
         // 强制焦点到 root 以便键盘导航
         root.forceActiveFocus();
     }
@@ -409,21 +413,36 @@ Item {
                     }
 
                     indicator: Rectangle {
-                        implicitWidth: 20
-                        implicitHeight: 20
+                        implicitWidth: 22
+                        implicitHeight: 22
                         x: rememberCheckBox.leftPadding
                         y: parent.height / 2 - height / 2
                         radius: 4
-                        border.color: rememberCheckBox.checked ? AppStyle.colors.primary : AppStyle.colors.border
-                        border.width: 2
                         color: rememberCheckBox.checked ? AppStyle.colors.primary : "transparent"
+                        border.color: rememberCheckBox.checked ? AppStyle.colors.primary : (root.focusArea === "checkbox" ? AppStyle.colors.primary : AppStyle.colors.textSecondary)
+                        border.width: root.focusArea === "checkbox" ? 2.5 : 1.5
+                        Behavior on color {
+                            ColorAnimation {
+                                duration: 150
+                            }
+                        }
+                        Behavior on border.color {
+                            ColorAnimation {
+                                duration: 150
+                            }
+                        }
+                        Behavior on border.width {
+                            NumberAnimation {
+                                duration: 150
+                            }
+                        }
 
-                        Rectangle {
-                            width: 10
-                            height: 10
+                        Text {
                             anchors.centerIn: parent
-                            radius: 2
-                            color: AppStyle.isDarkMode ? "#ffffff" : "#ffffff"
+                            text: "✓"
+                            font.pixelSize: 16
+                            font.bold: true
+                            color: "#ffffff"
                             visible: rememberCheckBox.checked
                         }
                     }
@@ -444,47 +463,67 @@ Item {
     // 键盘事件处理
     Keys.onPressed: event => {
         if (event.key === Qt.Key_Up || event.key === Qt.Key_Left) {
-            // 向上/左导航
-            if (selectedButton === exitButton) {
-                selectedButton = minimizeButton;
-                updateSlider(minimizeButton, AppStyle.colors.primary);
-            } else if (selectedButton === cancelButton) {
-                selectedButton = exitButton;
-                updateSlider(exitButton, AppStyle.colors.danger);
-            } else if (selectedButton === minimizeButton) {
-                selectedButton = cancelButton;
-                updateSlider(cancelButton, AppStyle.colors.textSecondary);
+            // 向上/左导航：只在聚焦在按钮时才在按钮之间导航
+            if (focusArea === "button") {
+                if (selectedButton === exitButton) {
+                    selectedButton = minimizeButton;
+                    updateSlider(minimizeButton, AppStyle.colors.primary);
+                } else if (selectedButton === cancelButton) {
+                    selectedButton = exitButton;
+                    updateSlider(exitButton, AppStyle.colors.danger);
+                } else if (selectedButton === minimizeButton) {
+                    selectedButton = cancelButton;
+                    updateSlider(cancelButton, AppStyle.colors.textSecondary);
+                }
             }
             event.accepted = true;
         } else if (event.key === Qt.Key_Down || event.key === Qt.Key_Right) {
-            // 向下/右导航
-            if (selectedButton === minimizeButton) {
-                selectedButton = exitButton;
-                updateSlider(exitButton, AppStyle.colors.danger);
-            } else if (selectedButton === exitButton) {
-                selectedButton = cancelButton;
-                updateSlider(cancelButton, AppStyle.colors.textSecondary);
-            } else if (selectedButton === cancelButton) {
-                selectedButton = minimizeButton;
-                updateSlider(minimizeButton, AppStyle.colors.primary);
+            // 向下/右导航：只在聚焦在按钮时才在按钮之间导航
+            if (focusArea === "button") {
+                if (selectedButton === minimizeButton) {
+                    selectedButton = exitButton;
+                    updateSlider(exitButton, AppStyle.colors.danger);
+                } else if (selectedButton === exitButton) {
+                    selectedButton = cancelButton;
+                    updateSlider(cancelButton, AppStyle.colors.textSecondary);
+                } else if (selectedButton === cancelButton) {
+                    selectedButton = minimizeButton;
+                    updateSlider(minimizeButton, AppStyle.colors.primary);
+                }
             }
             event.accepted = true;
         } else if (event.key === Qt.Key_Tab) {
-            // Tab 键循环导航
-            if (selectedButton === minimizeButton) {
-                selectedButton = exitButton;
-                updateSlider(exitButton, AppStyle.colors.danger);
-            } else if (selectedButton === exitButton) {
-                selectedButton = cancelButton;
-                updateSlider(cancelButton, AppStyle.colors.textSecondary);
-            } else if (selectedButton === cancelButton) {
-                selectedButton = minimizeButton;
-                updateSlider(minimizeButton, AppStyle.colors.primary);
+            // Tab 键：在选项按钮和记住选择复选框之间切换
+            if (focusArea === "button") {
+                // 从选项按钮切换到记住选择复选框，隐藏滑块
+                focusArea = "checkbox";
+                hideSlider();
+            } else {
+                // 从记住选择复选框切换到选项按钮，显示滑块
+                focusArea = "button";
+                // 更新当前选中的按钮的滑块位置
+                if (selectedButton === minimizeButton) {
+                    updateSlider(minimizeButton, AppStyle.colors.primary);
+                } else if (selectedButton === exitButton) {
+                    updateSlider(exitButton, AppStyle.colors.danger);
+                } else if (selectedButton === cancelButton) {
+                    updateSlider(cancelButton, AppStyle.colors.textSecondary);
+                }
             }
             event.accepted = true;
+        } else if (event.key === Qt.Key_Space) {
+            // 空格键：当聚焦在记住选择复选框时切换选择状态
+            if (focusArea === "checkbox") {
+                root.rememberChoice = !root.rememberChoice;
+                event.accepted = true;
+            }
         } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
             // 回车键确认选择
-            if (selectedButton === minimizeButton) {
+            if (focusArea === "checkbox") {
+                // 当聚焦在记住选择复选框时，回车键切换选择状态
+                root.rememberChoice = !root.rememberChoice;
+                event.accepted = true;
+            } else if (selectedButton === minimizeButton) {
                 root.minimizeToTray(rememberChoice);
             } else if (selectedButton === exitButton) {
                 root.exitApp(rememberChoice);
@@ -494,9 +533,10 @@ Item {
             }
             event.accepted = true;
         } else if (event.key === Qt.Key_Escape) {
-            // ESC 键取消
-            root.closeWithAnimation();
-            Qt.callLater(root.canceled);
+            // ESC 键取消 - 不处理，让Main.qml的Shortcut处理
+            event.accepted = false;
+        } else {
+            // 其他键盘事件也被拦截，防止传播到主窗口
             event.accepted = true;
         }
     }

--- a/src/ui/qml/components/ExitDialog.qml
+++ b/src/ui/qml/components/ExitDialog.qml
@@ -5,10 +5,20 @@ import QtQuick.Effects
 import "../styles"
 
 /**
- * @brief 退出选项对话框
+ * @brief 退出选项对话框（无任务时显示）
  *
- * 当用户点击关闭按钮且无正在进行的任务时显示。
- * 提供"最小化到托盘"和"退出程序"选项。
+ * **用途**：当用户点击关闭按钮且无正在进行的任务时显示
+ * **场景**：用户点击关闭按钮 → 检测到 exportProgressViewModel.isExporting 为 false → 显示此对话框
+ * **选项**：
+ *   - 最小化到托盘：最小化窗口到系统托盘，保持后台运行
+ *   - 退出程序：完全退出应用程序
+ *   - 取消：关闭对话框，继续使用程序
+ * **记住选择**：用户可以选择"记住我的选择"，下次自动执行相同操作
+ * **动画**：取消按钮点击后向下滑动消失（fade out + slide down + scale down）
+ *
+ * **注意**：不要与 ConfirmDialog 混淆
+ * - ExitDialog：无任务时显示，提供"最小化到托盘"/"退出程序"/"取消"选项
+ * - ConfirmDialog：有任务时显示，提供"强制退出"/"继续转换"选项
  */
 Item {
     id: root
@@ -16,36 +26,65 @@ Item {
     visible: false
     z: 9999
 
+    // 常量
+    readonly property int buttonHeight: 48
+    readonly property real sliderOpacity: 0.25
+
     // 属性
     property bool rememberChoice: false
+    property Item activeButton: null  // 当前活跃的按钮
+    property Item selectedButton: exitButton  // 当前键盘选中的按钮，默认为退出按钮
 
     // 信号
     signal minimizeToTray(bool remember)
     signal exitApp(bool remember)
     signal canceled
 
-    // 打开/关闭动画
+    // 更新滑块位置
+    function updateSlider(targetButton, targetColor) {
+        // 计算按钮在 buttonBox 中的相对位置
+        var buttonY = targetButton.mapToItem(buttonBox, 0, 0).y;
+
+        // 果冻拉伸效果：向下移动时轻微压缩高度
+        var centerY = buttonBox.height / 2;
+        var stretchFactor = 1.0 + Math.abs(buttonY - centerY) / centerY * 0.02;
+
+        sliderBackground.y = buttonY;
+        sliderBackground.height = buttonHeight * (2.0 - stretchFactor);  // 使用常量
+        sliderBackground.color = targetColor;
+        sliderBackground.opacity = sliderOpacity;  // 使用常量
+
+        // 更新活跃按钮
+        activeButton = targetButton;
+    }
+
+    // 隐藏滑块
+    function hideSlider() {
+        sliderBackground.opacity = 0;
+        // 清除活跃按钮
+        activeButton = null;
+    }
+
+    // 打开/关闭
     function open() {
         visible = true;
-        showAnim.start();
-        minimizeButton.forceActiveFocus();
+        // 直接设置对话框为完全显示状态，不播放打开动画
+        dialogBox.rotation = 0;
+        dialogBox.scale = 1.0;
+        dialogBox.opacity = 1.0;
+        dialogBoxTranslate.y = 0;
+        // 设置默认选中为退出按钮
+        selectedButton = exitButton;
+        // 强制焦点到 root 以便键盘导航
+        root.forceActiveFocus();
     }
 
     function close() {
-        hideAnim.start();
+        visible = false;
     }
 
-    // 遮罩层
-    Rectangle {
-        id: overlay
-        anchors.fill: parent
-        color: AppStyle.isDarkMode ? "#000000" : "#1e293b"
-        opacity: 0
-        MouseArea {
-            anchors.fill: parent
-            hoverEnabled: true
-            onClicked: {} // 拦截点击
-        }
+    function closeWithAnimation() {
+        hideAnim.start();
     }
 
     // 对话框主体
@@ -54,19 +93,41 @@ Item {
         width: Math.min(parent.width * 0.9, 440)
         implicitHeight: contentCol.implicitHeight + AppStyle.spacing.xxxl * 2
         anchors.centerIn: parent
-        color: AppStyle.colors.surface
+        color: AppStyle.isDarkMode ? "#1e293b" : "#ffffff"
         radius: AppStyle.radius.xl
-        scale: 0.9
-        opacity: 0
+        scale: 1.0
+        opacity: 1.0
+        rotation: 0  // 添加旋转属性
+
+        transform: Translate {
+            id: dialogBoxTranslate
+            y: 0
+        }
+
+        // 边框
+        Rectangle {
+            anchors.fill: parent
+            radius: AppStyle.radius.xl
+            color: "transparent"
+            border.color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.1) : Qt.rgba(0, 0, 0, 0.1)
+            border.width: 1
+            z: 1
+        }
 
         // 阴影
-        layer.enabled: true
-        layer.effect: MultiEffect {
-            shadowEnabled: true
-            shadowColor: AppStyle.shadows.lg.color
-            shadowBlur: 1.0
-            shadowHorizontalOffset: AppStyle.shadows.lg.horizontalOffset
-            shadowVerticalOffset: AppStyle.shadows.lg.verticalOffset
+        Rectangle {
+            anchors.fill: parent
+            radius: AppStyle.radius.xl
+            color: "transparent"
+            z: -1
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                shadowEnabled: true
+                shadowColor: AppStyle.shadows.lg.color
+                shadowBlur: 1.5
+                shadowHorizontalOffset: AppStyle.shadows.lg.horizontalOffset
+                shadowVerticalOffset: AppStyle.shadows.lg.verticalOffset
+            }
         }
 
         ColumnLayout {
@@ -96,50 +157,235 @@ Item {
                 lineHeight: 1.3
             }
 
-            // 按钮组
-            ColumnLayout {
+            // 按钮组容器
+            Rectangle {
+                id: buttonBox
                 Layout.fillWidth: true
                 Layout.topMargin: AppStyle.spacing.md
-                spacing: AppStyle.spacing.md
+                implicitHeight: buttonCol.implicitHeight + AppStyle.spacing.md * 2
+                color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.05) : Qt.rgba(0, 0, 0, 0.03)
+                radius: AppStyle.radius.lg
+                border.color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.1) : Qt.rgba(0, 0, 0, 0.08)
+                border.width: 1
 
-                // 最小化到托盘
-                ModernButton {
-                    id: minimizeButton
-                    Layout.fillWidth: true
-                    text: qsTr("最小化到托盘")
-                    backgroundColor: AppStyle.colors.primary
-                    onClicked: {
-                        root.close();
-                        // 延迟触发信号以显示关闭动画
-                        Qt.callLater(() => root.minimizeToTray(rememberChoice));
+                // 滑块背景（果冻效果）
+                Rectangle {
+                    id: sliderBackground
+                    x: AppStyle.spacing.sm
+                    y: AppStyle.spacing.sm
+                    width: buttonBox.width - AppStyle.spacing.sm * 2
+                    height: buttonHeight  // 使用常量
+                    radius: AppStyle.radius.md
+                    color: AppStyle.colors.primary
+                    opacity: 0
+                    z: 2
+
+                    // Q弹动画（弹簧效果 - 垂直移动）
+                    Behavior on y {
+                        enabled: sliderBackground.visible
+                        SpringAnimation {
+                            spring: 5.0
+                            damping: 0.5
+                            mass: 0.8
+                            epsilon: 0.25  // 防止在微小像素点上持续计算
+                        }
+                    }
+
+                    // Q弹动画（弹簧效果 - 高度变化，果冻拉伸）
+                    Behavior on height {
+                        enabled: sliderBackground.visible
+                        SpringAnimation {
+                            spring: 6.0  // 稍微更强的弹簧，让拉伸更有弹性
+                            damping: 0.4  // 更低的阻尼，让效果更明显
+                            mass: 0.7
+                            epsilon: 0.25
+                        }
+                    }
+
+                    // 颜色渐变动画
+                    Behavior on color {
+                        ColorAnimation {
+                            duration: 250
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+
+                    // 淡入淡出动画
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: 200
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+
+                    // 发光效果（只在可见时启用以提高性能）
+                    layer.enabled: sliderBackground.opacity > 0
+                    layer.effect: MultiEffect {
+                        shadowEnabled: true
+                        shadowColor: sliderBackground.color
+                        shadowBlur: 1.0
+                        shadowVerticalOffset: 0
+                        shadowHorizontalOffset: 0
                     }
                 }
 
-                // 退出程序
-                ModernButton {
-                    id: exitButton
-                    Layout.fillWidth: true
-                    text: qsTr("退出程序")
-                    backgroundColor: "transparent"
-                    textColor: AppStyle.colors.danger
-                    hoverColor: AppStyle.isDarkMode ? "#331e1e" : "#fee2e2"
-                    onClicked: {
-                        root.close();
-                        Qt.callLater(() => root.exitApp(rememberChoice));
-                    }
-                }
+                // 按钮列
+                ColumnLayout {
+                    id: buttonCol
+                    anchors.fill: parent
+                    anchors.topMargin: AppStyle.spacing.sm
+                    anchors.bottomMargin: AppStyle.spacing.sm
+                    spacing: 0
+                    z: 1
 
-                // 取消
-                ModernButton {
-                    id: cancelButton
-                    Layout.fillWidth: true
-                    text: qsTr("取消")
-                    backgroundColor: "transparent"
-                    textColor: AppStyle.colors.textSecondary
-                    hoverColor: AppStyle.isDarkMode ? "#334155" : "#f1f5f9"
-                    onClicked: {
-                        root.close();
-                        Qt.callLater(root.canceled);
+                    // 最小化到托盘
+                    Item {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: buttonHeight  // 使用常量
+
+                        ModernButton {
+                            id: minimizeButton
+                            anchors.fill: parent
+                            text: qsTr("最小化到托盘")
+                            backgroundColor: "transparent"
+                            // 动态文本颜色：当滑块在上方时变亮，键盘选中时使用不同颜色
+                            textColor: root.activeButton === minimizeButton ? Qt.lighter(AppStyle.colors.primary, 1.3) : (root.selectedButton === minimizeButton ? AppStyle.colors.primary : AppStyle.colors.text)
+                            hoverColor: "transparent"
+
+                            // 文本颜色渐变动画
+                            Behavior on textColor {
+                                ColorAnimation {
+                                    duration: 150
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+
+                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大
+                            scale: (root.activeButton === minimizeButton || root.selectedButton === minimizeButton) ? 1.05 : 1.0
+                            Behavior on scale {
+                                NumberAnimation {
+                                    duration: 150
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+
+                            onHoveredChanged: {
+                                if (hovered) {
+                                    root.updateSlider(this, AppStyle.colors.primary);
+                                } else if (!exitButton.hovered && !cancelButton.hovered) {
+                                    root.hideSlider();
+                                }
+                            }
+
+                            onClicked: {
+                                root.minimizeToTray(rememberChoice);
+                            }
+                        }
+                    }
+
+                    // 分隔线
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 1
+                        color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.08) : Qt.rgba(0, 0, 0, 0.06)
+                    }
+
+                    // 退出程序
+                    Item {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: buttonHeight  // 使用常量
+
+                        ModernButton {
+                            id: exitButton
+                            anchors.fill: parent
+                            text: qsTr("退出程序")
+                            backgroundColor: "transparent"
+                            // 动态文本颜色：当滑块在上方时变亮
+                            textColor: root.activeButton === exitButton ? Qt.lighter(AppStyle.colors.danger, 1.3) : (root.selectedButton === exitButton ? AppStyle.colors.danger : AppStyle.colors.text)
+                            hoverColor: "transparent"
+
+                            // 文本颜色渐变动画
+                            Behavior on textColor {
+                                ColorAnimation {
+                                    duration: 150
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+
+                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大
+                            scale: (root.activeButton === exitButton || root.selectedButton === exitButton) ? 1.05 : 1.0
+                            Behavior on scale {
+                                NumberAnimation {
+                                    duration: 150
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+
+                            onHoveredChanged: {
+                                if (hovered) {
+                                    root.updateSlider(this, AppStyle.colors.danger);
+                                } else if (!minimizeButton.hovered && !cancelButton.hovered) {
+                                    root.hideSlider();
+                                }
+                            }
+
+                            onClicked: {
+                                root.exitApp(rememberChoice);
+                            }
+                        }
+                    }
+
+                    // 分隔线
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 1
+                        color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.08) : Qt.rgba(0, 0, 0, 0.06)
+                    }
+
+                    // 取消
+                    Item {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: buttonHeight  // 使用常量
+
+                        ModernButton {
+                            id: cancelButton
+                            anchors.fill: parent
+                            text: qsTr("取消")
+                            backgroundColor: "transparent"
+                            // 动态文本颜色：当滑块在上方时变亮
+                            textColor: root.activeButton === cancelButton ? Qt.lighter(AppStyle.colors.textSecondary, 1.5) : (root.selectedButton === cancelButton ? AppStyle.colors.textSecondary : AppStyle.colors.text)
+                            hoverColor: "transparent"
+
+                            // 文本颜色渐变动画
+                            Behavior on textColor {
+                                ColorAnimation {
+                                    duration: 150
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+
+                            // 缩放效果：当滑块在上方时轻微放大，键盘选中时也放大
+                            scale: (root.activeButton === cancelButton || root.selectedButton === cancelButton) ? 1.05 : 1.0
+                            Behavior on scale {
+                                NumberAnimation {
+                                    duration: 150
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+
+                            onHoveredChanged: {
+                                if (hovered) {
+                                    root.updateSlider(this, AppStyle.colors.textSecondary);
+                                } else if (!minimizeButton.hovered && !exitButton.hovered) {
+                                    root.hideSlider();
+                                }
+                            }
+
+                            onClicked: {
+                                root.closeWithAnimation();
+                                Qt.callLater(root.canceled);
+                            }
+                        }
                     }
                 }
             }
@@ -152,9 +398,9 @@ Item {
 
                 CheckBox {
                     id: rememberCheckBox
-                    checked: false
+                    checked: root.rememberChoice  // 双向绑定
                     onClicked: {
-                        rememberChoice = checked;
+                        root.rememberChoice = checked;
                     }
 
                     indicator: Rectangle {
@@ -179,68 +425,127 @@ Item {
                 }
 
                 Text {
+
                     text: qsTr("记住我的选择")
+
                     font.pixelSize: AppStyle.fontSizes.sm
+
                     color: AppStyle.colors.textSecondary
                 }
             }
         }
     }
 
-    // 动画
-    ParallelAnimation {
-        id: showAnim
-        NumberAnimation {
-            target: overlay
-            property: "opacity"
-            from: 0
-            to: 0.6
-            duration: 250
-            easing.type: AppStyle.easings.easeOut
-        }
-        NumberAnimation {
-            target: dialogBox
-            property: "opacity"
-            from: 0
-            to: 1
-            duration: 250
-            easing.type: AppStyle.easings.easeOut
-        }
-        NumberAnimation {
-            target: dialogBox
-            property: "scale"
-            from: 0.8
-            to: 1
-            duration: 300
-            easing.type: Easing.OutBack
+    // 键盘事件处理
+    Keys.onPressed: (event) => {
+        if (event.key === Qt.Key_Up || event.key === Qt.Key_Left) {
+            // 向上/左导航
+            if (selectedButton === exitButton) {
+                selectedButton = minimizeButton;
+            } else if (selectedButton === cancelButton) {
+                selectedButton = exitButton;
+            } else if (selectedButton === minimizeButton) {
+                selectedButton = cancelButton;
+            }
+            event.accepted = true;
+        } else if (event.key === Qt.Key_Down || event.key === Qt.Key_Right) {
+            // 向下/右导航
+            if (selectedButton === minimizeButton) {
+                selectedButton = exitButton;
+            } else if (selectedButton === exitButton) {
+                selectedButton = cancelButton;
+            } else if (selectedButton === cancelButton) {
+                selectedButton = minimizeButton;
+            }
+            event.accepted = true;
+        } else if (event.key === Qt.Key_Tab) {
+            // Tab 键循环导航
+            if (selectedButton === minimizeButton) {
+                selectedButton = exitButton;
+            } else if (selectedButton === exitButton) {
+                selectedButton = cancelButton;
+            } else if (selectedButton === cancelButton) {
+                selectedButton = minimizeButton;
+            }
+            event.accepted = true;
+        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+            // 回车键确认选择
+            if (selectedButton === minimizeButton) {
+                root.minimizeToTray(rememberChoice);
+            } else if (selectedButton === exitButton) {
+                root.exitApp(rememberChoice);
+            } else if (selectedButton === cancelButton) {
+                root.closeWithAnimation();
+                Qt.callLater(root.canceled);
+            }
+            event.accepted = true;
+        } else if (event.key === Qt.Key_Escape) {
+            // ESC 键取消
+            root.closeWithAnimation();
+            Qt.callLater(root.canceled);
+            event.accepted = true;
         }
     }
 
+    // 向下滑动消失动画
+
     SequentialAnimation {
         id: hideAnim
+
         ParallelAnimation {
+
             NumberAnimation {
-                target: overlay
-                property: "opacity"
-                to: 0
-                duration: 200
-            }
-            NumberAnimation {
+
                 target: dialogBox
+
                 property: "opacity"
+
+                from: 1
+
                 to: 0
+
                 duration: 200
+
+                easing.type: Easing.OutQuad
             }
+
             NumberAnimation {
+
+                target: dialogBoxTranslate
+
+                property: "y"
+
+                from: 0
+
+                to: root.height
+
+                duration: 200
+
+                easing.type: Easing.OutQuad
+            }
+
+            NumberAnimation {
+
                 target: dialogBox
+
                 property: "scale"
+
+                from: 1.0
+
                 to: 0.9
+
                 duration: 200
+
+                easing.type: Easing.OutQuad
             }
         }
+
         PropertyAction {
+
             target: root
+
             property: "visible"
+
             value: false
         }
     }


### PR DESCRIPTION
## 概述
本次PR为退出对话框（ExitDialog）添加了完整的键盘导航功能，改进了复选框样式，并优化了焦点管理机制，提升用户交互体验。

## 主要变更

### 1. 改进复选框样式
- **变更内容**：将记住选择复选框的样式改为与导出设置保持一致
- **具体改进**：
  - 使用勾选符号（✓）替代矩形勾选标记
  - 调整尺寸为22x22像素
  - 选中状态：主色背景 + 白色粗体勾选符号 + 主色边框
  - 未选中聚焦：主色边框 + 加粗边框（2.5px）
  - 未选中未聚焦：次要文本颜色边框（1.5px）
  - 添加平滑的颜色、边框和宽度过渡动画（150ms）

### 2. 实现Tab键切换功能
- **变更内容**：支持Tab键在选项按钮和记住选择复选框之间切换
- **具体改进**：
  - Tab键从选项切换到记住选择时，滑块消失
  - Tab键从记住选择切换回选项时，滑块重新显示
  - 方向键（↑/↓/←/→）只在聚焦在按钮时才在按钮之间导航
  - 空格键和回车键都能在记住选择复选框上切换选择状态

### 3. 改进焦点管理
- **变更内容**：优化焦点管理机制，确保键盘事件正确处理
- **具体改进**：
  - 将根元素从`Item`改为`FocusScope`，提供更好的焦点控制
  - 添加`focus: visible`属性，确保对话框可见时接收焦点
  - ESC键事件传播到Main.qml处理，避免焦点冲突
  - 所有其他键盘事件都被拦截，不会传播到主窗口
  - 防止Tab键聚焦到主窗口内容

### 4. 修复ESC键回归问题
- **变更内容**：修复ESC键无法关闭对话框的回归问题
- **具体改进**：
  - Main.qml中的Shortcut组件现在既能打开也能关闭对话框
  - ExitDialog中的ESC键事件不被拦截，传播到Main.qml处理
  - 确保ESC键在对话框内外都能正常工作

## 键盘操作说明

| 按键 | 功能 |
|------|------|
| **↑/↓/←/→** | 在选项按钮之间导航（仅在按钮聚焦区域有效） |
| **Tab** | 在选项按钮和记住选择复选框之间切换 |
| **空格** | 在记住选择复选框上切换选择状态 |
| **回车** | 执行当前选中选项的操作 |
| **ESC** | 打开或关闭对话框 |
