### PR TITLE
修复弱网络环境下批量添加元器件闪退问题

### DIFF
--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -724,12 +724,9 @@ QString ComponentService::getOutputPath() const {
 }
 
 void ComponentService::fetchMultipleComponentsData(const QStringList& componentIds, bool fetch3DModel) {
-    qDebug() << "Fetching data for" << componentIds.size() << "components in parallel";
+    qDebug() << "Fetching data for" << componentIds.size() << "components with dynamic queue";
 
-    // 修复：实现分批次处理，限制最大并发请求数
-    // 防止弱网络环境下因并发过多导致资源耗尽和崩溃
-    const int MAX_CONCURRENT = 5;        // 最大并发请求数
-    const int BATCH_INTERVAL_MS = 2000;  // 批次间隔2秒
+    const int MAX_CONCURRENT = 5;  // 最大并发请求数
 
     // 初始化并行获取状态
     {
@@ -742,36 +739,49 @@ void ComponentService::fetchMultipleComponentsData(const QStringList& componentI
         m_parallelFetching = true;
     }
 
-    // 分批次处理请求
-    int processed = 0;
-    while (processed < componentIds.size()) {
-        int batchSize = qMin(MAX_CONCURRENT, componentIds.size() - processed);
-        QStringList batch = componentIds.mid(processed, batchSize);
+    // 动态队列处理：始终保持MAX_CONCURRENT个活跃请求
+    int activeCount = 0;
+    int currentIndex = 0;
 
-        qDebug() << "Processing batch" << (processed / MAX_CONCURRENT + 1) << "with" << batchSize << "components";
+    while (currentIndex < componentIds.size() || activeCount > 0) {
+        // 启动新请求直到达到最大并发数
+        while (activeCount < MAX_CONCURRENT && currentIndex < componentIds.size()) {
+            QString id = componentIds.at(currentIndex);
+            currentIndex++;
 
-        // 发起当前批次的请求
-        {
-            QMutexLocker locker(&m_parallelDataMutex);
-            for (const QString& id : batch) {
+            {
+                QMutexLocker locker(&m_parallelDataMutex);
                 m_parallelFetchingStatus[id] = true;
+            }
+
+            qDebug() << "Starting request for component:" << id << "(Active:" << activeCount + 1 << "/"
+                     << MAX_CONCURRENT << "Remaining:" << componentIds.size() - currentIndex << ")";
+
+            fetchComponentDataInternal(id, fetch3DModel);
+            activeCount++;
+
+            if (activeCount < MAX_CONCURRENT && currentIndex < componentIds.size()) {
+                QThread::msleep(200);  // 请求间隔
             }
         }
 
-        for (const QString& id : batch) {
-            fetchComponentDataInternal(id, fetch3DModel);
+        if (currentIndex >= componentIds.size() && activeCount > 0) {
+            qDebug() << "All requests started, waiting for completion. Active:" << activeCount;
+            QThread::msleep(1000);
         }
 
-        processed += batchSize;
-
-        // 如果还有待处理的，等待一段时间再处理下一批次
-        if (processed < componentIds.size()) {
-            qDebug() << "Waiting" << BATCH_INTERVAL_MS << "ms before next batch";
-            QThread::msleep(BATCH_INTERVAL_MS);
+        {
+            QMutexLocker locker(&m_parallelDataMutex);
+            int completed = m_parallelCompletedCount;
+            if (completed < currentIndex) {
+                activeCount = currentIndex - completed;
+            } else {
+                activeCount = 0;
+            }
         }
     }
 
-    qDebug() << "All batches submitted. Total components:" << componentIds.size();
+    qDebug() << "All components processed. Total:" << componentIds.size();
 }
 
 void ComponentService::handleParallelDataCollected(const QString& componentId, const ComponentData& data) {

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -18,8 +18,11 @@
 #include <QQueue>
 #include <QRegularExpression>
 #include <QTextStream>
+#include <QThread>
 #include <QTimer>
 #include <QUuid>
+
+#include <cstdlib>
 
 namespace EasyKiConverter {
 
@@ -42,8 +45,12 @@ ComponentService::ComponentService(QObject* parent)
         m_importer = new EasyedaImporter(this);
         m_networkManager = new QNetworkAccessManager(this);
         m_imageService = new LcscImageService(this);
+    } catch (const std::bad_alloc& e) {
+        qCritical() << "ComponentService: Memory allocation failed:" << e.what();
+        std::terminate();
     } catch (...) {
         qCritical() << "ComponentService: Failed to initialize sub-services!";
+        std::terminate();
     }
 
     initializeApiConnections();
@@ -106,7 +113,12 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
 
     // 确保 componentId 格式统一（大写）
     QString normalizedId = componentId.toUpper();
-    m_currentComponentId = normalizedId;
+
+    // 使用互斥锁保护 m_currentComponentId 的并发访问
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        m_currentComponentId = normalizedId;
+    }
 
     // 加锁保护共享数据的访问
     QMutexLocker locker(&m_fetchingComponentsMutex);
@@ -333,9 +345,13 @@ void ComponentService::handleCadDataFetched(const QJsonObject& data) {
 
     qDebug() << "CAD data fetched for:" << lcscId;
 
-    // 临时保存当前的组件ID
-    QString savedComponentId = m_currentComponentId;
-    m_currentComponentId = lcscId;
+    // 临时保存当前的组件ID，使用互斥锁保护
+    QString savedComponentId;
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        savedComponentId = m_currentComponentId;
+        m_currentComponentId = lcscId;
+    }
 
     // 加锁保护共享数据的访问
     QMutexLocker locker(&m_fetchingComponentsMutex);
@@ -438,9 +454,20 @@ void ComponentService::handleCadDataFetched(const QJsonObject& data) {
                      << datasheetUrl;
         }
     } else {
-        qWarning() << "Failed to import symbol data for:" << m_currentComponentId;
+        // 使用互斥锁保护读取 m_currentComponentId
+        QString currentId;
+        {
+            QMutexLocker locker(&m_currentIdMutex);
+            currentId = m_currentComponentId;
+        }
+        qWarning() << "Failed to import symbol data for:" << currentId;
         emit fetchError(lcscId, "Failed to parse Symbol data from EasyEDA JSON");
-        m_currentComponentId = savedComponentId;
+
+        // 恢复组件 ID
+        {
+            QMutexLocker locker(&m_currentIdMutex);
+            m_currentComponentId = savedComponentId;
+        }
         return;
     }
 
@@ -518,19 +545,27 @@ void ComponentService::handleCadDataFetched(const QJsonObject& data) {
 
     // 先发送完成信号，确保 ComponentListViewModel 获取到完整的 ComponentData
     // 图片下载是异步的，会在后台继续进行
-    emit cadDataReady(m_currentComponentId, componentData);
+    QString currentId;
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        currentId = m_currentComponentId;
+    }
+    emit cadDataReady(currentId, componentData);
 
     // 然后调用 LCSC API 获取数据手册和预览图
-    m_imageService->fetchPreviewImages(m_currentComponentId);
-    qDebug() << "Called fetchPreviewImages to get LCSC datasheet and preview images for" << m_currentComponentId;
+    m_imageService->fetchPreviewImages(currentId);
+    qDebug() << "Called fetchPreviewImages to get LCSC datasheet and preview images for" << currentId;
 
     // 如果在并行模式下，处理并行数据收集
     if (m_parallelFetching) {
-        handleParallelDataCollected(m_currentComponentId, componentData);
+        handleParallelDataCollected(currentId, componentData);
     }
 
-    // 恢复组件 ID
-    m_currentComponentId = savedComponentId;
+    // 恢复组件 ID，使用互斥锁保护
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        m_currentComponentId = savedComponentId;
+    }
 }
 
 void ComponentService::handleModel3DFetched(const QString& uuid, const QByteArray& data) {
@@ -691,16 +726,59 @@ QString ComponentService::getOutputPath() const {
 void ComponentService::fetchMultipleComponentsData(const QStringList& componentIds, bool fetch3DModel) {
     qDebug() << "Fetching data for" << componentIds.size() << "components in parallel";
 
-    // 初始化请求
-    m_parallelFetchingStatus.clear();
-    for (const QString& id : componentIds) {
-        m_parallelFetchingStatus[id] = true;
-        fetchComponentDataInternal(id, fetch3DModel);
+    // 修复：实现分批次处理，限制最大并发请求数
+    // 防止弱网络环境下因并发过多导致资源耗尽和崩溃
+    const int MAX_CONCURRENT = 5;        // 最大并发请求数
+    const int BATCH_INTERVAL_MS = 2000;  // 批次间隔2秒
+
+    // 初始化并行获取状态
+    {
+        QMutexLocker locker(&m_parallelDataMutex);
+        m_parallelFetchingStatus.clear();
+        m_parallelCollectedData.clear();
+        m_parallelPendingComponents = componentIds;
+        m_parallelTotalCount = componentIds.size();
+        m_parallelCompletedCount = 0;
+        m_parallelFetching = true;
     }
+
+    // 分批次处理请求
+    int processed = 0;
+    while (processed < componentIds.size()) {
+        int batchSize = qMin(MAX_CONCURRENT, componentIds.size() - processed);
+        QStringList batch = componentIds.mid(processed, batchSize);
+
+        qDebug() << "Processing batch" << (processed / MAX_CONCURRENT + 1) << "with" << batchSize << "components";
+
+        // 发起当前批次的请求
+        {
+            QMutexLocker locker(&m_parallelDataMutex);
+            for (const QString& id : batch) {
+                m_parallelFetchingStatus[id] = true;
+            }
+        }
+
+        for (const QString& id : batch) {
+            fetchComponentDataInternal(id, fetch3DModel);
+        }
+
+        processed += batchSize;
+
+        // 如果还有待处理的，等待一段时间再处理下一批次
+        if (processed < componentIds.size()) {
+            qDebug() << "Waiting" << BATCH_INTERVAL_MS << "ms before next batch";
+            QThread::msleep(BATCH_INTERVAL_MS);
+        }
+    }
+
+    qDebug() << "All batches submitted. Total components:" << componentIds.size();
 }
 
 void ComponentService::handleParallelDataCollected(const QString& componentId, const ComponentData& data) {
     qDebug() << "Parallel data collected for:" << componentId;
+
+    // 使用互斥锁保护并行数据收集状态的并发访问
+    QMutexLocker locker(&m_parallelDataMutex);
 
     // 保存收集到的数据
     m_parallelCollectedData[componentId] = data;
@@ -713,11 +791,15 @@ void ComponentService::handleParallelDataCollected(const QString& componentId, c
     if (m_parallelCompletedCount >= m_parallelTotalCount) {
         qDebug() << "All components data collected in parallel:" << m_parallelCollectedData.size();
 
-        // 发送完成信号
+        // 发送完成信号，先复制数据到局部变量
         QList<ComponentData> allData = m_parallelCollectedData.values();
+
+        // 在发送信号前释放锁，避免死锁
+        locker.unlock();
         emit allComponentsDataCollected(allData);
 
-        // 重置状态
+        // 重新加锁进行状态重置
+        QMutexLocker locker2(&m_parallelDataMutex);
         m_parallelFetching = false;
         m_parallelCollectedData.clear();
         m_parallelFetchingStatus.clear();
@@ -728,6 +810,9 @@ void ComponentService::handleParallelDataCollected(const QString& componentId, c
 void ComponentService::handleParallelFetchError(const QString& componentId, const QString& error) {
     qDebug() << "Parallel fetch error for:" << componentId << error;
 
+    // 使用互斥锁保护并行数据收集状态的并发访问
+    QMutexLocker locker(&m_parallelDataMutex);
+
     // 更新状态
     m_parallelFetchingStatus[componentId] = false;
     m_parallelCompletedCount++;
@@ -736,11 +821,15 @@ void ComponentService::handleParallelFetchError(const QString& componentId, cons
     if (m_parallelCompletedCount >= m_parallelTotalCount) {
         qDebug() << "All components data collected (with errors):" << m_parallelCollectedData.size();
 
-        // 发送完成信号
+        // 发送完成信号，先复制数据到局部变量
         QList<ComponentData> allData = m_parallelCollectedData.values();
+
+        // 在发送信号前释放锁，避免死锁
+        locker.unlock();
         emit allComponentsDataCollected(allData);
 
-        // 重置状态
+        // 重新加锁进行状态重置
+        QMutexLocker locker2(&m_parallelDataMutex);
         m_parallelFetching = false;
         m_parallelCollectedData.clear();
         m_parallelFetchingStatus.clear();

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -312,6 +312,16 @@ private:
     void handleParallelFetchError(const QString& componentId, const QString& error);
 
     /**
+     * @brief 动态队列管理：处理单个请求完成后的队列调度
+     */
+    void processQueueNext();
+
+    /**
+     * @brief 动态队列管理：启动队列处理
+     */
+    void startQueueProcessing();
+
+    /**
      * @brief 检测数据是否为 PDF 格式
      *
      * @param data 数据
@@ -371,6 +381,11 @@ private:
     int m_parallelTotalCount;                              // 总元件数
     int m_parallelCompletedCount;                          // 已完成数
     bool m_parallelFetching;                               // 是否正在并行获取
+
+    // 动态队列管理
+    QStringList m_requestQueue;   // 请求队列
+    int m_activeRequestCount;     // 当前活跃请求数
+    int m_maxConcurrentRequests;  // 最大并发请求数
 
     // 内部状态处理
 

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -332,6 +332,8 @@ private:
     // 添加互斥锁保护并发访问
     mutable QMutex m_fetchingComponentsMutex;
     mutable QMutex m_componentCacheMutex;
+    mutable QMutex m_currentIdMutex;     // 保护 m_currentComponentId 的并发访问
+    mutable QMutex m_parallelDataMutex;  // 保护并行数据收集状态的并发访问
 
     // 数据缓存
     QMap<QString, ComponentData> m_componentCache;

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -19,7 +19,7 @@ ApplicationWindow {
     // 默认窗口位置居中显示（如果配置中没有保存的值）
     x: configService ? (configService.getWindowX() > 0 ? configService.getWindowX() : (Screen.desktopAvailableWidth - width) / 2) : (Screen.desktopAvailableWidth - width) / 2
     y: configService ? (configService.getWindowY() > 0 ? configService.getWindowY() : (Screen.desktopAvailableHeight - height) / 2) : (Screen.desktopAvailableHeight - height) / 2
-    
+
     // 最小窗口宽度计算：
     // - 导出设置卡片需要的最小宽度 = 760px（选项680px + 间距30px + 内边距48px + 边框2px）
     // - 卡片的左右外边距（AppStyle.spacing.huge * 2 = 30 * 2 = 60px）

--- a/src/workers/FetchWorker.cpp
+++ b/src/workers/FetchWorker.cpp
@@ -5,12 +5,14 @@
 #include <QEventLoop>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMetaObject>
 #include <QMutex>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QThread>
 #include <QTimer>
 
+#include <memory>
 #include <zlib.h>
 
 namespace EasyKiConverter {
@@ -93,20 +95,14 @@ void FetchWorker::run() {
 
     // 使用线程局部存储缓存 QNetworkAccessManager
     // 避免为每个任务重复创建和销毁 QNAM（这是非常昂贵的操作）
-    static thread_local QNetworkAccessManager* threadQNAM = nullptr;
-    static thread_local bool threadQNAMInitialized = false;
+    // 修复：使用 std::unique_ptr 管理线程局部 QNetworkAccessManager 生命周期
+    static thread_local std::unique_ptr<QNetworkAccessManager> threadQNAM = nullptr;
 
-    if (!threadQNAMInitialized) {
-        threadQNAM = new QNetworkAccessManager();
-        threadQNAMInitialized = true;
-
-        // 修复：移除 QThread::finished 清理逻辑
-        // 原因：在低带宽环境下，活跃的 QNetworkReply 可能仍在使用这个 QNAM
-        // 过早删除会导致段错误。让 QNetworkAccessManager 随线程生命周期自然结束。
-
+    if (!threadQNAM) {
+        threadQNAM = std::make_unique<QNetworkAccessManager>();
         qDebug() << "Created thread-local QNetworkAccessManager for thread:" << QThread::currentThreadId();
     }
-    m_ownNetworkManager = threadQNAM;
+    m_ownNetworkManager = threadQNAM.get();
 
     bool hasError = false;
     QString errorMessage;
@@ -703,7 +699,8 @@ void FetchWorker::abort() {
     QMutexLocker locker(&m_replyMutex);
     if (m_currentReply) {
         qDebug() << "Aborting network request for component:" << m_componentId;
-        m_currentReply->abort();
+        // 安全：使用 Qt::QueuedConnection 确保在正确线程执行 abort()
+        QMetaObject::invokeMethod(m_currentReply, "abort", Qt::QueuedConnection);
     }
 }
 


### PR DESCRIPTION
## 问题描述

当用户在非常慢的网络环境下一次性添加多个元器件ID到列表时，会出现以下现象：
1. 元器件列表中所有元器件都显示"正在加载"
2. 程序突然闪退（崩溃）
