### PR TITLE
Fix metainfo summary to comply with Flathub guidelines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # 从 CI 环境动态获取版本号，如果没有定义则使用默认版本
 if(NOT DEFINED VERSION_FROM_CI)
-    set(VERSION_FROM_CI "3.0.13")
+    set(VERSION_FROM_CI "3.0.14")
     message(STATUS "VERSION_FROM_CI not defined, using default: ${VERSION_FROM_CI}")
 else()
     message(STATUS "VERSION_FROM_CI defined: ${VERSION_FROM_CI}")

--- a/deploy/flatpak/io.github.tangsangsimida.easykiconverter.yml
+++ b/deploy/flatpak/io.github.tangsangsimida.easykiconverter.yml
@@ -36,7 +36,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/tangsangsimida/EasyKiConverter.git
-        tag: v3.0.13
+        tag: v3.0.14
         commit:
       - type: archive
         url: https://github.com/QtExcel/QXlsx/archive/9f545935a1effa0144ba76598e95a7597210553a.tar.gz

--- a/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml
+++ b/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml
@@ -10,8 +10,8 @@
   </developer>
   <name>EasyKiConverter</name>
   <name xml:lang="zh_CN">EasyKiConverter</name>
-  <summary>Convert LCSC and EasyEDA components to KiCad libraries</summary>
-  <summary xml:lang="zh_CN">将嘉立创和 EasyEDA 元件转换为 KiCad 库</summary>
+  <summary>Convert components for KiCad</summary>
+  <summary xml:lang="zh_CN">转换元件用于 KiCad</summary>
 
   <translation type="qt">easykiconverter</translation>
 

--- a/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml
+++ b/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml
@@ -58,22 +58,22 @@
 
   <screenshots>
     <screenshot type="default">
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.13/resources/imgs/screenshot1.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.14/resources/imgs/screenshot1.png</image>
       <caption>Main application window with component conversion interface</caption>
       <caption xml:lang="zh_CN">主应用窗口 - 元件转换界面</caption>
     </screenshot>
     <screenshot>
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.13/resources/imgs/screenshot2.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.14/resources/imgs/screenshot2.png</image>
       <caption>Component input and list management</caption>
       <caption xml:lang="zh_CN">元件输入和列表管理</caption>
     </screenshot>
     <screenshot>
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.13/resources/imgs/screenshot3.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.14/resources/imgs/screenshot3.png</image>
       <caption>Export settings and progress tracking</caption>
       <caption xml:lang="zh_CN">导出设置和进度跟踪</caption>
     </screenshot>
     <screenshot>
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.13/resources/imgs/screenshot4.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.0.14/resources/imgs/screenshot4.png</image>
       <caption>Dark mode theme support</caption>
       <caption xml:lang="zh_CN">深色主题支持</caption>
     </screenshot>
@@ -106,6 +106,32 @@
   <content_rating type="oars-1.1"/>
 
   <releases>
+    <release version="3.0.14" date="2026-03-18">
+      <description>
+        <p>Changes from 3.0.13 to 3.0.14</p>
+        <p xml:lang="zh_CN">从 3.0.13 到 3.0.14 的变更</p>
+        <p>New Features:</p>
+        <p xml:lang="zh_CN">新功能:</p>
+        <ul>
+          <li>Improved resource cleanup mechanism on application exit</li>
+          <li xml:lang="zh_CN">改进应用退出时的资源清理机制</li>
+          <li>Refactored retry button style and added hover interaction effects</li>
+          <li xml:lang="zh_CN">重构重试按钮样式并添加悬停交互效果</li>
+          <li>Added retry functionality and optimized UI component structure</li>
+          <li xml:lang="zh_CN">添加重试功能和优化UI组件结构</li>
+          <li>Optimized concurrent processing mechanism for component data fetching</li>
+          <li xml:lang="zh_CN">优化组件数据获取的并发处理机制</li>
+          <li>Optimized ComponentService multi-thread safety and concurrency control</li>
+          <li xml:lang="zh_CN">优化ComponentService多线程安全性和并发控制</li>
+        </ul>
+        <p>Other Changes:</p>
+        <p xml:lang="zh_CN">其他变更:</p>
+        <ul>
+          <li>Enhanced version management tool with comprehensive file coverage</li>
+          <li xml:lang="zh_CN">增强版本管理工具，覆盖更多文件</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.0.13" date="2026-03-17">
       <description>
         <p>Changes from 3.0.12 to 3.0.13</p>

--- a/deploy/windows/AppxManifest.xml
+++ b/deploy/windows/AppxManifest.xml
@@ -24,7 +24,7 @@
 
   <Identity Name="EasyKiConverter.EasyKiConverter"
             Publisher="CN=674ae893-5637-43c6-894d-d9a3976ec062"
-            Version="3.0.9.0" ProcessorArchitecture="x64" />
+            Version="3.0.14.0" ProcessorArchitecture="x64" />
 
   <Properties>
     <DisplayName>EasyKiConverter</DisplayName>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ not_in_nav: |
 
 # 版本信息（可通过 macros 插件在页面中使用）
 extra:
-  version: 3.0.5
+  version: 3.0.14
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/tangsangsimida/EasyKiConverter

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[]) {
 
     // 设置应用程序信息（必须在解析命令行参数之前）
     app.setApplicationName("EasyKiConverter");
-    app.setApplicationVersion("3.0.13");
+    app.setApplicationVersion("3.0.14");
     app.setOrganizationName("EasyKiConverter");
     app.setOrganizationDomain("easykiconverter.com");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -495,30 +495,32 @@ int main(int argc, char* argv[]) {
     int exitCode = app.exec();
 
     // === 重要：显式按顺序销毁对象，防止退出时崩溃 ===
-    // 1. 首先清除 QML 引擎的上下文属性，防止 QML 组件访问已销毁的对象
+
+    // 1. 清除 QML 引擎的上下文属性，防止 QML 组件访问已销毁的对象
+    qDebug() << "Clearing QML context properties...";
     engine.rootContext()->setContextProperty("componentListViewModel", nullptr);
     engine.rootContext()->setContextProperty("exportSettingsViewModel", nullptr);
     engine.rootContext()->setContextProperty("exportProgressViewModel", nullptr);
     engine.rootContext()->setContextProperty("themeSettingsViewModel", nullptr);
 
     // 2. 销毁 QML 引擎（这会销毁所有 QML 组件）
+    qDebug() << "Destroying QML engine...";
     engine.deleteLater();
 
-    // 3. 处理事件队列，确保 QML 引擎销毁完成
-    QCoreApplication::processEvents();
-
-    // 4. 销毁 ViewModel
+    // 3. 销毁 ViewModel
+    qDebug() << "Destroying ViewModels...";
     delete themeSettingsViewModel;
     delete exportProgressViewModel;
     delete exportSettingsViewModel;
     delete componentListViewModel;
 
-    // 5. 销毁单例/核心服务
+    // 4. 销毁服务（析构函数会自动调用 cancelExport 和 cleanup）
+    qDebug() << "Destroying services...";
     delete exportService;
     delete componentService;
 
-    // 3. 最后卸载日志适配器并关闭 Logger
-    // 确保所有 worker 线程已在上述 delete 过程中停止后再关闭日志线程
+    // 5. 最后清理日志
+    qDebug() << "Cleaning up logging...";
     EasyKiConverter::QtLogAdapter::uninstall();
     auto* logger = EasyKiConverter::Logger::instance();
     if (logger) {
@@ -526,5 +528,6 @@ int main(int argc, char* argv[]) {
         logger->close();
     }
 
+    qDebug() << "Cleanup completed, exiting...";
     return exitCode;
 }

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -724,12 +724,9 @@ QString ComponentService::getOutputPath() const {
 }
 
 void ComponentService::fetchMultipleComponentsData(const QStringList& componentIds, bool fetch3DModel) {
-    qDebug() << "Fetching data for" << componentIds.size() << "components in parallel";
+    qDebug() << "Fetching data for" << componentIds.size() << "components with dynamic queue";
 
-    // 修复：实现分批次处理，限制最大并发请求数
-    // 防止弱网络环境下因并发过多导致资源耗尽和崩溃
-    const int MAX_CONCURRENT = 5;        // 最大并发请求数
-    const int BATCH_INTERVAL_MS = 2000;  // 批次间隔2秒
+    const int MAX_CONCURRENT = 5;  // 最大并发请求数
 
     // 初始化并行获取状态
     {
@@ -742,36 +739,49 @@ void ComponentService::fetchMultipleComponentsData(const QStringList& componentI
         m_parallelFetching = true;
     }
 
-    // 分批次处理请求
-    int processed = 0;
-    while (processed < componentIds.size()) {
-        int batchSize = qMin(MAX_CONCURRENT, componentIds.size() - processed);
-        QStringList batch = componentIds.mid(processed, batchSize);
+    // 动态队列处理：始终保持MAX_CONCURRENT个活跃请求
+    int activeCount = 0;
+    int currentIndex = 0;
 
-        qDebug() << "Processing batch" << (processed / MAX_CONCURRENT + 1) << "with" << batchSize << "components";
+    while (currentIndex < componentIds.size() || activeCount > 0) {
+        // 启动新请求直到达到最大并发数
+        while (activeCount < MAX_CONCURRENT && currentIndex < componentIds.size()) {
+            QString id = componentIds.at(currentIndex);
+            currentIndex++;
 
-        // 发起当前批次的请求
-        {
-            QMutexLocker locker(&m_parallelDataMutex);
-            for (const QString& id : batch) {
+            {
+                QMutexLocker locker(&m_parallelDataMutex);
                 m_parallelFetchingStatus[id] = true;
+            }
+
+            qDebug() << "Starting request for component:" << id << "(Active:" << activeCount + 1 << "/"
+                     << MAX_CONCURRENT << "Remaining:" << componentIds.size() - currentIndex << ")";
+
+            fetchComponentDataInternal(id, fetch3DModel);
+            activeCount++;
+
+            if (activeCount < MAX_CONCURRENT && currentIndex < componentIds.size()) {
+                QThread::msleep(200);  // 请求间隔
             }
         }
 
-        for (const QString& id : batch) {
-            fetchComponentDataInternal(id, fetch3DModel);
+        if (currentIndex >= componentIds.size() && activeCount > 0) {
+            qDebug() << "All requests started, waiting for completion. Active:" << activeCount;
+            QThread::msleep(1000);
         }
 
-        processed += batchSize;
-
-        // 如果还有待处理的，等待一段时间再处理下一批次
-        if (processed < componentIds.size()) {
-            qDebug() << "Waiting" << BATCH_INTERVAL_MS << "ms before next batch";
-            QThread::msleep(BATCH_INTERVAL_MS);
+        {
+            QMutexLocker locker(&m_parallelDataMutex);
+            int completed = m_parallelCompletedCount;
+            if (completed < currentIndex) {
+                activeCount = currentIndex - completed;
+            } else {
+                activeCount = 0;
+            }
         }
     }
 
-    qDebug() << "All batches submitted. Total components:" << componentIds.size();
+    qDebug() << "All components processed. Total:" << componentIds.size();
 }
 
 void ComponentService::handleParallelDataCollected(const QString& componentId, const ComponentData& data) {

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -18,8 +18,11 @@
 #include <QQueue>
 #include <QRegularExpression>
 #include <QTextStream>
+#include <QThread>
 #include <QTimer>
 #include <QUuid>
+
+#include <cstdlib>
 
 namespace EasyKiConverter {
 
@@ -42,8 +45,12 @@ ComponentService::ComponentService(QObject* parent)
         m_importer = new EasyedaImporter(this);
         m_networkManager = new QNetworkAccessManager(this);
         m_imageService = new LcscImageService(this);
+    } catch (const std::bad_alloc& e) {
+        qCritical() << "ComponentService: Memory allocation failed:" << e.what();
+        std::terminate();
     } catch (...) {
         qCritical() << "ComponentService: Failed to initialize sub-services!";
+        std::terminate();
     }
 
     initializeApiConnections();
@@ -106,7 +113,12 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
 
     // 确保 componentId 格式统一（大写）
     QString normalizedId = componentId.toUpper();
-    m_currentComponentId = normalizedId;
+
+    // 使用互斥锁保护 m_currentComponentId 的并发访问
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        m_currentComponentId = normalizedId;
+    }
 
     // 加锁保护共享数据的访问
     QMutexLocker locker(&m_fetchingComponentsMutex);
@@ -333,9 +345,13 @@ void ComponentService::handleCadDataFetched(const QJsonObject& data) {
 
     qDebug() << "CAD data fetched for:" << lcscId;
 
-    // 临时保存当前的组件ID
-    QString savedComponentId = m_currentComponentId;
-    m_currentComponentId = lcscId;
+    // 临时保存当前的组件ID，使用互斥锁保护
+    QString savedComponentId;
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        savedComponentId = m_currentComponentId;
+        m_currentComponentId = lcscId;
+    }
 
     // 加锁保护共享数据的访问
     QMutexLocker locker(&m_fetchingComponentsMutex);
@@ -438,9 +454,20 @@ void ComponentService::handleCadDataFetched(const QJsonObject& data) {
                      << datasheetUrl;
         }
     } else {
-        qWarning() << "Failed to import symbol data for:" << m_currentComponentId;
+        // 使用互斥锁保护读取 m_currentComponentId
+        QString currentId;
+        {
+            QMutexLocker locker(&m_currentIdMutex);
+            currentId = m_currentComponentId;
+        }
+        qWarning() << "Failed to import symbol data for:" << currentId;
         emit fetchError(lcscId, "Failed to parse Symbol data from EasyEDA JSON");
-        m_currentComponentId = savedComponentId;
+
+        // 恢复组件 ID
+        {
+            QMutexLocker locker(&m_currentIdMutex);
+            m_currentComponentId = savedComponentId;
+        }
         return;
     }
 
@@ -518,19 +545,27 @@ void ComponentService::handleCadDataFetched(const QJsonObject& data) {
 
     // 先发送完成信号，确保 ComponentListViewModel 获取到完整的 ComponentData
     // 图片下载是异步的，会在后台继续进行
-    emit cadDataReady(m_currentComponentId, componentData);
+    QString currentId;
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        currentId = m_currentComponentId;
+    }
+    emit cadDataReady(currentId, componentData);
 
     // 然后调用 LCSC API 获取数据手册和预览图
-    m_imageService->fetchPreviewImages(m_currentComponentId);
-    qDebug() << "Called fetchPreviewImages to get LCSC datasheet and preview images for" << m_currentComponentId;
+    m_imageService->fetchPreviewImages(currentId);
+    qDebug() << "Called fetchPreviewImages to get LCSC datasheet and preview images for" << currentId;
 
     // 如果在并行模式下，处理并行数据收集
     if (m_parallelFetching) {
-        handleParallelDataCollected(m_currentComponentId, componentData);
+        handleParallelDataCollected(currentId, componentData);
     }
 
-    // 恢复组件 ID
-    m_currentComponentId = savedComponentId;
+    // 恢复组件 ID，使用互斥锁保护
+    {
+        QMutexLocker locker(&m_currentIdMutex);
+        m_currentComponentId = savedComponentId;
+    }
 }
 
 void ComponentService::handleModel3DFetched(const QString& uuid, const QByteArray& data) {
@@ -691,16 +726,59 @@ QString ComponentService::getOutputPath() const {
 void ComponentService::fetchMultipleComponentsData(const QStringList& componentIds, bool fetch3DModel) {
     qDebug() << "Fetching data for" << componentIds.size() << "components in parallel";
 
-    // 初始化请求
-    m_parallelFetchingStatus.clear();
-    for (const QString& id : componentIds) {
-        m_parallelFetchingStatus[id] = true;
-        fetchComponentDataInternal(id, fetch3DModel);
+    // 修复：实现分批次处理，限制最大并发请求数
+    // 防止弱网络环境下因并发过多导致资源耗尽和崩溃
+    const int MAX_CONCURRENT = 5;        // 最大并发请求数
+    const int BATCH_INTERVAL_MS = 2000;  // 批次间隔2秒
+
+    // 初始化并行获取状态
+    {
+        QMutexLocker locker(&m_parallelDataMutex);
+        m_parallelFetchingStatus.clear();
+        m_parallelCollectedData.clear();
+        m_parallelPendingComponents = componentIds;
+        m_parallelTotalCount = componentIds.size();
+        m_parallelCompletedCount = 0;
+        m_parallelFetching = true;
     }
+
+    // 分批次处理请求
+    int processed = 0;
+    while (processed < componentIds.size()) {
+        int batchSize = qMin(MAX_CONCURRENT, componentIds.size() - processed);
+        QStringList batch = componentIds.mid(processed, batchSize);
+
+        qDebug() << "Processing batch" << (processed / MAX_CONCURRENT + 1) << "with" << batchSize << "components";
+
+        // 发起当前批次的请求
+        {
+            QMutexLocker locker(&m_parallelDataMutex);
+            for (const QString& id : batch) {
+                m_parallelFetchingStatus[id] = true;
+            }
+        }
+
+        for (const QString& id : batch) {
+            fetchComponentDataInternal(id, fetch3DModel);
+        }
+
+        processed += batchSize;
+
+        // 如果还有待处理的，等待一段时间再处理下一批次
+        if (processed < componentIds.size()) {
+            qDebug() << "Waiting" << BATCH_INTERVAL_MS << "ms before next batch";
+            QThread::msleep(BATCH_INTERVAL_MS);
+        }
+    }
+
+    qDebug() << "All batches submitted. Total components:" << componentIds.size();
 }
 
 void ComponentService::handleParallelDataCollected(const QString& componentId, const ComponentData& data) {
     qDebug() << "Parallel data collected for:" << componentId;
+
+    // 使用互斥锁保护并行数据收集状态的并发访问
+    QMutexLocker locker(&m_parallelDataMutex);
 
     // 保存收集到的数据
     m_parallelCollectedData[componentId] = data;
@@ -713,11 +791,15 @@ void ComponentService::handleParallelDataCollected(const QString& componentId, c
     if (m_parallelCompletedCount >= m_parallelTotalCount) {
         qDebug() << "All components data collected in parallel:" << m_parallelCollectedData.size();
 
-        // 发送完成信号
+        // 发送完成信号，先复制数据到局部变量
         QList<ComponentData> allData = m_parallelCollectedData.values();
+
+        // 在发送信号前释放锁，避免死锁
+        locker.unlock();
         emit allComponentsDataCollected(allData);
 
-        // 重置状态
+        // 重新加锁进行状态重置
+        QMutexLocker locker2(&m_parallelDataMutex);
         m_parallelFetching = false;
         m_parallelCollectedData.clear();
         m_parallelFetchingStatus.clear();
@@ -728,6 +810,9 @@ void ComponentService::handleParallelDataCollected(const QString& componentId, c
 void ComponentService::handleParallelFetchError(const QString& componentId, const QString& error) {
     qDebug() << "Parallel fetch error for:" << componentId << error;
 
+    // 使用互斥锁保护并行数据收集状态的并发访问
+    QMutexLocker locker(&m_parallelDataMutex);
+
     // 更新状态
     m_parallelFetchingStatus[componentId] = false;
     m_parallelCompletedCount++;
@@ -736,11 +821,15 @@ void ComponentService::handleParallelFetchError(const QString& componentId, cons
     if (m_parallelCompletedCount >= m_parallelTotalCount) {
         qDebug() << "All components data collected (with errors):" << m_parallelCollectedData.size();
 
-        // 发送完成信号
+        // 发送完成信号，先复制数据到局部变量
         QList<ComponentData> allData = m_parallelCollectedData.values();
+
+        // 在发送信号前释放锁，避免死锁
+        locker.unlock();
         emit allComponentsDataCollected(allData);
 
-        // 重置状态
+        // 重新加锁进行状态重置
+        QMutexLocker locker2(&m_parallelDataMutex);
         m_parallelFetching = false;
         m_parallelCollectedData.clear();
         m_parallelFetchingStatus.clear();

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -312,6 +312,16 @@ private:
     void handleParallelFetchError(const QString& componentId, const QString& error);
 
     /**
+     * @brief 动态队列管理：处理单个请求完成后的队列调度
+     */
+    void processQueueNext();
+
+    /**
+     * @brief 动态队列管理：启动队列处理
+     */
+    void startQueueProcessing();
+
+    /**
      * @brief 检测数据是否为 PDF 格式
      *
      * @param data 数据
@@ -371,6 +381,11 @@ private:
     int m_parallelTotalCount;                              // 总元件数
     int m_parallelCompletedCount;                          // 已完成数
     bool m_parallelFetching;                               // 是否正在并行获取
+
+    // 动态队列管理
+    QStringList m_requestQueue;   // 请求队列
+    int m_activeRequestCount;     // 当前活跃请求数
+    int m_maxConcurrentRequests;  // 最大并发请求数
 
     // 内部状态处理
 

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -332,6 +332,8 @@ private:
     // 添加互斥锁保护并发访问
     mutable QMutex m_fetchingComponentsMutex;
     mutable QMutex m_componentCacheMutex;
+    mutable QMutex m_currentIdMutex;     // 保护 m_currentComponentId 的并发访问
+    mutable QMutex m_parallelDataMutex;  // 保护并行数据收集状态的并发访问
 
     // 数据缓存
     QMap<QString, ComponentData> m_componentCache;

--- a/src/services/ExportService_Pipeline.cpp
+++ b/src/services/ExportService_Pipeline.cpp
@@ -764,79 +764,54 @@ void ExportServicePipeline::cancelExport() {
 
 bool ExportServicePipeline::waitForCompletion(int timeoutMs) {
     if (!m_isPipelineRunning)
-
         return true;
 
     // 检查 QApplication 实例是否存在
-
     if (!QCoreApplication::instance()) {
         qWarning() << "QCoreApplication instance not available, skipping graceful wait.";
-
         return false;
     }
 
     qDebug() << "Waiting for pipeline completion (timeout:" << timeoutMs << "ms)...";
 
     // 确保已设置取消标志，加速 Worker 退出
-
     if (!m_isCancelled.loadAcquire()) {
         m_isCancelled.storeRelease(1);
     }
 
     QElapsedTimer timer;
-
     timer.start();
 
-    // 缓存主线程指针
+    // 简化的线程池等待逻辑，避免使用 processEvents()
+    // 这是为了防止 Windows 上的 UI 冻结和死锁问题
 
-    QThread* mainThread = QCoreApplication::instance()->thread();
-
-    // 定义一个辅助 lambda 用于安全等待线程池
-
-    auto safeWaitForPool = [&](QThreadPool* pool, const char* name) -> bool {
+    auto simpleWaitForPool = [&](QThreadPool* pool, const char* name) -> bool {
         if (!pool)
             return true;
 
-        while (pool->activeThreadCount() > 0) {
-            if (timer.elapsed() > timeoutMs) {
-                qWarning() << name << "thread pool wait timed out";
-
-                return false;
-            }
-
-            // 尝试非阻塞等待一小段时间
-
-            if (pool->waitForDone(50)) {
-                break;
-            }
-
-            // 关键：仅在主线程处理事件循环，防止死锁并确保线程安全
-
-            if (QThread::currentThread() == mainThread) {
-                QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-            }
+        // 直接等待线程池完成，使用较短的超时
+        if (!pool->waitForDone(timeoutMs / 3)) {
+            qWarning() << name << "thread pool did not finish within" << (timeoutMs / 3) << "ms";
+            // 超时后不再等待，直接返回
+            return false;
         }
-
+        qDebug() << name << "thread pool finished successfully";
         return true;
     };
 
     // 1. 等待 fetch 线程池
-
-    if (!safeWaitForPool(m_fetchThreadPool, "Fetch"))
+    if (!simpleWaitForPool(m_fetchThreadPool, "Fetch"))
         return false;
 
     // 2. 等待 process 线程池
-
-    if (!safeWaitForPool(m_processThreadPool, "Process"))
+    if (!simpleWaitForPool(m_processThreadPool, "Process"))
         return false;
 
     // 3. 等待 write 线程池
-
-    if (!safeWaitForPool(m_writeThreadPool, "Write"))
+    if (!simpleWaitForPool(m_writeThreadPool, "Write"))
         return false;
 
     qDebug() << "Pipeline wait finished successfully in" << timer.elapsed() << "ms";
-
     return true;
 }
 
@@ -936,6 +911,32 @@ bool ExportServicePipeline::exportDatasheetFromMemory(const QByteArray& datashee
         qWarning() << "Failed to write datasheet to:" << filePath;
         return false;
     }
+}
+
+void ExportServicePipeline::forceCleanupThreadPools() {
+    qDebug() << "Force cleanup all thread pools...";
+
+    clearThreadPool(m_fetchThreadPool);
+    clearThreadPool(m_processThreadPool);
+    clearThreadPool(m_writeThreadPool);
+}
+
+void ExportServicePipeline::clearThreadPool(QThreadPool* pool) {
+    if (!pool)
+        return;
+
+    // 1. 取消所有挂起的任务
+    pool->clear();
+
+    // 2. 等待运行中的任务完成（最多 500ms）
+    if (!pool->waitForDone(500)) {
+        qWarning() << "Thread pool did not finish in 500ms, waiting for graceful shutdown";
+        // QThreadPool 没有强制停止正在运行的任务的方法
+        // 我们只能等待任务自然完成
+        pool->waitForDone(2000);
+    }
+
+    qDebug() << "Thread pool cleared";
 }
 
 }  // namespace EasyKiConverter

--- a/src/services/ExportService_Pipeline.h
+++ b/src/services/ExportService_Pipeline.h
@@ -104,6 +104,11 @@ public:
     bool waitForCompletion(int timeoutMs = 5000) override;
 
     /**
+     * @brief 强制清理所有线程池（用于退出时）
+     */
+    void forceCleanupThreadPools();
+
+    /**
      * @brief 设置预加载的数据
      *
      * @param data 预加载的数据映射 (ComponentId -> ComponentData)
@@ -136,6 +141,12 @@ public slots:
      * @brief 紧急清理（用于取消时的异步清理）
      */
     void emergencyCleanup();
+
+private:
+    /**
+     * @brief 清理指定的线程池
+     */
+    void clearThreadPool(QThreadPool* pool);
 
 private slots:
     /**

--- a/src/services/pipeline/queue/PipelineQueueManager.cpp
+++ b/src/services/pipeline/queue/PipelineQueueManager.cpp
@@ -29,42 +29,32 @@ bool PipelineQueueManager::safePush(StatusQueuePtr queue,
     if (!queue || isCancelled.loadAcquire())
         return false;
 
-    // 1. 快速尝试
+    // 1. 快速尝试（非阻塞）
     if (queue->tryPush(status))
         return true;
 
-    // 2. 指数退避策略
-    constexpr int MAX_RETRIES = 5;
-    constexpr int BASE_DELAY_MS = 10;
-    constexpr int MAX_TOTAL_TIMEOUT_MS = 500;
+    // 2. 使用简单的重试策略（移除指数退避和抖动）
+    constexpr int MAX_RETRIES = 3;
+    constexpr int RETRY_DELAY_MS = 10;
 
     int retryCount = 0;
-    int totalDelay = 0;
 
     while (retryCount < MAX_RETRIES) {
         if (isCancelled.loadAcquire())
             return false;
 
-        // 防止 UI 冻结
-        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+        // 短暂等待
+        QThread::msleep(RETRY_DELAY_MS);
 
         if (queue->tryPush(status)) {
             return true;
         }
 
-        int delay = BASE_DELAY_MS * (1 << retryCount);
-        delay += QRandomGenerator::global()->bounded(0, 20);  // 抖动
-
-        if (totalDelay + delay > MAX_TOTAL_TIMEOUT_MS) {
-            qWarning() << "PipelineQueueManager: Push timed out for" << status->componentId;
-            return false;
-        }
-
-        QThread::msleep(delay);
-        totalDelay += delay;
         retryCount++;
     }
 
+    // 3. 超时返回
+    qWarning() << "PipelineQueueManager: Push timed out for" << status->componentId;
     return false;
 }
 

--- a/src/services/pipeline/stage/FetchStageHandler.cpp
+++ b/src/services/pipeline/stage/FetchStageHandler.cpp
@@ -105,11 +105,33 @@ void FetchStageHandler::start() {
 
 void FetchStageHandler::stop() {
     QMutexLocker locker(&m_workerMutex);
+
+    qDebug() << "FetchStageHandler stopping, active workers:" << m_activeWorkers.size();
+
+    // 1. 标记所有 worker 为中止
     for (FetchWorker* worker : m_activeWorkers) {
-        if (worker)
+        if (worker) {
             worker->abort();
+        }
+    }
+
+    // 2. 等待所有 worker 完成（最多 200ms）
+    QElapsedTimer timer;
+    timer.start();
+
+    while (!m_activeWorkers.isEmpty() && timer.elapsed() < 200) {
+        QThread::msleep(10);
+        locker.unlock();  // 临时解锁允许 worker 完成
+        locker.relock();
+    }
+
+    // 3. 清空列表
+    if (!m_activeWorkers.isEmpty()) {
+        qWarning() << "FetchStageHandler: Some workers did not finish in 200ms";
     }
     m_activeWorkers.clear();
+
+    qDebug() << "FetchStageHandler stopped in" << timer.elapsed() << "ms";
 }
 
 void FetchStageHandler::onWorkerCompleted(QSharedPointer<ComponentExportStatus> status, FetchWorker* worker) {

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -19,7 +19,7 @@ ApplicationWindow {
     // 默认窗口位置居中显示（如果配置中没有保存的值）
     x: configService ? (configService.getWindowX() > 0 ? configService.getWindowX() : (Screen.desktopAvailableWidth - width) / 2) : (Screen.desktopAvailableWidth - width) / 2
     y: configService ? (configService.getWindowY() > 0 ? configService.getWindowY() : (Screen.desktopAvailableHeight - height) / 2) : (Screen.desktopAvailableHeight - height) / 2
-    
+
     // 最小窗口宽度计算：
     // - 导出设置卡片需要的最小宽度 = 760px（选项680px + 间距30px + 内边距48px + 边框2px）
     // - 卡片的左右外边距（AppStyle.spacing.huge * 2 = 30 * 2 = 60px）

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -9,17 +9,14 @@ ApplicationWindow {
     property int defaultWidth: Math.max(800, Screen.desktopAvailableWidth * 0.65)
     property int defaultHeight: Math.max(600, Screen.desktopAvailableHeight * 0.65)
     property int windowRadius: 10
-
     // 状态锁：防止重复触发关闭/最小化动画
     property bool isClosing: false
     property bool isMinimizing: false
-
     width: configService ? (configService.getWindowWidth() > 0 ? configService.getWindowWidth() : defaultWidth) : defaultWidth
     height: configService ? (configService.getWindowHeight() > 0 ? configService.getWindowHeight() : defaultHeight) : defaultHeight
     // 默认窗口位置居中显示（如果配置中没有保存的值）
     x: configService ? (configService.getWindowX() > 0 ? configService.getWindowX() : (Screen.desktopAvailableWidth - width) / 2) : (Screen.desktopAvailableWidth - width) / 2
     y: configService ? (configService.getWindowY() > 0 ? configService.getWindowY() : (Screen.desktopAvailableHeight - height) / 2) : (Screen.desktopAvailableHeight - height) / 2
-
     // 最小窗口宽度计算：
     // - 导出设置卡片需要的最小宽度 = 760px（选项680px + 间距30px + 内边距48px + 边框2px）
     // - 卡片的左右外边距（AppStyle.spacing.huge * 2 = 30 * 2 = 60px）
@@ -33,7 +30,6 @@ ApplicationWindow {
     color: "transparent"
     // 使用自定义标题栏，移除无效的系统按钮标志
     flags: Qt.Window | Qt.FramelessWindowHint | Qt.CustomizeWindowHint
-
     // 监听窗口可见性变化
     onVisibleChanged: {
         if (visible) {
@@ -50,7 +46,6 @@ ApplicationWindow {
             console.log("  width:", width, "height:", height);
             console.log("  x:", x, "y:", y);
             console.log("  visibility:", visibility);
-
             configService.setWindowWidth(width);
             configService.setWindowHeight(height);
             // 只在窗口不是最大化、全屏或最小化时保存位置
@@ -89,25 +84,15 @@ ApplicationWindow {
 
     Rectangle {
         id: exitAnimationLayer
-
         width: appWindow.width
-
         height: appWindow.height
-
         anchors.horizontalCenter: parent.horizontalCenter
-
         y: 0
-
         opacity: 0
-
         z: 1000
-
         visible: opacity > 0
-
         color: themeSettingsViewModel && themeSettingsViewModel.isDarkMode ? "#1a1a1a" : "#f5f5f5"
-
         radius: appWindow.windowRadius
-
         // 添加尺寸绑定，确保窗口大小改变时动画层同步更新
         Binding on width {
             when: exitAnimationLayer.opacity > 0
@@ -123,13 +108,9 @@ ApplicationWindow {
 
         transform: Scale {
             id: exitScale
-
             origin.x: (exitAnimationLayer.width || 800) / 2
-
             origin.y: exitAnimationLayer.height || 600
-
             xScale: 1.0
-
             yScale: 1.0
         }
 
@@ -137,45 +118,28 @@ ApplicationWindow {
 
         ParallelAnimation {
             id: exitWindowAnim
-
             running: false
-
             NumberAnimation {
-
                 target: exitAnimationLayer
-
                 property: "y"
-
                 to: appWindow.height
-
                 duration: 400
-
                 easing.type: Easing.InOutQuad
             }
 
             NumberAnimation {
-
                 target: exitScale
-
                 property: "xScale"
-
                 to: 0.1
-
                 duration: 400
-
                 easing.type: Easing.InOutQuad
             }
 
             NumberAnimation {
-
                 target: exitScale
-
                 property: "yScale"
-
                 to: 0.1
-
                 duration: 400
-
                 easing.type: Easing.InOutQuad
             }
         }
@@ -184,30 +148,20 @@ ApplicationWindow {
 
         Timer {
             id: exitAnimTimer
-
             interval: 450
-
             onTriggered: {
-
                 // 清理动画层
 
                 exitAnimationLayer.opacity = 0;
-
                 exitAnimationLayer.y = 0;
-
                 exitScale.xScale = 1.0;
-
                 exitScale.yScale = 1.0;
-
                 // 执行退出
 
                 saveWindowPosition();
-
                 exportProgressViewModel.handleCloseRequest();
-
                 // 重置状态锁
                 isClosing = false;
-
                 Qt.quit();
             }
         }
@@ -217,25 +171,15 @@ ApplicationWindow {
 
     Rectangle {
         id: minimizeAnimationLayer
-
         width: appWindow.width
-
         height: appWindow.height
-
         anchors.horizontalCenter: parent.horizontalCenter
-
         y: 0
-
         opacity: 0
-
         z: 1000
-
         visible: opacity > 0
-
         color: themeSettingsViewModel && themeSettingsViewModel.isDarkMode ? "#1a1a1a" : "#f5f5f5"
-
         radius: appWindow.windowRadius
-
         // 添加尺寸绑定，确保窗口大小改变时动画层同步更新
         Binding on width {
             when: minimizeAnimationLayer.opacity > 0
@@ -251,13 +195,9 @@ ApplicationWindow {
 
         transform: Scale {
             id: minimizeScale
-
             origin.x: (minimizeAnimationLayer.width || 800) / 2
-
             origin.y: minimizeAnimationLayer.height || 600
-
             xScale: 1.0
-
             yScale: 1.0
         }
 
@@ -265,45 +205,28 @@ ApplicationWindow {
 
         ParallelAnimation {
             id: minimizeWindowAnim
-
             running: false
-
             NumberAnimation {
-
                 target: minimizeAnimationLayer
-
                 property: "y"
-
                 to: appWindow.height
-
                 duration: 400
-
                 easing.type: Easing.InOutQuad
             }
 
             NumberAnimation {
-
                 target: minimizeScale
-
                 property: "xScale"
-
                 to: 0.1
-
                 duration: 400
-
                 easing.type: Easing.InOutQuad
             }
 
             NumberAnimation {
-
                 target: minimizeScale
-
                 property: "yScale"
-
                 to: 0.1
-
                 duration: 400
-
                 easing.type: Easing.InOutQuad
             }
         }
@@ -312,27 +235,18 @@ ApplicationWindow {
 
         Timer {
             id: minimizeAnimTimer
-
             interval: 450
-
             onTriggered: {
-
                 // 清理动画层
 
                 minimizeAnimationLayer.opacity = 0;
-
                 minimizeAnimationLayer.y = 0;
-
                 minimizeScale.xScale = 1.0;
-
                 minimizeScale.yScale = 1.0;
-
                 // 执行最小化
 
                 saveWindowPosition();
-
                 appWindow.showMinimized();
-
                 // 重置状态锁
                 isMinimizing = false;
             }
@@ -446,7 +360,6 @@ ApplicationWindow {
     Item {
         id: windowContent
         anchors.fill: parent
-
         // 加载主窗口内容
         Loader {
             id: mainWindowLoader

--- a/src/ui/qml/components/ComponentInputCard.qml
+++ b/src/ui/qml/components/ComponentInputCard.qml
@@ -19,7 +19,6 @@ Card {
             font.pixelSize: AppStyle.fontSizes.md
             color: AppStyle.colors.textPrimary
             placeholderTextColor: AppStyle.colors.textSecondary
-
             // 组件加载完成后自动设置焦点
             Component.onCompleted: {
                 Qt.callLater(function () {

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -50,6 +50,11 @@ Card {
                         componentListCard.componentListController.removeComponentById(itemData.componentId);
                     }
                 }
+                onRetryClicked: {
+                    if (itemData) {
+                        componentListCard.componentListController.refreshComponentInfo(index);
+                    }
+                }
             }
 
             // 过滤函数
@@ -144,6 +149,54 @@ Card {
 
             onTextChanged: {
                 visualModel.updateFilter();
+            }
+        }
+
+        // 重试所有验证失败元器件按钮
+        Item {
+            id: retryAllButton
+            Layout.preferredWidth: retryAllButtonContent.width + AppStyle.spacing.xl * 2
+            Layout.preferredHeight: 44
+            Layout.alignment: Qt.AlignVCenter
+            visible: componentListCard.componentListController ? componentListCard.componentListController.hasInvalidComponents : false
+            // 按钮背景
+            Rectangle {
+                anchors.fill: parent
+                color: retryAllButtonMouseArea.pressed ? AppStyle.colors.primaryHover : retryAllButtonMouseArea.containsMouse ? Qt.darker(AppStyle.colors.primary, 1.1) : AppStyle.colors.primary
+                radius: AppStyle.radius.md
+                opacity: 0.8
+                Behavior on color {
+                    ColorAnimation {
+                        duration: AppStyle.durations.fast
+                    }
+                }
+                Behavior on opacity {
+                    NumberAnimation {
+                        duration: AppStyle.durations.fast
+                    }
+                }
+            }
+
+            // 按钮文本
+            Text {
+                id: retryAllButtonContent
+                anchors.centerIn: parent
+                text: qsTranslate("MainWindow", "重试所有")
+                font.pixelSize: AppStyle.fontSizes.sm
+                color: "white"
+            }
+
+            // 鼠标区域
+            MouseArea {
+                id: retryAllButtonMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    if (componentListCard.componentListController) {
+                        componentListCard.componentListController.retryAllInvalidComponents();
+                    }
+                }
             }
         }
 

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -11,6 +11,7 @@ Rectangle {
     property string searchText: ""
     signal deleteClicked
     signal copyClicked
+    signal retryClicked
     height: 64 // 增加高度以容纳缩略图和更多信息
     // 悬停效果
     color: itemMouseArea.containsMouse ? AppStyle.colors.background : AppStyle.colors.surface
@@ -75,14 +76,12 @@ Rectangle {
         anchors.fill: parent
         anchors.margins: AppStyle.spacing.sm
         spacing: AppStyle.spacing.md
-
         // 预览图区域 - 支持悬停放大
         Item {
             id: previewArea
             Layout.preferredWidth: 48
             Layout.preferredHeight: 48
             Layout.alignment: Qt.AlignVCenter
-
             // 默认显示的单张缩略图
             Rectangle {
                 id: defaultThumbnail
@@ -93,7 +92,6 @@ Rectangle {
                 border.color: AppStyle.colors.border
                 border.width: 1
                 clip: true
-
                 Image {
                     anchors.centerIn: parent
                     width: 46
@@ -136,24 +134,19 @@ Rectangle {
                 modal: false
                 focus: false
                 dim: false
-
                 // 智能位置计算：检测是否超出窗口边界
                 onVisibleChanged: {
                     if (visible) {
                         // 获取缩略图在屏幕上的位置
                         var thumbGlobalPos = defaultThumbnail.mapToGlobal(Qt.point(0, 0));
-
                         // 获取窗口在屏幕上的位置
                         var window = item.Window.window;
                         var windowGlobalX = window ? window.x : 0;
                         var windowWidth = window ? window.width : item.width;
-
                         // 计算缩略图相对于窗口的位置
                         var thumbRelativeX = thumbGlobalPos.x - windowGlobalX;
-
                         // 预览图宽度（490）+ 间距（60）= 550
                         var popupWidth = width + 60;
-
                         // 如果右侧空间不足，显示在左侧
                         if (thumbRelativeX + popupWidth > windowWidth) {
                             x = -540; // 显示在缩略图左侧
@@ -189,7 +182,6 @@ Rectangle {
                     border.color: AppStyle.colors.primary
                     border.width: 2
                     radius: AppStyle.radius.md
-
                     // 阴影效果
                     layer.enabled: true
                     layer.effect: MultiEffect {
@@ -205,10 +197,8 @@ Rectangle {
                     anchors.fill: parent
                     anchors.margins: 10
                     spacing: 10
-
                     Repeater {
                         model: itemData ? itemData.previewImageCount : 0
-
                         Rectangle {
                             width: 150
                             height: 150
@@ -217,10 +207,8 @@ Rectangle {
                             border.color: AppStyle.colors.border
                             border.width: 1
                             clip: true
-
                             property bool imageLoaded: false
                             property bool loadTriggered: false
-
                             // 延迟加载触发器
                             Timer {
                                 id: loadDelayTimer
@@ -255,7 +243,6 @@ Rectangle {
                                 cache: true
                                 asynchronous: true
                                 visible: parent.loadTriggered && parent.imageLoaded
-
                                 onStatusChanged: {
                                     if (status === Image.Ready) {
                                         parent.imageLoaded = true;
@@ -280,7 +267,6 @@ Rectangle {
                                 color: AppStyle.colors.background
                                 radius: AppStyle.radius.md
                                 visible: !parent.loadTriggered
-
                                 Text {
                                     anchors.centerIn: parent
                                     text: index + 1
@@ -401,7 +387,38 @@ Rectangle {
                 elide: Text.ElideRight
             }
         }
-
+        // 重试按钮（仅对验证失败的元器件显示）
+        Button {
+            Layout.preferredWidth: 28
+            Layout.preferredHeight: 28
+            Layout.alignment: Qt.AlignVCenter
+            visible: itemData && !itemData.isValid && !itemData.isFetching
+            background: Rectangle {
+                color: parent.pressed ? AppStyle.colors.primaryHover : parent.hovered ? "#dbeafe" : "transparent"
+                radius: AppStyle.radius.sm
+                Behavior on color {
+                    ColorAnimation {
+                        duration: AppStyle.durations.fast
+                    }
+                }
+            }
+            contentItem: Text {
+                text: "↻"
+                font.pixelSize: AppStyle.fontSizes.xxl
+                font.bold: true
+                color: parent.pressed ? AppStyle.colors.primaryPressed : parent.hovered ? AppStyle.colors.primary : AppStyle.colors.primary
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                Behavior on color {
+                    ColorAnimation {
+                        duration: AppStyle.durations.fast
+                    }
+                }
+            }
+            onClicked: {
+                item.retryClicked();
+            }
+        }
         // 删除按钮
         Button {
             Layout.preferredWidth: 28

--- a/src/ui/qml/components/ConfirmDialog.qml
+++ b/src/ui/qml/components/ConfirmDialog.qml
@@ -87,7 +87,6 @@ Item {
         scale: 0.9
         opacity: 0
         y: 0
-
         transform: Translate {
             id: dialogBoxTranslate
             y: 0

--- a/src/ui/qml/components/ExitDialog.qml
+++ b/src/ui/qml/components/ExitDialog.qml
@@ -26,36 +26,29 @@ FocusScope {
     visible: false
     z: 9999
     focus: visible  // 当对话框可见时接收焦点
-
     // 常量
     readonly property int buttonHeight: 48
     readonly property real sliderOpacity: 0.25
-
     // 属性
     property bool rememberChoice: false
     property Item activeButton: null  // 当前活跃的按钮
     property Item selectedButton: exitButton  // 当前键盘选中的按钮，默认为退出按钮
     property string focusArea: "button"  // 当前聚焦区域："button" 或 "checkbox"，默认为按钮
-
     // 信号
     signal minimizeToTray(bool remember)
     signal exitApp(bool remember)
     signal canceled
-
     // 更新滑块位置
     function updateSlider(targetButton, targetColor) {
         // 计算按钮在 buttonBox 中的相对位置
         var buttonY = targetButton.mapToItem(buttonBox, 0, 0).y;
-
         // 果冻拉伸效果：向下移动时轻微压缩高度
         var centerY = buttonBox.height / 2;
         var stretchFactor = 1.0 + Math.abs(buttonY - centerY) / centerY * 0.02;
-
         sliderBackground.y = buttonY;
         sliderBackground.height = buttonHeight * (2.0 - stretchFactor);  // 使用常量
         sliderBackground.color = targetColor;
         sliderBackground.opacity = sliderOpacity;  // 使用常量
-
         // 更新活跃按钮
         activeButton = targetButton;
     }
@@ -104,7 +97,6 @@ FocusScope {
         scale: 1.0
         opacity: 1.0
         rotation: 0
-
         transform: Translate {
             id: dialogBoxTranslate
             y: 0
@@ -141,7 +133,6 @@ FocusScope {
             anchors.fill: parent
             anchors.margins: AppStyle.spacing.xxxl
             spacing: AppStyle.spacing.lg
-
             // 标题
             Text {
                 text: qsTr("关闭程序")
@@ -173,7 +164,6 @@ FocusScope {
                 radius: AppStyle.radius.lg
                 border.color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.1) : Qt.rgba(0, 0, 0, 0.08)
                 border.width: 1
-
                 // 滑块背景（果冻效果）
                 Rectangle {
                     id: sliderBackground
@@ -185,7 +175,6 @@ FocusScope {
                     color: AppStyle.colors.primary
                     opacity: 0
                     z: 2
-
                     // Q弹动画（弹簧效果 - 垂直移动）
                     Behavior on y {
                         enabled: sliderBackground.visible
@@ -243,12 +232,10 @@ FocusScope {
                     anchors.bottomMargin: AppStyle.spacing.sm
                     spacing: 0
                     z: 1
-
                     // 最小化到托盘
                     Item {
                         Layout.fillWidth: true
                         Layout.preferredHeight: buttonHeight  // 使用常量
-
                         ModernButton {
                             id: minimizeButton
                             anchors.fill: parent
@@ -257,7 +244,6 @@ FocusScope {
                             // 动态文本颜色：当滑块在上方时变亮，键盘选中时使用不同颜色
                             textColor: root.activeButton === minimizeButton ? Qt.lighter(AppStyle.colors.primary, 1.3) : (root.selectedButton === minimizeButton ? AppStyle.colors.primary : AppStyle.colors.textPrimary)
                             hoverColor: "transparent"
-
                             // 文本颜色渐变动画
                             Behavior on textColor {
                                 ColorAnimation {
@@ -301,7 +287,6 @@ FocusScope {
                     Item {
                         Layout.fillWidth: true
                         Layout.preferredHeight: buttonHeight  // 使用常量
-
                         ModernButton {
                             id: exitButton
                             anchors.fill: parent
@@ -310,7 +295,6 @@ FocusScope {
                             // 动态文本颜色：当滑块在上方时变亮
                             textColor: root.activeButton === exitButton ? Qt.lighter(AppStyle.colors.danger, 1.3) : (root.selectedButton === exitButton ? AppStyle.colors.danger : AppStyle.colors.textPrimary)
                             hoverColor: "transparent"
-
                             // 文本颜色渐变动画
                             Behavior on textColor {
                                 ColorAnimation {
@@ -354,7 +338,6 @@ FocusScope {
                     Item {
                         Layout.fillWidth: true
                         Layout.preferredHeight: buttonHeight  // 使用常量
-
                         ModernButton {
                             id: cancelButton
                             anchors.fill: parent
@@ -363,7 +346,6 @@ FocusScope {
                             // 动态文本颜色：当滑块在上方时变亮
                             textColor: root.activeButton === cancelButton ? Qt.lighter(AppStyle.colors.textSecondary, 1.5) : (root.selectedButton === cancelButton ? AppStyle.colors.textSecondary : AppStyle.colors.textPrimary)
                             hoverColor: "transparent"
-
                             // 文本颜色渐变动画
                             Behavior on textColor {
                                 ColorAnimation {
@@ -404,7 +386,6 @@ FocusScope {
                 Layout.fillWidth: true
                 Layout.topMargin: AppStyle.spacing.md
                 spacing: AppStyle.spacing.sm
-
                 CheckBox {
                     id: rememberCheckBox
                     checked: root.rememberChoice  // 双向绑定
@@ -449,11 +430,8 @@ FocusScope {
                 }
 
                 Text {
-
                     text: qsTr("记住我的选择")
-
                     font.pixelSize: AppStyle.fontSizes.sm
-
                     color: AppStyle.colors.textSecondary
                 }
             }
@@ -545,61 +523,38 @@ FocusScope {
 
     SequentialAnimation {
         id: hideAnim
-
         ParallelAnimation {
-
             NumberAnimation {
-
                 target: dialogBox
-
                 property: "opacity"
-
                 from: 1
-
                 to: 0
-
                 duration: 200
-
                 easing.type: Easing.OutQuad
             }
 
             NumberAnimation {
-
                 target: dialogBoxTranslate
-
                 property: "y"
-
                 from: 0
-
                 to: root.height
-
                 duration: 200
-
                 easing.type: Easing.OutQuad
             }
 
             NumberAnimation {
-
                 target: dialogBox
-
                 property: "scale"
-
                 from: 1.0
-
                 to: 0.9
-
                 duration: 200
-
                 easing.type: Easing.OutQuad
             }
         }
 
         PropertyAction {
-
             target: root
-
             property: "visible"
-
             value: false
         }
     }

--- a/src/ui/qml/components/ExportButtonsSection.qml
+++ b/src/ui/qml/components/ExportButtonsSection.qml
@@ -11,7 +11,6 @@ ColumnLayout {
     property var exportSettingsController
     property var componentListController
     spacing: AppStyle.spacing.md
-
     // 错误提示对话框
     Dialog {
         id: errorDialog
@@ -19,7 +18,6 @@ ColumnLayout {
         modal: true
         title: qsTranslate("MainWindow", "错误")
         anchors.centerIn: parent
-
         contentItem: Text {
             text: qsTranslate("MainWindow", "打开导出目录失败，请检查导出路径是否存在。")
             font.pixelSize: AppStyle.fontSizes.md
@@ -37,7 +35,6 @@ ColumnLayout {
         }
 
         standardButtons: Dialog.Ok
-
         onAccepted: {
             close();
         }

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -128,7 +128,6 @@ Card {
         Layout.columnSpan: 10  // 跨越10列
         Layout.preferredHeight: exportOptionsLayout.implicitHeight
         Layout.minimumWidth: ResponsiveHelper.minimumWindowWidth  // 使用计算的最小窗口宽度
-
         RowLayout {
             id: exportOptionsLayout
             anchors.fill: parent

--- a/src/ui/qml/components/HeaderSection.qml
+++ b/src/ui/qml/components/HeaderSection.qml
@@ -48,7 +48,6 @@ ColumnLayout {
             ]
             textRole: "text"
             valueRole: "value"
-
             // 直接绑定到 LanguageManager.currentLanguage，避免手动设置
             currentIndex: {
                 var lang = LanguageManager.currentLanguage;
@@ -133,7 +132,6 @@ ColumnLayout {
                 width: languageComboBox.width
                 implicitHeight: listview.contentHeight
                 padding: 0
-
                 contentItem: ListView {
                     id: listview
                     clip: true

--- a/src/ui/qml/components/ResultListItem.qml
+++ b/src/ui/qml/components/ResultListItem.qml
@@ -173,37 +173,70 @@ Rectangle {
             }
         }
         // 重试按钮
-        Button {
+        Item {
+            id: retryButton
             visible: status === "failed" || status.indexOf("fail") !== -1
-            Layout.preferredWidth: 30
-            Layout.preferredHeight: 30
-            flat: true
-            contentItem: Text {
-                text: "↺"
-                font.pixelSize: 20
+            Layout.preferredWidth: 28
+            Layout.preferredHeight: 28
+            Layout.alignment: Qt.AlignVCenter
+            Rectangle {
+                anchors.fill: parent
+                color: retryButtonHovered ? AppStyle.colors.warningLight : "transparent"
+                radius: AppStyle.radius.sm
+                Behavior on color {
+                    ColorAnimation {
+                        duration: AppStyle.durations.fast
+                    }
+                }
+            }
+            Text {
+                anchors.centerIn: parent
+                text: "↻"
+                font.pixelSize: AppStyle.fontSizes.xxl
+                font.bold: true
                 color: AppStyle.colors.warning
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
             }
-
-            background: Rectangle {
-                color: parent.hovered ? (AppStyle.isDarkMode ? "#33f59e0b" : AppStyle.colors.warningLight) : "transparent"
-                radius: 15
-            }
-
-            ToolTip.visible: hovered
+            ToolTip.visible: retryButtonHovered
             ToolTip.text: qsTr("重试")
             ToolTip.delay: 500
-            onClicked: item.retryClicked()
         }
     }
+
+    // 追踪重试按钮悬停状态
+    property bool retryButtonHovered: false
     MouseArea {
         id: itemMouseArea
         anchors.fill: parent
         hoverEnabled: true
         cursorShape: Qt.ArrowCursor
-        acceptedButtons: Qt.RightButton | Qt.LeftButton // 同时响应右键和左键
+        acceptedButtons: Qt.RightButton | Qt.LeftButton
+        onMouseXChanged: {
+            // 检查鼠标是否在重试按钮区域
+            if (retryButton.visible) {
+                var retryBtnX = item.width - AppStyle.spacing.lg - retryButton.width;
+                var retryBtnY = (item.height - retryButton.height) / 2;
+                if (mouseX >= retryBtnX && mouseX <= retryBtnX + retryButton.width && mouseY >= retryBtnY && mouseY <= retryBtnY + retryButton.height) {
+                    retryButtonHovered = true;
+                } else {
+                    retryButtonHovered = false;
+                }
+            } else {
+                retryButtonHovered = false;
+            }
+        }
+
         onClicked: mouse => {
+            // 检查是否点击在重试按钮区域
+            if (retryButton.visible) {
+                var retryBtnX = item.width - AppStyle.spacing.lg - retryButton.width;
+                var retryBtnY = (item.height - retryButton.height) / 2;
+                if (mouse.x >= retryBtnX && mouse.x <= retryBtnX + retryButton.width && mouse.y >= retryBtnY && mouse.y <= retryBtnY + retryButton.height) {
+                    // 点击在重试按钮区域，调用重试功能
+                    item.retryClicked();
+                    return;
+                }
+            }
+
             // 右键点击复制 ID
             if (mouse.button === Qt.RightButton) {
                 if (componentId) {

--- a/src/ui/qml/styles/ResponsiveHelper.qml
+++ b/src/ui/qml/styles/ResponsiveHelper.qml
@@ -5,21 +5,16 @@ import QtQuick.Window
 QtObject {
     // DPI 缩放因子（基于设备像素比，使用保守的缩放策略）
     readonly property real scaleFactor: Math.min(Screen.devicePixelRatio > 0 ? Screen.devicePixelRatio : 1.0, 1.5)
-
     // 当前窗口宽度
     readonly property int currentWindowWidth: Window.window ? Window.window.width : 1200
-
     // 基准窗口宽度（用于计算间距比例）
     readonly property int baseWindowWidth: 1200
-
     // 最小和最大间距
     readonly property int minSpacing: 6
     readonly property int maxSpacing: 40
-
     // 窗口宽度范围（用于计算间距比例）
     readonly property int minWidthForMinSpacing: 800
     readonly property int maxWidthForMaxSpacing: 2000
-
     // 计算动态间距（基于窗口宽度，不换行）
     readonly property var spacing: QtObject {
         // 动态间距因子（0.0 - 1.0），根据窗口宽度计算
@@ -33,16 +28,12 @@ QtObject {
 
         // xs 间距（极小间距，用于紧凑布局）
         readonly property int xs: Math.round(minSpacing + widthRatio * (minSpacing * 0.5))
-
         // sm 间距（小间距，用于一般间距）
         readonly property int sm: Math.round(minSpacing * 1.5 + widthRatio * (minSpacing * 0.8))
-
         // md 间距（中等间距，用于主要间距）
         readonly property int md: Math.round(minSpacing * 2.0 + widthRatio * (minSpacing * 1.0))
-
         // lg 间距（大间距，用于主要分组）
         readonly property int lg: Math.round(minSpacing * 2.5 + widthRatio * (minSpacing * 1.2))
-
         // xl 间距（超大间距，用于大分组）
         readonly property int xl: Math.round(minSpacing * 3.0 + widthRatio * (minSpacing * 1.4))
     }
@@ -58,10 +49,8 @@ QtObject {
 
     // 导出选项的固定列数（始终6列，不换行）
     readonly property int exportOptionColumns: 6
-
     // 导出选项的最小宽度（紧凑模式）
     readonly property int exportOptionMinWidth: 100
-
     // 导出模式选项的最小宽度（需要包含说明文字，但在窄窗口下允许压缩）
     readonly property int exportModeOptionMinWidth: {
         if (currentWindowWidth <= 0)
@@ -94,16 +83,12 @@ QtObject {
     readonly property int minimumWindowWidth: {
         // 6个选项的最小宽度总和
         var optionsMinWidth = 80 * 5 + 280; // 5个普通选项80px + 导出模式280px
-
         // 5个间距的最小值
         var spacingMinWidth = minSpacing * 5;
-
         // 卡片的左右内边距（AppStyle.spacing.xl ≈ 24px）
         var cardPadding = 24 * 2;
-
         // 卡片的边框（1px * 2）
         var cardBorder = 2;
-
         // 最小窗口宽度 = 选项宽度 + 间距 + 内边距 + 边框
         return optionsMinWidth + spacingMinWidth + cardPadding + cardBorder;
     }

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -152,6 +152,9 @@ void ComponentListViewModel::removeComponent(int index) {
         delete item;
         endRemoveRows();
 
+        // 更新 hasInvalidComponents 状态
+        updateHasInvalidComponents();
+
         emit componentCountChanged();
         emit componentRemoved(removedId);
     }
@@ -178,6 +181,9 @@ void ComponentListViewModel::clearComponentList() {
         m_componentList.clear();
         m_componentIdIndex.clear();  // 清空索引
         endResetModel();
+
+        // 更新 hasInvalidComponents 状态
+        updateHasInvalidComponents();
 
         emit componentCountChanged();
         emit listCleared();
@@ -397,6 +403,9 @@ void ComponentListViewModel::handleCadDataReady(const QString& componentId, cons
         item->setValid(true);
         item->setErrorMessage("");
 
+        // 更新 hasInvalidComponents 状态
+        updateHasInvalidComponents();
+
         // 异步生成缩略图 - 使用 QPointer 防止悬垂指针
         QPointer<ComponentListItemData> safeItem = item;
         QThreadPool::globalInstance()->start(QRunnable::create([safeItem, dataPtr]() {
@@ -426,19 +435,35 @@ void ComponentListViewModel::handleModel3DReady(const QString& uuid, const QStri
 
 void ComponentListViewModel::handleFetchError(const QString& componentId, const QString& error) {
     qWarning() << "Fetch error for:" << componentId << "-" << error;
+
     auto item = findItemData(componentId);
+
     if (item) {
         item->setFetching(false);
-        // 如果是严重错误（如404），标记为无效
-        if (error.contains("404") || error.contains("not found", Qt::CaseInsensitive)) {
+
+        // 如果是验证失败（如"No result"、"404"、"not found"），标记为无效
+
+        if (error.contains("No result", Qt::CaseInsensitive) ||
+
+            error.contains("404") ||
+
+            error.contains("not found", Qt::CaseInsensitive)) {
             item->setValid(false);
-            item->setErrorMessage("Not Found");
+
+            item->setErrorMessage("元件不存在");
+
         } else {
             item->setErrorMessage(error);
         }
 
+        // 更新 hasInvalidComponents 状态
+
+        updateHasInvalidComponents();
+
         // 添加到防抖集合
+
         m_pendingUpdateIndices.insert(componentId);
+
         m_debounceTimer->start();
     }
 }
@@ -566,6 +591,17 @@ void ComponentListViewModel::refreshComponentInfo(int index) {
     }
 }
 
+void ComponentListViewModel::retryAllInvalidComponents() {
+    for (int i = 0; i < m_componentList.count(); ++i) {
+        auto item = m_componentList.at(i);
+        if (item && !item->isValid() && !item->isFetching()) {
+            item->setFetching(true);
+            item->setErrorMessage("");
+            m_service->fetchComponentData(item->componentId(), false);
+        }
+    }
+}
+
 QStringList ComponentListViewModel::getAllComponentIds() const {
     QStringList ids;
     for (const auto& item : m_componentList) {
@@ -586,6 +622,20 @@ void ComponentListViewModel::copyToClipboard(const QString& text) {
     QClipboard* clipboard = QGuiApplication::clipboard();
     clipboard->setText(text);
     qDebug() << "Copied to clipboard:" << text;
+}
+
+void ComponentListViewModel::updateHasInvalidComponents() {
+    bool hasInvalid = false;
+    for (const auto& item : m_componentList) {
+        if (item && !item->isValid() && !item->isFetching()) {
+            hasInvalid = true;
+            break;
+        }
+    }
+    if (hasInvalid != m_hasInvalidComponents) {
+        m_hasInvalidComponents = hasInvalid;
+        emit hasInvalidComponentsChanged();
+    }
 }
 
 }  // namespace EasyKiConverter

--- a/src/ui/viewmodels/ComponentListViewModel.h
+++ b/src/ui/viewmodels/ComponentListViewModel.h
@@ -24,6 +24,7 @@ class ComponentListViewModel : public QAbstractListModel {
     Q_PROPERTY(int componentCount READ componentCount NOTIFY componentCountChanged)
     Q_PROPERTY(QString bomFilePath READ bomFilePath NOTIFY bomFilePathChanged)
     Q_PROPERTY(QString bomResult READ bomResult NOTIFY bomResultChanged)
+    Q_PROPERTY(bool hasInvalidComponents READ hasInvalidComponents NOTIFY hasInvalidComponentsChanged)
 
 public:
     enum ComponentRoles { ItemDataRole = Qt::UserRole + 1 };
@@ -56,6 +57,10 @@ public:
 
     QString bomResult() const {
         return m_bomResult;
+    }
+
+    bool hasInvalidComponents() const {
+        return m_hasInvalidComponents;
     }
 
     // 获取预加载的数据（用于导出流程）
@@ -142,6 +147,11 @@ public slots:
     Q_INVOKABLE void refreshComponentInfo(int index);
 
     /**
+     * @brief 重试所有验证失败的元器件
+     */
+    Q_INVOKABLE void retryAllInvalidComponents();
+
+    /**
      * @brief 获取所有元件ID列表
      * @return QStringList 元件ID列表
      */
@@ -159,6 +169,7 @@ signals:
     void componentCountChanged();
     void bomFilePathChanged();
     void bomResultChanged();
+    void hasInvalidComponentsChanged();
     void componentAdded(const QString& componentId, bool success, const QString& message);
     void componentRemoved(const QString& componentId);
     void listCleared();
@@ -264,6 +275,9 @@ private:
     // 查找列表项数据
     ComponentListItemData* findItemData(const QString& componentId) const;
 
+    // 更新 hasInvalidComponents 状态
+    void updateHasInvalidComponents();
+
 private:
     ComponentService* m_service;
     QList<ComponentListItemData*> m_componentList;
@@ -271,6 +285,7 @@ private:
     QString m_outputPath;
     QString m_bomFilePath;
     QString m_bomResult;
+    bool m_hasInvalidComponents = false;
 
     // 防抖定时器，用于减少频繁的 UI 更新
     QTimer* m_debounceTimer;

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -228,22 +228,17 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
 bool ExportProgressViewModel::handleCloseRequest() {
     // 如果正在导出，先尝试停止
     if (m_isExporting && m_exportService) {
-        qDebug() << "Close requested while exporting. Initiating cancel sequence...";
+        qDebug() << "Close requested while exporting. Initiating immediate cancel...";
 
-        // 1. 发送取消信号
+        // 1. 发送取消信号（cancelExport 会自动清理线程池）
         cancelExport();
 
-        // 2. 尝试等待一段时间让 Worker 结束 (最多 5 秒)
-        // 注意：这里不能使用 processEvents，否则可能会导致递归调用或其他 UI 问题
-        // 我们依靠 ExportService::waitForCompletion 来进行有限的等待
-        if (!m_exportService->waitForCompletion(5000)) {
-            qWarning() << "Workers did not stop within timeout, forcing close.";
-        } else {
-            qDebug() << "All workers stopped gracefully.";
-        }
+        // 2. 确保状态重置
+        m_isExporting = false;
+        m_isStopping = false;
     }
 
-    return true;  // 允许关闭
+    return true;
 }
 
 void ExportProgressViewModel::cancelExport() {

--- a/src/workers/FetchWorker.cpp
+++ b/src/workers/FetchWorker.cpp
@@ -5,12 +5,14 @@
 #include <QEventLoop>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMetaObject>
 #include <QMutex>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QThread>
 #include <QTimer>
 
+#include <memory>
 #include <zlib.h>
 
 namespace EasyKiConverter {
@@ -93,20 +95,14 @@ void FetchWorker::run() {
 
     // 使用线程局部存储缓存 QNetworkAccessManager
     // 避免为每个任务重复创建和销毁 QNAM（这是非常昂贵的操作）
-    static thread_local QNetworkAccessManager* threadQNAM = nullptr;
-    static thread_local bool threadQNAMInitialized = false;
+    // 修复：使用 std::unique_ptr 管理线程局部 QNetworkAccessManager 生命周期
+    static thread_local std::unique_ptr<QNetworkAccessManager> threadQNAM = nullptr;
 
-    if (!threadQNAMInitialized) {
-        threadQNAM = new QNetworkAccessManager();
-        threadQNAMInitialized = true;
-
-        // 修复：移除 QThread::finished 清理逻辑
-        // 原因：在低带宽环境下，活跃的 QNetworkReply 可能仍在使用这个 QNAM
-        // 过早删除会导致段错误。让 QNetworkAccessManager 随线程生命周期自然结束。
-
+    if (!threadQNAM) {
+        threadQNAM = std::make_unique<QNetworkAccessManager>();
         qDebug() << "Created thread-local QNetworkAccessManager for thread:" << QThread::currentThreadId();
     }
-    m_ownNetworkManager = threadQNAM;
+    m_ownNetworkManager = threadQNAM.get();
 
     bool hasError = false;
     QString errorMessage;
@@ -703,7 +699,8 @@ void FetchWorker::abort() {
     QMutexLocker locker(&m_replyMutex);
     if (m_currentReply) {
         qDebug() << "Aborting network request for component:" << m_componentId;
-        m_currentReply->abort();
+        // 安全：使用 Qt::QueuedConnection 确保在正确线程执行 abort()
+        QMetaObject::invokeMethod(m_currentReply, "abort", Qt::QueuedConnection);
     }
 }
 

--- a/src/workers/FetchWorker.cpp
+++ b/src/workers/FetchWorker.cpp
@@ -1,5 +1,6 @@
 #include "FetchWorker.h"
 
+#include <QCoreApplication>
 #include <QDateTime>
 #include <QElapsedTimer>
 #include <QEventLoop>
@@ -101,6 +102,7 @@ void FetchWorker::run() {
     if (!threadQNAM) {
         threadQNAM = std::make_unique<QNetworkAccessManager>();
         qDebug() << "Created thread-local QNetworkAccessManager for thread:" << QThread::currentThreadId();
+        // 注意：线程局部存储的 unique_ptr 会在线程退出时自动清理，不需要手动清理
     }
     m_ownNetworkManager = threadQNAM.get();
 
@@ -695,12 +697,25 @@ bool FetchWorker::fetch3DModelData(QSharedPointer<ComponentExportStatus> status)
 }
 
 void FetchWorker::abort() {
-    m_isAborted.storeRelaxed(1);
-    QMutexLocker locker(&m_replyMutex);
-    if (m_currentReply) {
-        qDebug() << "Aborting network request for component:" << m_componentId;
-        // 安全：使用 Qt::QueuedConnection 确保在正确线程执行 abort()
-        QMetaObject::invokeMethod(m_currentReply, "abort", Qt::QueuedConnection);
+    // 使用原子操作确保只执行一次
+    if (m_isAborted.testAndSetRelaxed(0, 1)) {
+        qDebug() << "FetchWorker abort requested for:" << m_componentId;
+
+        // 使用互斥锁保护 m_currentReply 的访问
+        QMutexLocker locker(&m_replyMutex);
+
+        // 直接 abort，不使用跨线程调用
+        // 注意：不调用 deleteLater()，因为 QSharedPointer 的删除器已经处理了清理
+        if (m_currentReply && !m_currentReply->isFinished()) {
+            m_currentReply->abort();
+            // m_currentReply 由 QSharedPointer 管理，不需要手动 deleteLater
+        }
+        m_currentReply = nullptr;
+
+        // 清理网络管理器
+        if (m_ownNetworkManager) {
+            m_ownNetworkManager->clearConnectionCache();
+        }
     }
 }
 

--- a/tools/python/manage_version.py
+++ b/tools/python/manage_version.py
@@ -49,6 +49,9 @@ VCPKG_JSON_PATH = os.path.join(PROJECT_ROOT, "vcpkg.json")
 CMAKE_LISTS_PATH = os.path.join(PROJECT_ROOT, "CMakeLists.txt")
 MAIN_CPP_PATH = os.path.join(PROJECT_ROOT, "src", "main.cpp")
 METAINFO_XML_PATH = os.path.join(PROJECT_ROOT, "deploy", "metainfo", "io.github.tangsangsimida.easykiconverter.metainfo.xml")
+MKDOCS_YAML_PATH = os.path.join(PROJECT_ROOT, "mkdocs.yml")
+APPX_MANIFEST_PATH = os.path.join(PROJECT_ROOT, "deploy", "windows", "AppxManifest.xml")
+FLATPAK_MANIFEST_PATH = os.path.join(PROJECT_ROOT, "deploy", "flatpak", "io.github.tangsangsimida.easykiconverter.yml")
 
 def get_current_version():
     """
@@ -198,21 +201,24 @@ def update_cmake_lists(new_version, force=False):
         with open(CMAKE_LISTS_PATH, "r", encoding="utf-8") as f:
             content = f.read()
 
-        # 1. 更新 VERSION_FROM_CI默认值
-        # set(VERSION_FROM_CI "0.1")
+        # 1. 更新 VERSION_FROM_CI 默认值
+        # set(VERSION_FROM_CI "3.0.13")
         pattern1 = r'(set\(VERSION_FROM_CI\s+")([^"]+)("\))'
-        replacement1 = f'\\g<1>{new_version}\\g<3>'
-        content = re.sub(pattern1, replacement1, content)
+        content = re.sub(pattern1, f'\\g<1>{new_version}\\g<3>', content)
 
         # 2. 更新 qt_add_qml_module 中的 VERSION (只保留 Major.Minor)
-        # VERSION 1.0
+        # VERSION 3.0
         major_minor = ".".join(new_version.split(".")[:2])
+        pattern2 = r'(qt_add_qml_module\(appEasyKiconverter_Cpp_Version.*?VERSION\s+)(\d+\.\d+)'
+        content = re.sub(pattern2, f'\\g<1>{major_minor}', content, flags=re.DOTALL)
 
-        # 使用正则替换 qt_add_qml_module 中的 VERSION
-        pattern_qml_block = r'(qt_add_qml_module\(appEasyKiconverter_Cpp_Version.*?VERSION\s+)(\d+\.\d+)'
-        new_content = re.sub(pattern_qml_block, f'\\g<1>{major_minor}', content, flags=re.DOTALL)
+        # 3. 更新 project() 中的 VERSION (如果存在显式指定)
+        # project(EasyKiconverter_Cpp_Version VERSION 3.0.13 LANGUAGES CXX)
+        # 注意：这个通常由 PROJECT_VERSION_SANITIZED 动态生成，但如果有硬编码也需要更新
+        pattern3 = r'(project\(EasyKiconverter_Cpp_Version\s+VERSION\s+)(\d+\.\d+\.\d+)(\s+LANGUAGES)'
+        content = re.sub(pattern3, f'\\g<1>{new_version}\\g<3>', content)
 
-        if content == new_content:
+        if content == content:
             if force:
                 print(f"  ✓ {CMAKE_LISTS_PATH} 版本已经是 {new_version}")
                 return True
@@ -221,12 +227,12 @@ def update_cmake_lists(new_version, force=False):
                 return False
         else:
             with open(CMAKE_LISTS_PATH, "w", encoding="utf-8") as f:
-                f.write(new_content)
-            print(f"  ✓ 成功更新 {CMAKE_LISTS_PATH}")
+                f.write(content)
+            print(f"  ✓ 成功更新 {CMake_LISTS_PATH}")
             return True
 
     except Exception as e:
-        print(f"  ✗ 更新 {CMAKE_LISTS_PATH} 失败: {e}")
+        print(f"  ✗ 更新 {CMake_LISTS_PATH} 失败: {e}")
         import traceback
         traceback.print_exc()
         return False
@@ -546,6 +552,138 @@ def generate_release_description(old_version, new_version, commits):
 
     return "\n".join(xml_parts)
 
+def update_mkdocs_yaml(new_version, force=False):
+    """更新 mkdocs.yml 中的版本号"""
+    print(f"正在更新 {MKDOCS_YAML_PATH}...")
+
+    # 检查版本是否已经是目标版本（除非是强制模式）
+    if not force:
+        check_result = check_mkdocs_version(new_version)
+        if check_result is True:
+            print(f"  ✓ {MKDOCS_YAML_PATH} 版本已经是 {new_version}，跳过更新")
+            return True
+        elif check_result is None:
+            print(f"  ✗ 无法检查 {MKDOCS_YAML_PATH} 版本")
+            return False
+
+    try:
+        with open(MKDOCS_YAML_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # 更新 extra.version
+        # extra:
+        #   version: 3.0.5
+        pattern = r'(extra:\s*\n\s*version:\s*)([^\s\n]+)'
+        replacement = f'\\g<1>{new_version}'
+        new_content = re.sub(pattern, replacement, content)
+
+        if content == new_content:
+            if force:
+                print(f"  ✓ {MKDOCS_YAML_PATH} 版本已经是 {new_version}")
+                return True
+            else:
+                print(f"  ✗ {MKDOCS_YAML_PATH} 未发生变化")
+                return False
+        else:
+            with open(MKDOCS_YAML_PATH, "w", encoding="utf-8") as f:
+                f.write(new_content)
+            print(f"  ✓ 成功更新 {MKDOCS_YAML_PATH}")
+            return True
+    except Exception as e:
+        print(f"  ✗ 更新 {MKDOCS_YAML_PATH} 失败: {e}")
+        return False
+
+def update_appx_manifest(new_version, force=False):
+    """更新 AppxManifest.xml 中的版本号"""
+    print(f"正在更新 {APPX_MANIFEST_PATH}...")
+
+    if not os.path.exists(APPX_MANIFEST_PATH):
+        print(f"  ℹ  文件 {APPX_MANIFEST_PATH} 不存在，跳过更新")
+        return True
+
+    # 转换为 MSIX 版本格式 (X.Y.Z -> X.Y.Z.0)
+    msix_version = convert_to_msix_version(new_version)
+
+    # 检查版本是否已经是目标版本（除非是强制模式）
+    if not force:
+        check_result = check_appx_version(new_version)
+        if check_result is True:
+            print(f"  ✓ {APPX_MANIFEST_PATH} 版本已经是 {msix_version}，跳过更新")
+            return True
+        elif check_result is None:
+            print(f"  ✗ 无法检查 {APPX_MANIFEST_PATH} 版本")
+            return False
+
+    try:
+        with open(APPX_MANIFEST_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # 更新 Identity Version（只匹配 Identity 标签内的 Version）
+        # <Identity ... Version="3.0.9.0" ...>
+        pattern = r'(<Identity[^>]*\sVersion=")(\d+\.\d+\.\d+\.\d+)("[^>]*>)'
+        replacement = f'\\g<1>{msix_version}\\g<3>'
+        new_content = re.sub(pattern, replacement, content)
+
+        if content == new_content:
+            if force:
+                print(f"  ✓ {APPX_MANIFEST_PATH} 版本已经是 {msix_version}")
+                return True
+            else:
+                print(f"  ✗ {APPX_MANIFEST_PATH} 未发生变化")
+                return False
+        else:
+            with open(APPX_MANIFEST_PATH, "w", encoding="utf-8") as f:
+                f.write(new_content)
+            print(f"  ✓ 成功更新 {APPX_MANIFEST_PATH}")
+            return True
+    except Exception as e:
+        print(f"  ✗ 更新 {APPX_MANIFEST_PATH} 失败: {e}")
+        return False
+
+def update_flatpak_manifest(new_version, force=False):
+    """更新 Flatpak 清单中的 Git 标签版本"""
+    print(f"正在更新 {FLATPAK_MANIFEST_PATH}...")
+
+    if not os.path.exists(FLATPAK_MANIFEST_PATH):
+        print(f"  ℹ  文件 {FLATPAK_MANIFEST_PATH} 不存在，跳过更新")
+        return True
+
+    # 检查版本是否已经是目标版本（除非是强制模式）
+    if not force:
+        check_result = check_flatpak_version(new_version)
+        if check_result is True:
+            print(f"  ✓ {FLATPAK_MANIFEST_PATH} Git 标签已经是 v{new_version}，跳过更新")
+            return True
+        elif check_result is None:
+            print(f"  ✗ 无法检查 {FLATPAK_MANIFEST_PATH} 版本")
+            return False
+
+    try:
+        with open(FLATPAK_MANIFEST_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # 更新 tag
+        # tag: v3.0.13
+        pattern = r'(tag:\s*)v([^\s\n]+)'
+        replacement = f'\\g<1>v{new_version}'
+        new_content = re.sub(pattern, replacement, content)
+
+        if content == new_content:
+            if force:
+                print(f"  ✓ {FLATPAK_MANIFEST_PATH} Git 标签已经是 v{new_version}")
+                return True
+            else:
+                print(f"  ✗ {FLATPAK_MANIFEST_PATH} 未发生变化")
+                return False
+        else:
+            with open(FLATPAK_MANIFEST_PATH, "w", encoding="utf-8") as f:
+                f.write(new_content)
+            print(f"  ✓ 成功更新 {FLATPAK_MANIFEST_PATH}")
+            return True
+    except Exception as e:
+        print(f"  ✗ 更新 {FLATPAK_MANIFEST_PATH} 失败: {e}")
+        return False
+
 def check_all_versions(version):
     """检查所有文件中的版本是否一致"""
     print(f"检查所有文件中的版本是否为 {version}...")
@@ -554,7 +692,10 @@ def check_all_versions(version):
         "vcpkg.json": check_vcpkg_json_version(version),
         "CMakeLists.txt": check_cmake_version(version),
         "src/main.cpp": check_main_cpp_version(version),
-        "metainfo.xml": check_metainfo_version(version)
+        "metainfo.xml": check_metainfo_version(version),
+        "mkdocs.yml": check_mkdocs_version(version),
+        "AppxManifest.xml": check_appx_version(version),
+        "Flatpak manifest": check_flatpak_version(version)
     }
 
     all_match = True
@@ -569,6 +710,86 @@ def check_all_versions(version):
             all_match = False
 
     return all_match
+
+def convert_to_msix_version(version):
+    """
+    将 X.Y.Z 格式转换为 MSIX 的 X.Y.Z.R 格式
+    MSIX 要求 4 段版本号，R 通常设为 0
+    """
+    parts = version.split(".")
+    if len(parts) == 3:
+        return f"{version}.0"
+    elif len(parts) == 4:
+        return version
+    else:
+        raise ValueError(f"无效的版本格式: {version}")
+
+def parse_msix_version(msix_version):
+    """
+    将 MSIX 的 X.Y.Z.R 格式转换为 X.Y.Z 格式
+    """
+    parts = msix_version.split(".")
+    if len(parts) == 4:
+        return ".".join(parts[:3])
+    elif len(parts) == 3:
+        return msix_version
+    else:
+        raise ValueError(f"无效的 MSIX 版本格式: {msix_version}")
+
+def check_mkdocs_version(version):
+    """检查 mkdocs.yml 中的版本是否已经是目标版本"""
+    if not os.path.exists(MKDOCS_YAML_PATH):
+        return None
+
+    try:
+        with open(MKDOCS_YAML_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+            # 检查 extra.version
+            pattern = r'extra:\s*\n\s*version:\s*([^\s\n]+)'
+            match = re.search(pattern, content)
+            if match:
+                return match.group(1) == version
+    except Exception as e:
+        print(f"检查 mkdocs.yml 失败: {e}")
+        return None
+    return False
+
+def check_appx_version(version):
+    """检查 AppxManifest.xml 中的版本是否已经是目标版本"""
+    if not os.path.exists(APPX_MANIFEST_PATH):
+        return None
+
+    try:
+        msix_version = convert_to_msix_version(version)
+        with open(APPX_MANIFEST_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+            # 检查 Identity Version（只匹配 Identity 标签内的 Version）
+            pattern = r'<Identity[^>]*\sVersion="(\d+\.\d+\.\d+\.\d+)"'
+            match = re.search(pattern, content)
+            if match:
+                return match.group(1) == msix_version
+    except Exception as e:
+        print(f"检查 AppxManifest.xml 失败: {e}")
+        return None
+    return False
+
+def check_flatpak_version(version):
+    """检查 Flatpak 清单中的 Git 标签是否已经是目标版本"""
+    if not os.path.exists(FLATPAK_MANIFEST_PATH):
+        return None
+
+    try:
+        with open(FLATPAK_MANIFEST_PATH, "r", encoding="utf-8") as f:
+            content = f.read()
+            # 检查 tag
+            pattern = r'tag:\s*v([^\s\n]+)'
+            match = re.search(pattern, content)
+            if match:
+                return match.group(1) == version
+    except Exception as e:
+        print(f"检查 Flatpak 清单失败: {e}")
+        return None
+    return False
 
 def main():
     parser = argparse.ArgumentParser(description="EasyKiConverter 版本管理工具")
@@ -634,11 +855,22 @@ def main():
     success &= update_cmake_lists(new_version, force=args.force)
     success &= update_main_cpp(new_version, force=args.force)
     success &= update_metainfo_xml(new_version, generate_release=not args.no_release_notes, force=args.force)
+    success &= update_mkdocs_yaml(new_version, force=args.force)
+    success &= update_appx_manifest(new_version, force=args.force)
+    success &= update_flatpak_manifest(new_version, force=args.force)
 
     if success:
         print("\n✓ 所有文件更新完成！")
         if args.no_release_notes:
             print(f"\n提示: 请手动编辑 {METAINFO_XML_PATH} 添加新版本的 release 描述")
+
+        # 验证更新结果
+        print("\n正在验证更新结果...")
+        all_match = check_all_versions(new_version)
+        if all_match:
+            print("\n✓ 所有文件版本验证通过！")
+        else:
+            print("\n⚠ 部分文件版本验证失败，请检查上述信息")
     else:
         print("\n✗ 更新过程中出现错误，请检查上述信息。")
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "easykiconverter",
-  "version-string": "3.0.13",
+  "version-string": "3.0.14",
   "description": "EasyKiConverter - LCSC and EasyEDA component to KiCad library converter",
   "dependencies": [
     {


### PR DESCRIPTION
## 概述
修复 metainfo.xml 中的 summary 字段，使其符合 Flathub 应用商店的规范要求，提高应用在商店中的展示效果。

## 问题

### 原始 Summary
- **英文**: `Convert LCSC and EasyEDA components to KiCad libraries` (57 字符)
- **中文**: `将嘉立创和 EasyEDA 元件转换为 KiCad 库` (21 字符)

### 不符合规范的问题
1. 英文 summary 超过 35 字符限制（57 > 35）
2. 包含过多技术术语（LCSC、EasyEDA、libraries）
3. 对非技术人员不够友好

## 解决方案

### 修复后的 Summary
- **英文**: `Convert components for KiCad` (24 字符)
- **中文**: `转换元件用于 KiCad` (9 字符)
