### PR TITLE
fix(ci): 统一所有平台的可执行文件名为小写 easykiconverter

### DIFF
--- a/.github/workflows/pack-linux.yml
+++ b/.github/workflows/pack-linux.yml
@@ -95,7 +95,7 @@ jobs:
           # 注意：这里不生成 AppImage 文件，只处理目录内容
           # --icon-file 参数必须指向 AppDir 中的图标文件，而不是源路径
           linuxdeploy --appdir ${APPIMAGE_DST_PATH} --plugin qt \
-            --executable ${APPIMAGE_DST_PATH}/usr/bin/EasyKiConverter \
+            --executable ${APPIMAGE_DST_PATH}/usr/bin/easykiconverter \
             --desktop-file ${APPIMAGE_DST_PATH}/com.tangsangsimida.EasyKiConverter.desktop \
             --icon-file ${APPIMAGE_DST_PATH}/com.tangsangsimida.EasyKiConverter.png
 
@@ -137,7 +137,7 @@ jobs:
           # 重新运行 linuxdeploy 以生成 AppImage
           # 必须再次指定 executable 和 desktop-file 否则 AppRun 可能不会正确链接
           linuxdeploy --appdir ${{ env.PRODUCT }}.AppDir --plugin qt \
-            --executable ${{ env.PRODUCT }}.AppDir/usr/bin/EasyKiConverter \
+            --executable ${{ env.PRODUCT }}.AppDir/usr/bin/easykiconverter \
             --desktop-file ${{ env.PRODUCT }}.AppDir/com.tangsangsimida.EasyKiConverter.desktop \
             --output appimage
 
@@ -200,8 +200,8 @@ jobs:
             export APP_DIR="${GITHUB_WORKSPACE}/AppDir"
             echo "Found AppDir at: $APP_DIR"
           else
-            # 检查当前目录是否包含 AppDir 的特征文件（usr/bin/EasyKiConverter）
-            if [ -f "usr/bin/EasyKiConverter" ] && [ -f "AppRun" ]; then
+            # 检查当前目录是否包含 AppDir 的特征文件（usr/bin/easykiconverter）
+            if [ -f "usr/bin/easykiconverter" ] && [ -f "AppRun" ]; then
               # nfpm 不支持使用根目录，需要创建一个子目录
               echo "Found AppDir structure in current directory, creating subdirectory for nfpm"
               mkdir -p AppDir_temp
@@ -307,8 +307,8 @@ jobs:
             export APP_DIR="${GITHUB_WORKSPACE}/AppDir"
             echo "Found AppDir at: $APP_DIR"
           else
-            # 检查当前目录是否包含 AppDir 的特征文件（usr/bin/EasyKiConverter）
-            if [ -f "usr/bin/EasyKiConverter" ] && [ -f "AppRun" ]; then
+            # 检查当前目录是否包含 AppDir 的特征文件（usr/bin/easykiconverter）
+            if [ -f "usr/bin/easykiconverter" ] && [ -f "AppRun" ]; then
               # nfpm 不支持使用根目录，需要创建一个子目录
               echo "Found AppDir structure in current directory, creating subdirectory for nfpm"
               mkdir -p AppDir_temp
@@ -410,8 +410,8 @@ jobs:
             export APP_DIR="${GITHUB_WORKSPACE}/AppDir"
             echo "Found AppDir at: $APP_DIR"
           else
-            # 检查当前目录是否包含 AppDir 的特征文件（usr/bin/EasyKiConverter）
-            if [ -f "usr/bin/EasyKiConverter" ] && [ -f "AppRun" ]; then
+            # 检查当前目录是否包含 AppDir 的特征文件（usr/bin/easykiconverter）
+            if [ -f "usr/bin/easykiconverter" ] && [ -f "AppRun" ]; then
               # nfpm 不支持使用根目录，需要创建一个子目录
               echo "Found AppDir structure in current directory, creating subdirectory for nfpm"
               mkdir -p AppDir_temp

--- a/.github/workflows/pack-windows.yml
+++ b/.github/workflows/pack-windows.yml
@@ -122,7 +122,7 @@ jobs:
       - name: 'Deploy Qt dependencies'
         shell: pwsh
         run: |
-          $exePath = "$env:GITHUB_WORKSPACE\build\bin\Release\EasyKiConverter.exe"
+          $exePath = "$env:GITHUB_WORKSPACE\build\bin\Release\easykiconverter.exe"
           Write-Host "Running windeployqt on $exePath"
           # Rely on PATH to find windeployqt
           windeployqt --release --no-translations --no-system-d3d-compiler --no-opengl-sw --qmldir "$env:GITHUB_WORKSPACE\src\ui\qml" $exePath

--- a/EasyKiConverter.desktop
+++ b/EasyKiConverter.desktop
@@ -10,5 +10,5 @@ Terminal=false
 Categories=Development;Electronics;Engineering;
 Keywords=KiCad;LCSC;EasyEDA;Component;Converter;Electronics;
 StartupNotify=true
-StartupWMClass=EasyKiConverter
+StartupWMClass=easykiconverter
 MimeType=application/vnd.easyeda+json;

--- a/deploy/flatpak/com.tangsangsimida.EasyKiConverter.yml
+++ b/deploy/flatpak/com.tangsangsimida.EasyKiConverter.yml
@@ -2,7 +2,7 @@ app-id: com.tangsangsimida.EasyKiConverter
 runtime: org.kde.Platform
 runtime-version: '6.6'
 sdk: org.kde.Sdk
-command: EasyKiConverter
+command: easykiconverter
 finish-args:
   - --share=ipc
   - --socket=fallback-x11
@@ -29,13 +29,13 @@ modules:
       - cmake --install .
       - |
         # 验证可执行文件是否被安装
-        if [ ! -f /app/bin/EasyKiConverter ]; then
-          echo "ERROR: EasyKiConverter executable was not installed!"
+        if [ ! -f /app/bin/easykiconverter ]; then
+          echo "ERROR: easykiconverter executable was not installed!"
           ls -la /app/bin/
           exit 1
         fi
-        echo "EasyKiConverter executable installed successfully"
-        ls -lh /app/bin/EasyKiConverter
+        echo "easykiconverter executable installed successfully"
+        ls -lh /app/bin/easykiconverter
     post-install:
       - |
         # 创建 desktop 文件
@@ -45,7 +45,7 @@ modules:
         Type=Application
         Name=EasyKiConverter
         Comment=Convert LCSC and EasyEDA components to KiCad libraries
-        Exec=EasyKiConverter
+        Exec=easykiconverter
         Icon=com.tangsangsimida.EasyKiConverter
         Categories=Development;Electronics;
         Terminal=false

--- a/resources/windows_setup.iss
+++ b/resources/windows_setup.iss
@@ -3,7 +3,7 @@
 #define MyAppName "EasyKiConverter"
 #define MyAppPublisher "tangsangsimida"
 #define MyAppURL "https://github.com/tangsangsimida/EasyKiConverter"
-#define MyAppExeName "EasyKiConverter.exe"
+#define MyAppExeName "easykiconverter.exe"
 
 ; 这些变量将通过命令行定义传入
 ;#define MyAppVersion "3.0.0"


### PR DESCRIPTION
## 描述

修复了跨平台打包工作流中的可执行文件名大小写不一致问题，确保所有平台使用统一的小写命名约定 `easykiconverter`，与 `CMakeLists.txt` 中设置的 `OUTPUT_NAME` 保持一致。

## 问题背景

### Linux 打包失败
在 GitHub Actions 的 Linux 打包工作流中，出现以下错误：
```
ERROR: No such file or directory: /__w/EasyKiConverter/EasyKiConverter/EasyKiConverter.AppDir/usr/bin/EasyKiConverter
```

**根本原因**：
- Linux 文件系统（ext4、xfs 等）**区分大小写**
- `CMakeLists.txt` 中设置的可执行文件名为 `easykiconverter`（小写）
- 工作流中引用的是 `EasyKiConverter`（大写）
- 在 Linux 上，这是两个完全不同的文件名

### Windows 打包为何未受影响
Windows 文件系统（NTFS、FAT32）**不区分大小写**，所以 `EasyKiConverter.exe` 可以成功找到 `easykiconverter.exe`。但为了代码一致性和跨平台兼容性，也应统一使用小写。
