### PR TITLE
fix(packaging): 修复桌面图标启动消失问题并优化卸载清理流程

### DIFF
--- a/.github/workflows/pack-linux.yml
+++ b/.github/workflows/pack-linux.yml
@@ -841,6 +841,7 @@ jobs:
               -e "s|deploy/scripts/easykiconverter-register.desktop|$(pwd)/deploy/scripts/easykiconverter-register.desktop|g" \
               -e "s|deploy/scripts/trigger-gnome-refresh.sh|$(pwd)/deploy/scripts/trigger-gnome-refresh.sh|g" \
               -e "s|deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|$(pwd)/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|g" \
+              -e "s|deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|$(pwd)/deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|g" \
               deploy/nfpm.yaml > nfpm_temp.yaml
 
           # 确保 AppDir 中所有二进制文件有执行权限（解决 root 用户创建文件的问题）
@@ -926,6 +927,7 @@ jobs:
               -e "s|deploy/scripts/easykiconverter-register.desktop|$(pwd)/deploy/scripts/easykiconverter-register.desktop|g" \
               -e "s|deploy/scripts/trigger-gnome-refresh.sh|$(pwd)/deploy/scripts/trigger-gnome-refresh.sh|g" \
               -e "s|deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|$(pwd)/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|g" \
+              -e "s|deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|$(pwd)/deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|g" \
               deploy/nfpm.yaml > nfpm_temp.yaml
 
           # 确保 AppDir 中所有二进制文件有执行权限
@@ -1006,6 +1008,7 @@ jobs:
               -e "s|deploy/scripts/easykiconverter-register.desktop|$(pwd)/deploy/scripts/easykiconverter-register.desktop|g" \
               -e "s|deploy/scripts/trigger-gnome-refresh.sh|$(pwd)/deploy/scripts/trigger-gnome-refresh.sh|g" \
               -e "s|deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|$(pwd)/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|g" \
+              -e "s|deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|$(pwd)/deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|g" \
               deploy/nfpm.yaml > nfpm_temp.yaml
 
           # 确保 AppDir 中所有二进制文件有执行权限

--- a/.github/workflows/pack-linux.yml
+++ b/.github/workflows/pack-linux.yml
@@ -827,6 +827,7 @@ jobs:
           cp deploy/scripts/postinstall.sh scripts/postinstall.sh
           cp deploy/scripts/prerm.sh scripts/preremove.sh
           cp deploy/scripts/postrm.sh scripts/postrm.sh
+          cp deploy/scripts/uninstall-common.sh scripts/uninstall-common.sh
           chmod +x scripts/*.sh
 
           # 使用 sed 动态替换 nfpm.yaml 中的 ${APP_DIR} 变量和其他路径
@@ -834,6 +835,7 @@ jobs:
               -e "s|deploy/scripts/postinstall.sh|$(pwd)/deploy/scripts/postinstall.sh|g" \
               -e "s|deploy/scripts/prerm.sh|$(pwd)/deploy/scripts/prerm.sh|g" \
               -e "s|deploy/scripts/postrm.sh|$(pwd)/deploy/scripts/postrm.sh|g" \
+              -e "s|deploy/scripts/uninstall-common.sh|$(pwd)/deploy/scripts/uninstall-common.sh|g" \
               -e "s|deploy/scripts/easykiconverter-wrapper.sh|$(pwd)/deploy/scripts/easykiconverter-wrapper.sh|g" \
               -e "s|deploy/scripts/easykiconverter-register.sh|$(pwd)/deploy/scripts/easykiconverter-register.sh|g" \
               -e "s|deploy/scripts/easykiconverter-register.desktop|$(pwd)/deploy/scripts/easykiconverter-register.desktop|g" \
@@ -910,6 +912,7 @@ jobs:
           cp deploy/scripts/postinstall.sh scripts/postinstall.sh
           cp deploy/scripts/prerm.sh scripts/preremove.sh
           cp deploy/scripts/postrm.sh scripts/postrm.sh
+          cp deploy/scripts/uninstall-common.sh scripts/uninstall-common.sh
           chmod +x scripts/*.sh
 
           # 使用 sed 动态替换 nfpm.yaml 中的 ${APP_DIR} 变量和其他路径
@@ -917,6 +920,7 @@ jobs:
               -e "s|deploy/scripts/postinstall.sh|$(pwd)/deploy/scripts/postinstall.sh|g" \
               -e "s|deploy/scripts/prerm.sh|$(pwd)/deploy/scripts/prerm.sh|g" \
               -e "s|deploy/scripts/postrm.sh|$(pwd)/deploy/scripts/postrm.sh|g" \
+              -e "s|deploy/scripts/uninstall-common.sh|$(pwd)/deploy/scripts/uninstall-common.sh|g" \
               -e "s|deploy/scripts/easykiconverter-wrapper.sh|$(pwd)/deploy/scripts/easykiconverter-wrapper.sh|g" \
               -e "s|deploy/scripts/easykiconverter-register.sh|$(pwd)/deploy/scripts/easykiconverter-register.sh|g" \
               -e "s|deploy/scripts/easykiconverter-register.desktop|$(pwd)/deploy/scripts/easykiconverter-register.desktop|g" \
@@ -988,6 +992,7 @@ jobs:
           cp deploy/scripts/postinstall.sh scripts/postinstall.sh
           cp deploy/scripts/prerm.sh scripts/preremove.sh
           cp deploy/scripts/postrm.sh scripts/postrm.sh
+          cp deploy/scripts/uninstall-common.sh scripts/uninstall-common.sh
           chmod +x scripts/*.sh
 
           # 使用 sed 动态替换 nfpm.yaml 中的 ${APP_DIR} 变量和其他路径
@@ -995,6 +1000,7 @@ jobs:
               -e "s|deploy/scripts/postinstall.sh|$(pwd)/deploy/scripts/postinstall.sh|g" \
               -e "s|deploy/scripts/prerm.sh|$(pwd)/deploy/scripts/prerm.sh|g" \
               -e "s|deploy/scripts/postrm.sh|$(pwd)/deploy/scripts/postrm.sh|g" \
+              -e "s|deploy/scripts/uninstall-common.sh|$(pwd)/deploy/scripts/uninstall-common.sh|g" \
               -e "s|deploy/scripts/easykiconverter-wrapper.sh|$(pwd)/deploy/scripts/easykiconverter-wrapper.sh|g" \
               -e "s|deploy/scripts/easykiconverter-register.sh|$(pwd)/deploy/scripts/easykiconverter-register.sh|g" \
               -e "s|deploy/scripts/easykiconverter-register.desktop|$(pwd)/deploy/scripts/easykiconverter-register.desktop|g" \

--- a/deploy/linux/io.github.tangsangsimida.easykiconverter.desktop
+++ b/deploy/linux/io.github.tangsangsimida.easykiconverter.desktop
@@ -9,6 +9,6 @@ Icon=io.github.tangsangsimida.easykiconverter
 Categories=Development;Electronics;Engineering;
 Terminal=false
 Keywords=KiCad;LCSC;EasyEDA;Component;Converter;Electronics;
-StartupNotify=true
+StartupNotify=false
 StartupWMClass=easykiconverter
 MimeType=application/vnd.easyeda+json;

--- a/deploy/nfpm.yaml
+++ b/deploy/nfpm.yaml
@@ -24,8 +24,8 @@ contents:
     file_info:
       mode: 0755
 
-  # 安装 desktop 文件到系统目录（使用实际文件路径，不是符号链接）
-  - src: "${APP_DIR}/usr/share/applications/io.github.tangsangsimida.easykiconverter.desktop"
+  # 安装 desktop 文件到系统目录（使用 deploy/linux 中的正确版本，Exec=easykiconverter）
+  - src: "deploy/linux/io.github.tangsangsimida.easykiconverter.desktop"
     dst: "/usr/share/applications/io.github.tangsangsimida.easykiconverter.desktop"
     file_info:
       mode: 0644

--- a/deploy/scripts/postrm.sh
+++ b/deploy/scripts/postrm.sh
@@ -1,24 +1,14 @@
 #!/bin/sh
 # 卸载后清理脚本
-# 在软件包卸载后执行，清理桌面缓存和配置
+# 在软件包卸载后执行，清理桌面缓存
 
 # 应用配置变量
 APP_NAME="easykiconverter"
-APP_DESKTOP_NAME="io.github.tangsangsimida.easykiconverter"
-APP_INSTALL_DIR="/opt/easykiconverter"
-APP_BIN_LINK="/usr/bin/easykiconverter"
-APP_DESKTOP_FILE="/usr/share/applications/${APP_DESKTOP_NAME}.desktop"
-APP_DESKTOP_FILE_COMPAT="/usr/share/applications/com.tangsangsimida.easykiconverter.desktop"  # 兼容旧版本
-APP_METAINFO_FILE="/usr/share/metainfo/${APP_DESKTOP_NAME}.metainfo.xml"
-APP_METAINFO_FILE_COMPAT="/usr/share/metainfo/com.tangsangsimida.easykiconverter.metainfo.xml"  # 兼容旧版本
-APP_BIN_LINK="/usr/bin/easykiconverter"
-APP_DESKTOP_FILE="/usr/share/applications/${APP_DESKTOP_NAME}.desktop"
-APP_METAINFO_FILE="/usr/share/metainfo/${APP_DESKTOP_NAME}.metainfo.xml"
-APP_SCRIPT_DIR="/usr/share/easykiconverter"
-AUTOSTART_FILE="/etc/xdg/autostart/easykiconverter-register.desktop"
-AUTOSTART_FILE_SYSTEM="/usr/share/xdg/autostart/easykiconverter-register.desktop"
+APP_ID="io.github.tangsangsimida.easykiconverter"
+USER_DATA_DIR="${HOME}/.local/share/EasyKiConverter"
+USER_CONFIG_DIR="${HOME}/.config/EasyKiConverter"
+FLATPAK_USER_DATA_DIR="${HOME}/.var/app/${APP_ID}"
 
-# 日志函数
 log_info() {
     echo "[INFO] $1" >&2
 }
@@ -31,389 +21,118 @@ log_error() {
     echo "[ERROR] $1" >&2
 }
 
-# 安全删除文件函数
 safe_remove_file() {
     local file="$1"
-    if [ -z "$file" ]; then
-        log_error "safe_remove_file: 文件路径为空"
-        return 1
+    [ -z "$file" ] && return 1
+    if [ -f "$file" ] || [ -L "$file" ]; then
+        rm -f "$file" 2>/dev/null && log_info "已删除: $file"
     fi
-
-    if [ -f "$file" ]; then
-        if rm -f "$file" 2>/dev/null; then
-            log_info "已删除文件: $file"
-            return 0
-        else
-            log_warn "无法删除文件（权限不足或其他错误）: $file"
-            return 1
-        fi
-    elif [ -L "$file" ]; then
-        if rm -f "$file" 2>/dev/null; then
-            log_info "已删除符号链接: $file"
-            return 0
-        else
-            log_warn "无法删除符号链接（权限不足或其他错误）: $file"
-            return 1
-        fi
-    else
-        return 0  # 文件不存在，视为成功
-    fi
+    return 0
 }
 
-# 安全删除目录函数
 safe_remove_dir() {
     local dir="$1"
-    if [ -z "$dir" ]; then
-        log_error "safe_remove_dir: 目录路径为空"
-        return 1
-    fi
-
+    [ -z "$dir" ] && return 1
     if [ -d "$dir" ]; then
-        if rm -rf "$dir" 2>/dev/null; then
-            log_info "已删除目录: $dir"
-            return 0
-        else
-            log_warn "无法删除目录（权限不足或其他错误）: $dir"
-            return 1
-        fi
-    else
-        return 0  # 目录不存在，视为成功
+        rm -rf "$dir" 2>/dev/null && log_info "已删除目录: $dir"
     fi
+    return 0
 }
 
-# 删除应用文件和可执行文件
-remove_app_files() {
-    log_info "删除应用文件和可执行文件..."
-    safe_remove_dir "$APP_INSTALL_DIR"
-    safe_remove_file "$APP_BIN_LINK"
-}
-
-# 删除系统级别的桌面文件
-remove_system_desktop_file() {
-    log_info "删除系统级别的桌面文件..."
-    safe_remove_file "$APP_DESKTOP_FILE"
-    # 删除旧版本的桌面文件（兼容性）
-    safe_remove_file "$APP_DESKTOP_FILE_COMPAT"
-}
-
-# 删除系统级别的图标文件
-remove_system_icons() {
-    log_info "删除系统级别的图标文件..."
-    for size in 16x16 32x32 48x48 64x64 128x128 256x256 512x512; do
-        local icon_file="/usr/share/icons/hicolor/$size/apps/${APP_DESKTOP_NAME}.png"
-        safe_remove_file "$icon_file"
-    done
-}
-
-# 删除 AppStream 元数据文件
-remove_metainfo_file() {
-    log_info "删除 AppStream 元数据文件..."
-    safe_remove_file "$APP_METAINFO_FILE"
-    # 删除旧版本的元数据文件（兼容性）
-    safe_remove_file "$APP_METAINFO_FILE_COMPAT"
-}
-
-# 删除自动启动文件
-remove_autostart_files() {
-    log_info "删除自动启动文件..."
-    safe_remove_file "$AUTOSTART_FILE"
-    safe_remove_file "$AUTOSTART_FILE_SYSTEM"
-}
-
-# 删除用户级别的脚本文件
-remove_user_scripts() {
-    log_info "删除用户级别的脚本文件..."
-    safe_remove_dir "$APP_SCRIPT_DIR"
-}
-
-# 更新桌面数据库
 update_desktop_database() {
     log_info "更新桌面数据库..."
     if command -v update-desktop-database >/dev/null 2>&1; then
-        if update-desktop-database /usr/share/applications 2>/dev/null; then
-            log_info "桌面数据库更新成功"
-        else
-            log_warn "桌面数据库更新失败"
-        fi
+        update-desktop-database /usr/share/applications 2>/dev/null
     fi
 }
 
-# 更新图标缓存
 update_icon_cache() {
     log_info "更新图标缓存..."
     if command -v gtk-update-icon-cache >/dev/null 2>&1; then
-        for theme in hicolor Adwaita; do
-            if [ -d "/usr/share/icons/$theme" ]; then
-                if gtk-update-icon-cache -q -t -f "/usr/share/icons/$theme" 2>/dev/null; then
-                    log_info "图标缓存更新成功: $theme"
-                else
-                    log_warn "图标缓存更新失败: $theme"
-                fi
-            fi
+        for theme in hicolor hicolor-dark Adwaita; do
+            [ -d "/usr/share/icons/$theme" ] && gtk-update-icon-cache -q -t -f "/usr/share/icons/$theme" 2>/dev/null
         done
     fi
 }
 
-# 验证用户参数安全性
-validate_user() {
-    local user="$1"
-    if [ -z "$user" ]; then
-        log_error "validate_user: 用户名为空"
-        return 1
-    fi
-
-    # 检查用户名是否只包含安全字符（字母、数字、下划线、连字符）
-    if ! echo "$user" | grep -qE '^[a-zA-Z0-9_-]+$'; then
-        log_error "validate_user: 用户名包含不安全字符: $user"
-        return 1
-    fi
-
-    # 检查用户是否存在
-    if ! getent passwd "$user" >/dev/null 2>&1; then
-        log_error "validate_user: 用户不存在: $user"
-        return 1
-    fi
-
-    return 0
-}
-
-# 安全执行用户命令
-safe_run_as_user() {
-    local user="$1"
-    shift
-    local cmd="$@"
-
-    if ! validate_user "$user"; then
-        return 1
-    fi
-
-    if ! sudo -u "$user" $cmd 2>/dev/null; then
-        log_warn "以用户 $user 执行命令失败: $cmd"
-        return 1
-    fi
-
-    return 0
-}
-
-# 删除用户级别的桌面文件
-remove_user_desktop_files() {
-    log_info "删除用户级别的桌面文件..."
-
-    if ! command -v getent >/dev/null 2>&1; then
-        log_warn "getent 命令不可用，跳过用户级别清理"
-        return 1
-    fi
-
-    # 遍历所有普通用户（UID >= 1000）
-    getent passwd | awk -F: '$3 >= 1000 {print $1, $6}' | while read -r user home; do
-        if [ -z "$user" ] || [ -z "$home" ] || [ ! -d "$home" ]; then
-            continue
-        fi
-
-        if ! validate_user "$user"; then
-            continue
-        fi
-
-        local user_desktop="$home/.local/share/applications"
-        if [ ! -d "$user_desktop" ]; then
-            continue
-        fi
-
-        # 使用 find 命令查找所有匹配的文件
-        find "$user_desktop" -maxdepth 1 -type f \( -iname "*EasyKi*.desktop" -o -iname "*easykiconverter*.desktop" \) 2>/dev/null | while read -r desktop_file; do
-            if [ ! -f "$desktop_file" ]; then
-                continue
-            fi
-
-            # 检查文件内容，确保是当前应用的桌面文件
-            if grep -qi "EasyKiConverter\|easykiconverter\|tangsangsimida" "$desktop_file" 2>/dev/null; then
-                if safe_remove_file "$desktop_file"; then
-                    log_info "已删除用户级别桌面文件: $desktop_file"
-                fi
-            fi
-        done
-
-        # 更新用户桌面数据库
-        if command -v update-desktop-database >/dev/null 2>&1; then
-            if update-desktop-database "$user_desktop" 2>/dev/null; then
-                log_info "用户桌面数据库更新成功: $user"
-            else
-                log_warn "用户桌面数据库更新失败: $user"
-            fi
-        fi
-
-        # 删除用户级别的应用注册标记文件
-        local marker_file="$home/.config/easykiconverter-registered"
-        safe_remove_file "$marker_file"
-
-        # 删除待处理刷新标记文件
-        local pending_file="$home/.config/easykiconverter/pending-refresh"
-        safe_remove_file "$pending_file"
-    done
-
-    return 0
-}
-
-# 刷新 GNOME Shell 应用缓存
 refresh_gnome_cache() {
     log_info "刷新 GNOME Shell 应用缓存..."
-
     if ! command -v loginctl >/dev/null 2>&1 || ! command -v sudo >/dev/null 2>&1; then
         log_warn "loginctl 或 sudo 命令不可用，跳过 GNOME 缓存刷新"
         return 1
     fi
 
-    # 获取所有已登录用户
     loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
-        if [ -z "$user" ]; then
-            continue
-        fi
-
-        if ! validate_user "$user"; then
-            continue
-        fi
-
-        # 获取用户信息
-        local user_info=$(getent passwd "$user" 2>/dev/null)
-        if [ -z "$user_info" ]; then
-            continue
-        fi
-
-        local user_id=$(echo "$user_info" | cut -d: -f3)
-
-        # 只为普通用户运行（UID >= 1000）
-        if [ "$user_id" -lt 1000 ]; then
-            continue
-        fi
-
-        # 获取用户的活动会话
+        [ -z "$user" ] && continue
+        getent passwd "$user" >/dev/null 2>&1 || continue
+        local user_id=$(getent passwd "$user" 2>/dev/null | cut -d: -f3)
+        [ "$user_id" -lt 1000 ] && continue
         local sessions=$(loginctl list-sessions "$user" 2>/dev/null | awk '{print $1}' | grep -v "^$") || true
         for session in $sessions; do
-            # 获取会话的 XDG_RUNTIME_DIR
             local runtime_dir=$(loginctl show-session "$session" -p XDG_RUNTIME_DIR --value 2>/dev/null)
-            if [ -z "$runtime_dir" ]; then
-                continue
-            fi
-
-            # 检查 D-Bus 会话总线是否存在
+            [ -z "$runtime_dir" ] && continue
             local dbus_bus="$runtime_dir/bus"
-            if [ ! -S "$dbus_bus" ]; then
-                continue
-            fi
-
-            # 方法1：调用 GNOME Shell 的 appSystem.reload() 方法
-            if safe_run_as_user "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval "appSystem.reload()"; then
-                log_info "GNOME Shell 应用列表刷新成功: $user"
-            else
-                log_warn "GNOME Shell 应用列表刷新失败: $user"
-            fi
-
-            # 方法2：强制刷新应用数据库
-            if safe_run_as_user "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" gio monitor --cancel "$home/.local/share/applications"; then
-                log_info "应用数据库刷新成功: $user"
-            else
-                log_warn "应用数据库刷新失败: $user"
-            fi
-
-            # 方法3：清除 GNOME Shell 的应用图标缓存
-            if [ -d "$runtime_dir" ]; then
-                # 删除应用图标缓存文件
-                find "$runtime_dir" -name "*.desktop" -type f -delete 2>/dev/null
-                find "$runtime_dir" -name "*easykiconverter*" -type f -delete 2>/dev/null
-                log_info "GNOME Shell 应用图标缓存清除成功: $user"
-            fi
+            [ ! -S "$dbus_bus" ] && continue
+            sudo -u "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" \
+                gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval "appSystem.reload()" 2>/dev/null && \
+                log_info "GNOME Shell 刷新成功: $user" || log_warn "GNOME Shell 刷新失败: $user"
         done
     done
-
-    return 0
 }
 
-# 自动清除 dpkg 元数据
+remove_user_data() {
+    log_info "删除用户数据..."
+    safe_remove_dir "$USER_DATA_DIR"
+}
+
+remove_user_config() {
+    log_info "删除用户配置..."
+    safe_remove_dir "$USER_CONFIG_DIR"
+}
+
+remove_flatpak_user_data() {
+    log_info "删除 Flatpak 用户数据..."
+    safe_remove_dir "$FLATPAK_USER_DATA_DIR"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/app/${APP_ID}"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/runtime/${APP_ID}.Debug"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/easykiconverter-origin"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/easykiconverter1-origin"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/debug-origin"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/local-repo"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/local-repo-local"
+}
+
 purge_dpkg_metadata() {
-    log_info "清除 dpkg 元数据..."
-
     local purge_flag_file="/tmp/${APP_NAME}-purge-in-progress"
-
     if [ "$1" = "purge" ]; then
-        # 已在 purge 模式，清理标志文件
         safe_remove_file "$purge_flag_file"
         return 0
     elif [ "$1" = "remove" ]; then
-        # 在 remove 模式下，等待短暂时间后自动执行 purge
         (
             sleep 2
-
-            # 检查标志文件，防止并发执行
-            if [ -f "$purge_flag_file" ]; then
-                exit 0
-            fi
-
-            # 创建标志文件（使用更安全的临时文件创建方法）
-            if ! mktemp "$purge_flag_file.XXXXXX" >/dev/null 2>&1; then
-                log_error "无法创建标志文件: $purge_flag_file"
-                exit 1
-            fi
-
-            # 检查包状态
+            [ -f "$purge_flag_file" ] && exit 0
             if dpkg-query -W -f='${Status}' "$APP_NAME" 2>/dev/null | grep -q "config-files"; then
-                log_info "包处于 config-files 状态，执行 purge"
-                if dpkg --purge "$APP_NAME" >/dev/null 2>&1; then
-                    log_info "dpkg purge 成功"
-                else
-                    log_error "dpkg purge 失败"
-                fi
+                dpkg --purge "$APP_NAME" >/dev/null 2>&1 || log_error "dpkg purge 失败"
             fi
-
-            # 清理标志文件
             safe_remove_file "$purge_flag_file*"
         ) >/dev/null 2>&1 &
-
-        return 0
     fi
-
-    return 1
+    return 0
 }
 
-# === 主清理逻辑 ===
+log_info "执行 postrm 清理..."
 
-# 确保删除应用程序文件和可执行文件（双重保险）
-remove_app_files
-
-# 删除系统级别的桌面文件
-remove_system_desktop_file
-
-# 删除系统级别的图标文件
-remove_system_icons
-
-# 删除 AppStream 元数据文件
-remove_metainfo_file
-
-# 删除自动启动文件
-remove_autostart_files
-
-# 删除用户级别的脚本文件
-remove_user_scripts
-
-# 强制更新桌面数据库（移除已卸载的桌面文件）
 update_desktop_database
-
-# 强制更新图标缓存（移除已卸载的图标）
 update_icon_cache
-
-# 为所有已登录用户触发 GNOME 应用列表刷新
 refresh_gnome_cache
 
-# 删除用户级别的桌面文件副本
-remove_user_desktop_files
+if [ "$1" = "purge" ]; then
+    log_info "执行 purge，清理用户数据..."
+    remove_user_data
+    remove_user_config
+    remove_flatpak_user_data
+fi
 
-# 注意：不删除用户级别的配置文件
-# 用户的配置文件位于 ~/.config/EasyKiConverter/
-# 如果需要删除，可以取消下面的注释（但通常不建议自动删除）
-# if [ -d "$HOME/.config/EasyKiConverter" ]; then
-#     safe_remove_dir "$HOME/.config/EasyKiConverter"
-# fi
-
-# 自动清除 dpkg 元数据，确保状态从 'rc' 变为完全清除
 purge_dpkg_metadata "$1"
 
 exit 0

--- a/deploy/scripts/postrm.sh
+++ b/deploy/scripts/postrm.sh
@@ -82,24 +82,34 @@ refresh_gnome_cache() {
 
 remove_user_data() {
     log_info "删除用户数据..."
-    safe_remove_dir "$USER_DATA_DIR"
+    getent passwd | awk -F: '$3 >= 1000 {print $1, $6}' | while read -r user home; do
+        [ -z "$user" ] || [ -z "$home" ] || [ ! -d "$home" ] && continue
+        safe_remove_dir "$home/.local/share/EasyKiConverter"
+    done
 }
 
 remove_user_config() {
     log_info "删除用户配置..."
-    safe_remove_dir "$USER_CONFIG_DIR"
+    getent passwd | awk -F: '$3 >= 1000 {print $1, $6}' | while read -r user home; do
+        [ -z "$user" ] || [ -z "$home" ] || [ ! -d "$home" ] && continue
+        safe_remove_dir "$home/.config/EasyKiConverter"
+        safe_remove_dir "$home/.config/easykiconverter-registered"
+    done
 }
 
 remove_flatpak_user_data() {
     log_info "删除 Flatpak 用户数据..."
-    safe_remove_dir "$FLATPAK_USER_DATA_DIR"
-    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/app/${APP_ID}"
-    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/runtime/${APP_ID}.Debug"
-    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/easykiconverter-origin"
-    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/easykiconverter1-origin"
-    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/debug-origin"
-    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/local-repo"
-    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/local-repo-local"
+    getent passwd | awk -F: '$3 >= 1000 {print $1, $6}' | while read -r user home; do
+        [ -z "$user" ] || [ -z "$home" ] || [ ! -d "$home" ] && continue
+        safe_remove_dir "$home/.var/app/${APP_ID}"
+        safe_remove_dir "$home/.local/share/flatpak/repo/refs/heads/deploy/app/${APP_ID}"
+        safe_remove_dir "$home/.local/share/flatpak/repo/refs/heads/deploy/runtime/${APP_ID}.Debug"
+        safe_remove_dir "$home/.local/share/flatpak/repo/refs/remotes/easykiconverter-origin"
+        safe_remove_dir "$home/.local/share/flatpak/repo/refs/remotes/easykiconverter1-origin"
+        safe_remove_dir "$home/.local/share/flatpak/repo/refs/remotes/debug-origin"
+        safe_remove_dir "$home/.local/share/flatpak/repo/refs/remotes/local-repo"
+        safe_remove_dir "$home/.local/share/flatpak/repo/refs/remotes/local-repo-local"
+    done
 }
 
 purge_dpkg_metadata() {

--- a/deploy/scripts/prerm.sh
+++ b/deploy/scripts/prerm.sh
@@ -9,13 +9,10 @@ APP_INSTALL_DIR="/opt/easykiconverter"
 APP_BIN_LINK="/usr/bin/easykiconverter"
 APP_DESKTOP_FILE="/usr/share/applications/${APP_DESKTOP_NAME}.desktop"
 APP_METAINFO_FILE="/usr/share/metainfo/${APP_DESKTOP_NAME}.metainfo.xml"
-APP_DESKTOP_FILE_COMPAT="/usr/share/applications/com.tangsangsimida.easykiconverter.desktop"  # 兼容旧版本
-APP_METAINFO_FILE_COMPAT="/usr/share/metainfo/com.tangsangsimida.easykiconverter.metainfo.xml"  # 兼容旧版本
 APP_SCRIPT_DIR="/usr/share/easykiconverter"
 AUTOSTART_FILE="/etc/xdg/autostart/easykiconverter-register.desktop"
 AUTOSTART_FILE_SYSTEM="/usr/share/xdg/autostart/easykiconverter-register.desktop"
 
-# 日志函数
 log_info() {
     echo "[INFO] $1" >&2
 }
@@ -28,333 +25,85 @@ log_error() {
     echo "[ERROR] $1" >&2
 }
 
-# 安全删除文件函数
 safe_remove_file() {
     local file="$1"
-    if [ -z "$file" ]; then
-        log_error "safe_remove_file: 文件路径为空"
-        return 1
+    [ -z "$file" ] && return 1
+    if [ -f "$file" ] || [ -L "$file" ]; then
+        rm -f "$file" 2>/dev/null && log_info "已删除: $file"
     fi
-
-    if [ -f "$file" ]; then
-        if rm -f "$file" 2>/dev/null; then
-            log_info "已删除文件: $file"
-            return 0
-        else
-            log_warn "无法删除文件（权限不足或其他错误）: $file"
-            return 1
-        fi
-    elif [ -L "$file" ]; then
-        if rm -f "$file" 2>/dev/null; then
-            log_info "已删除符号链接: $file"
-            return 0
-        else
-            log_warn "无法删除符号链接（权限不足或其他错误）: $file"
-            return 1
-        fi
-    else
-        return 0  # 文件不存在，视为成功
-    fi
+    return 0
 }
 
-# 安全删除目录函数
 safe_remove_dir() {
     local dir="$1"
-    if [ -z "$dir" ]; then
-        log_error "safe_remove_dir: 目录路径为空"
-        return 1
-    fi
-
+    [ -z "$dir" ] && return 1
     if [ -d "$dir" ]; then
-        if rm -rf "$dir" 2>/dev/null; then
-            log_info "已删除目录: $dir"
-            return 0
-        else
-            log_warn "无法删除目录（权限不足或其他错误）: $dir"
-            return 1
-        fi
-    else
-        return 0  # 目录不存在，视为成功
+        rm -rf "$dir" 2>/dev/null && log_info "已删除目录: $dir"
     fi
+    return 0
 }
 
-# 删除应用文件和可执行文件
 remove_app_files() {
     log_info "删除应用文件和可执行文件..."
     safe_remove_dir "$APP_INSTALL_DIR"
     safe_remove_file "$APP_BIN_LINK"
 }
 
-# 删除系统级别的桌面文件
 remove_system_desktop_file() {
     log_info "删除系统级别的桌面文件..."
     safe_remove_file "$APP_DESKTOP_FILE"
-    # 删除旧版本的桌面文件（兼容性）
-    safe_remove_file "$APP_DESKTOP_FILE_COMPAT"
+    safe_remove_file "/usr/share/applications/com.tangsangsimida.easykiconverter.desktop"
 }
 
-# 删除系统级别的图标文件
 remove_system_icons() {
     log_info "删除系统级别的图标文件..."
     for size in 16x16 32x32 48x48 64x64 128x128 256x256 512x512; do
-        local icon_file="/usr/share/icons/hicolor/$size/apps/${APP_DESKTOP_NAME}.png"
-        safe_remove_file "$icon_file"
+        safe_remove_file "/usr/share/icons/hicolor/$size/apps/${APP_DESKTOP_NAME}.png"
+        safe_remove_file "/usr/share/icons/hicolor-dark/$size/apps/${APP_DESKTOP_NAME}.png"
     done
 }
 
-# 删除 AppStream 元数据文件
 remove_metainfo_file() {
     log_info "删除 AppStream 元数据文件..."
     safe_remove_file "$APP_METAINFO_FILE"
-    # 删除旧版本的元数据文件（兼容性）
-    safe_remove_file "$APP_METAINFO_FILE_COMPAT"
+    safe_remove_file "/usr/share/metainfo/com.tangsangsimida.easykiconverter.metainfo.xml"
 }
 
-# 删除自动启动文件
 remove_autostart_files() {
     log_info "删除自动启动文件..."
     safe_remove_file "$AUTOSTART_FILE"
     safe_remove_file "$AUTOSTART_FILE_SYSTEM"
 }
 
-# 删除用户级别的脚本文件
 remove_user_scripts() {
     log_info "删除用户级别的脚本文件..."
     safe_remove_dir "$APP_SCRIPT_DIR"
 }
 
-# 更新桌面数据库
-update_desktop_database() {
-    log_info "更新桌面数据库..."
-    if command -v update-desktop-database >/dev/null 2>&1; then
-        if update-desktop-database /usr/share/applications 2>/dev/null; then
-            log_info "桌面数据库更新成功"
-        else
-            log_warn "桌面数据库更新失败"
-        fi
-    fi
-}
-
-# 更新图标缓存
-update_icon_cache() {
-    log_info "更新图标缓存..."
-    if command -v gtk-update-icon-cache >/dev/null 2>&1; then
-        for theme in hicolor Adwaita; do
-            if [ -d "/usr/share/icons/$theme" ]; then
-                if gtk-update-icon-cache -q -t -f "/usr/share/icons/$theme" 2>/dev/null; then
-                    log_info "图标缓存更新成功: $theme"
-                else
-                    log_warn "图标缓存更新失败: $theme"
-                fi
-            fi
-        done
-    fi
-}
-
-# 验证用户参数安全性
-validate_user() {
-    local user="$1"
-    if [ -z "$user" ]; then
-        log_error "validate_user: 用户名为空"
-        return 1
-    fi
-
-    # 检查用户名是否只包含安全字符（字母、数字、下划线、连字符）
-    if ! echo "$user" | grep -qE '^[a-zA-Z0-9_-]+$'; then
-        log_error "validate_user: 用户名包含不安全字符: $user"
-        return 1
-    fi
-
-    # 检查用户是否存在
-    if ! getent passwd "$user" >/dev/null 2>&1; then
-        log_error "validate_user: 用户不存在: $user"
-        return 1
-    fi
-
-    return 0
-}
-
-# 安全执行用户命令
-safe_run_as_user() {
-    local user="$1"
-    shift
-    local cmd="$@"
-
-    if ! validate_user "$user"; then
-        return 1
-    fi
-
-    if ! sudo -u "$user" $cmd 2>/dev/null; then
-        log_warn "以用户 $user 执行命令失败: $cmd"
-        return 1
-    fi
-
-    return 0
-}
-
-# 删除用户级别的桌面文件
 remove_user_desktop_files() {
     log_info "删除用户级别的桌面文件..."
-
-    if ! command -v getent >/dev/null 2>&1; then
-        log_warn "getent 命令不可用，跳过用户级别清理"
-        return 1
-    fi
-
-    # 遍历所有普通用户（UID >= 1000）
     getent passwd | awk -F: '$3 >= 1000 {print $1, $6}' | while read -r user home; do
-        if [ -z "$user" ] || [ -z "$home" ] || [ ! -d "$home" ]; then
-            continue
-        fi
-
-        if ! validate_user "$user"; then
-            continue
-        fi
-
+        [ -z "$user" ] || [ -z "$home" ] || [ ! -d "$home" ] && continue
         local user_desktop="$home/.local/share/applications"
-        if [ ! -d "$user_desktop" ]; then
-            continue
-        fi
-
-        # 使用 find 命令查找所有匹配的文件
-        find "$user_desktop" -maxdepth 1 -type f \( -iname "*EasyKi*.desktop" -o -iname "*easykiconverter*.desktop" \) 2>/dev/null | while read -r desktop_file; do
-            if [ ! -f "$desktop_file" ]; then
-                continue
-            fi
-
-            # 检查文件内容，确保是当前应用的桌面文件
-            if grep -qi "EasyKiConverter\|easykiconverter\|tangsangsimida" "$desktop_file" 2>/dev/null; then
-                if safe_remove_file "$desktop_file"; then
-                    log_info "已删除用户级别桌面文件: $desktop_file"
-                fi
+        [ -d "$user_desktop" ] || continue
+        find "$user_desktop" -maxdepth 1 -type f \( -iname "*EasyKi*.desktop" -o -iname "*easykiconverter*.desktop" \) 2>/dev/null | while read -r df; do
+            if [ -f "$df" ] && grep -qi "EasyKiConverter\|easykiconverter\|tangsangsimida" "$df" 2>/dev/null; then
+                safe_remove_file "$df"
             fi
         done
-
-        # 更新用户桌面数据库
-        if command -v update-desktop-database >/dev/null 2>&1; then
-            if update-desktop-database "$user_desktop" 2>/dev/null; then
-                log_info "用户桌面数据库更新成功: $user"
-            else
-                log_warn "用户桌面数据库更新失败: $user"
-            fi
-        fi
-
-        # 删除用户级别的应用注册标记文件
-        local marker_file="$home/.config/easykiconverter-registered"
-        safe_remove_file "$marker_file"
-
-        # 删除待处理刷新标记文件
-        local pending_file="$home/.config/easykiconverter/pending-refresh"
-        safe_remove_file "$pending_file"
+        safe_remove_file "$home/.config/easykiconverter-registered"
+        safe_remove_file "$home/.config/easykiconverter/pending-refresh"
     done
-
-    return 0
 }
 
-# 刷新 GNOME Shell 应用缓存
-refresh_gnome_cache() {
-    log_info "刷新 GNOME Shell 应用缓存..."
+log_info "执行 pre-remove 清理..."
 
-    if ! command -v loginctl >/dev/null 2>&1 || ! command -v sudo >/dev/null 2>&1; then
-        log_warn "loginctl 或 sudo 命令不可用，跳过 GNOME 缓存刷新"
-        return 1
-    fi
-
-    # 获取所有已登录用户
-    loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
-        if [ -z "$user" ]; then
-            continue
-        fi
-
-        if ! validate_user "$user"; then
-            continue
-        fi
-
-        # 获取用户信息
-        local user_info=$(getent passwd "$user" 2>/dev/null)
-        if [ -z "$user_info" ]; then
-            continue
-        fi
-
-        local user_id=$(echo "$user_info" | cut -d: -f3)
-
-        # 只为普通用户运行（UID >= 1000）
-        if [ "$user_id" -lt 1000 ]; then
-            continue
-        fi
-
-        # 获取用户的活动会话
-        local sessions=$(loginctl list-sessions "$user" 2>/dev/null | awk '{print $1}' | grep -v "^$") || true
-        for session in $sessions; do
-            # 获取会话的 XDG_RUNTIME_DIR
-            local runtime_dir=$(loginctl show-session "$session" -p XDG_RUNTIME_DIR --value 2>/dev/null)
-            if [ -z "$runtime_dir" ]; then
-                continue
-            fi
-
-            # 检查 D-Bus 会话总线是否存在
-            local dbus_bus="$runtime_dir/bus"
-            if [ ! -S "$dbus_bus" ]; then
-                continue
-            fi
-
-            # 方法1：调用 GNOME Shell 的 appSystem.reload() 方法
-            if safe_run_as_user "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval "appSystem.reload()"; then
-                log_info "GNOME Shell 应用列表刷新成功: $user"
-            else
-                log_warn "GNOME Shell 应用列表刷新失败: $user"
-            fi
-
-            # 方法2：强制刷新应用数据库
-            if safe_run_as_user "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" gio monitor --cancel "$home/.local/share/applications"; then
-                log_info "应用数据库刷新成功: $user"
-            else
-                log_warn "应用数据库刷新失败: $user"
-            fi
-
-            # 方法3：清除 GNOME Shell 的应用图标缓存
-            if [ -d "$runtime_dir" ]; then
-                # 删除应用图标缓存文件
-                find "$runtime_dir" -name "*.desktop" -type f -delete 2>/dev/null
-                find "$runtime_dir" -name "*easykiconverter*" -type f -delete 2>/dev/null
-                log_info "GNOME Shell 应用图标缓存清除成功: $user"
-            fi
-        done
-    done
-
-    return 0
-}
-
-# === 主清理逻辑 ===
-
-# 删除应用程序文件和可执行文件
 remove_app_files
-
-# 删除系统级别的桌面文件
 remove_system_desktop_file
-
-# 删除系统级别的图标文件
 remove_system_icons
-
-# 删除 AppStream 元数据文件
 remove_metainfo_file
-
-# 删除自动启动文件
 remove_autostart_files
-
-# 删除用户级别的脚本文件
 remove_user_scripts
-
-# 同步更新桌面数据库，确保缓存更新完成
-update_desktop_database
-
-# 同步更新图标缓存，确保缓存更新完成
-update_icon_cache
-
-# 为所有已登录用户触发 GNOME 应用列表刷新
-refresh_gnome_cache
-
-# 清理用户级别的桌面文件
 remove_user_desktop_files
 
 exit 0

--- a/deploy/scripts/uninstall-appimage.sh
+++ b/deploy/scripts/uninstall-appimage.sh
@@ -1,21 +1,18 @@
 #!/bin/bash
 # AppImage 卸载脚本
-# 删除 EasyKiConverter AppImage 创建的用户级 desktop 文件和图标
+# 删除 EasyKiConverter AppImage 创建的用户级文件
 
 set -e
 
-# 应用配置
-APP_DESKTOP_NAME="io.github.tangsangsimida.easykiconverter"
-USER_DESKTOP_DIR="$HOME/.local/share/applications"
-USER_ICON_DIR="$HOME/.local/share/icons"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_ID="io.github.tangsangsimida.easykiconverter"
 
 # 颜色输出
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# 日志函数
 log_info() {
     echo -e "${GREEN}[INFO]${NC} $1"
 }
@@ -28,7 +25,17 @@ log_error() {
     echo -e "${RED}[ERROR]${NC} $1"
 }
 
-# 检查是否以正确的用户身份运行
+# 加载公共函数库
+load_common() {
+    if [ -f "${SCRIPT_DIR}/uninstall-common.sh" ]; then
+        . "${SCRIPT_DIR}/uninstall-common.sh"
+    else
+        log_error "找不到 uninstall-common.sh"
+        exit 1
+    fi
+}
+
+# 检查是否以 root 身份运行
 check_user() {
     if [ "$(id -u)" = "0" ]; then
         log_error "不要以 root 身份运行此脚本"
@@ -37,22 +44,9 @@ check_user() {
     fi
 }
 
-# 检查 desktop 文件是否存在
-check_desktop_file() {
-    local desktop_file="$USER_DESKTOP_DIR/$APP_DESKTOP_NAME.desktop"
-
-    if [ ! -f "$desktop_file" ]; then
-        log_warn "未找到 desktop 文件: $desktop_file"
-        log_warn "AppImage 可能未被正确安装"
-        return 1
-    fi
-
-    return 0
-}
-
-# 删除 desktop 文件
+# 删除桌面文件
 remove_desktop_file() {
-    local desktop_file="$USER_DESKTOP_DIR/$APP_DESKTOP_NAME.desktop"
+    local desktop_file="${HOME}/.local/share/applications/${APP_ID}.desktop"
 
     if [ -f "$desktop_file" ]; then
         if rm -f "$desktop_file"; then
@@ -61,6 +55,8 @@ remove_desktop_file() {
             log_error "无法删除 desktop 文件: $desktop_file"
             return 1
         fi
+    else
+        log_warn "未找到 desktop 文件: $desktop_file"
     fi
 
     return 0
@@ -70,43 +66,37 @@ remove_desktop_file() {
 remove_icons() {
     local removed_count=0
 
-    # 删除浅色主题图标
     for size in 16 24 32 48 64 128 256 512; do
-        local icon_file="$USER_ICON_DIR/hicolor/${size}x${size}/apps/$APP_DESKTOP_NAME.png"
-
+        local icon_file="${HOME}/.local/share/icons/hicolor/${size}x${size}/apps/${APP_ID}.png"
         if [ -f "$icon_file" ]; then
             if rm -f "$icon_file"; then
                 log_info "已删除图标 ($size x $size): $icon_file"
                 ((removed_count++))
-            else
-                log_error "无法删除图标: $icon_file"
             fi
         fi
     done
 
-    # 删除暗色主题图标
-    if [ -d "$USER_ICON_DIR/hicolor-dark" ]; then
+    if [ -d "${HOME}/.local/share/icons/hicolor-dark" ]; then
         for size in 16 24 32 48 64 128 256 512; do
-            local icon_file="$USER_ICON_DIR/hicolor-dark/${size}x${size}/apps/$APP_DESKTOP_NAME.png"
-
+            local icon_file="${HOME}/.local/share/icons/hicolor-dark/${size}x${size}/apps/${APP_ID}.png"
             if [ -f "$icon_file" ]; then
                 if rm -f "$icon_file"; then
                     log_info "已删除暗色图标 ($size x $size): $icon_file"
                     ((removed_count++))
-                else
-                    log_error "无法删除图标: $icon_file"
                 fi
             fi
         done
     fi
 
-    return 0
+    if [ $removed_count -eq 0 ]; then
+        log_warn "未找到任何图标文件"
+    fi
 }
 
 # 更新桌面数据库
 update_desktop_database() {
     if command -v update-desktop-database >/dev/null 2>&1; then
-        if update-desktop-database "$USER_DESKTOP_DIR" 2>/dev/null; then
+        if update-desktop-database "${HOME}/.local/share/applications" 2>/dev/null; then
             log_info "桌面数据库更新成功"
         else
             log_warn "桌面数据库更新失败"
@@ -118,14 +108,39 @@ update_desktop_database() {
 update_icon_cache() {
     if command -v gtk-update-icon-cache >/dev/null 2>&1; then
         for theme in hicolor hicolor-dark; do
-            if [ -d "$USER_ICON_DIR/$theme" ]; then
-                if gtk-update-icon-cache -q "$USER_ICON_DIR/$theme" 2>/dev/null; then
+            local icon_dir="${HOME}/.local/share/icons/$theme"
+            if [ -d "$icon_dir" ]; then
+                if gtk-update-icon-cache -q "$icon_dir" 2>/dev/null; then
                     log_info "图标缓存更新成功: $theme"
                 else
                     log_warn "图标缓存更新失败: $theme"
                 fi
             fi
         done
+    fi
+}
+
+# 刷新 GNOME Shell
+refresh_gnome() {
+    log_info "刷新 GNOME Shell..."
+
+    if ! command -v loginctl >/dev/null 2>&1; then
+        log_warn "loginctl 不可用，跳过 GNOME 刷新"
+        return
+    fi
+
+    local user=$(whoami)
+    local session=$(loginctl list-sessions "$user" 2>/dev/null | awk 'NR>1 {print $1}' | head -1)
+
+    if [ -n "$session" ]; then
+        local runtime_dir=$(loginctl show-session "$session" -p XDG_RUNTIME_DIR --value 2>/dev/null)
+        if [ -n "$runtime_dir" ]; then
+            export XDG_RUNTIME_DIR="$runtime_dir"
+            export DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus"
+            gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell \
+                --method org.gnome.Shell.Eval "appSystem.reload()" 2>/dev/null && \
+                log_info "GNOME Shell 刷新成功" || log_warn "GNOME Shell 刷新失败"
+        fi
     fi
 }
 
@@ -136,23 +151,15 @@ main() {
     echo "=========================================="
     echo ""
 
-    # 检查用户身份
+    load_common
     check_user
-
-    # 检查 desktop 文件是否存在
-    if ! check_desktop_file; then
-        echo ""
-        log_warn "没有找到需要卸载的文件"
-        exit 0
-    fi
 
     echo ""
     log_info "即将删除以下文件："
-    echo "  - Desktop 文件: $USER_DESKTOP_DIR/$APP_DESKTOP_NAME.desktop"
+    echo "  - Desktop 文件: ${HOME}/.local/share/applications/${APP_ID}.desktop"
     echo "  - 图标文件（所有尺寸）"
     echo ""
 
-    # 询问用户确认
     read -p "确认卸载？(y/N): " confirm
     if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
         log_info "卸载已取消"
@@ -163,17 +170,11 @@ main() {
     log_info "开始卸载..."
     echo ""
 
-    # 删除 desktop 文件
     remove_desktop_file
-
-    # 删除图标
     remove_icons
-
-    # 更新桌面数据库
     update_desktop_database
-
-    # 更新图标缓存
     update_icon_cache
+    refresh_gnome
 
     echo ""
     log_info "卸载完成！"
@@ -185,5 +186,4 @@ main() {
     echo ""
 }
 
-# 运行主函数
 main "$@"

--- a/deploy/scripts/uninstall-common.sh
+++ b/deploy/scripts/uninstall-common.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 # 通用卸载清理函数库
-# 用于 prerm.sh 和 postrm.sh 的共享清理逻辑
+# 用于 prerm.sh、postrm.sh 和 uninstall-*.sh 的共享清理逻辑
 
 # 应用配置变量
 APP_NAME="easykiconverter"
-APP_DESKTOP_NAME="io.github.tangsangsimida.easykiconverter"
+APP_ID="io.github.tangsangsimida.easykiconverter"
+APP_DESKTOP_NAME="${APP_ID}"
 APP_INSTALL_DIR="/opt/easykiconverter"
 APP_BIN_LINK="/usr/bin/easykiconverter"
 APP_DESKTOP_FILE="/usr/share/applications/${APP_DESKTOP_NAME}.desktop"
@@ -12,6 +13,12 @@ APP_METAINFO_FILE="/usr/share/metainfo/${APP_DESKTOP_NAME}.metainfo.xml"
 APP_SCRIPT_DIR="/usr/share/easykiconverter"
 AUTOSTART_FILE="/etc/xdg/autostart/easykiconverter-register.desktop"
 AUTOSTART_FILE_SYSTEM="/usr/share/xdg/autostart/easykiconverter-register.desktop"
+
+# 用户数据目录
+USER_DATA_DIR="${HOME}/.local/share/EasyKiConverter"
+USER_CONFIG_DIR="${HOME}/.config/EasyKiConverter"
+FLATPAK_USER_DATA_DIR="${HOME}/.var/app/${APP_ID}"
+FLATPAK_REPO_DIR="${HOME}/.local/share/flatpak/repo/refs/heads/deploy/app/${APP_ID}"
 
 # 日志函数
 log_info() {
@@ -51,7 +58,7 @@ safe_remove_file() {
             return 1
         fi
     else
-        return 0  # 文件不存在，视为成功
+        return 0
     fi
 }
 
@@ -72,7 +79,7 @@ safe_remove_dir() {
             return 1
         fi
     else
-        return 0  # 目录不存在，视为成功
+        return 0
     fi
 }
 
@@ -87,21 +94,27 @@ remove_app_files() {
 remove_system_desktop_file() {
     log_info "删除系统级别的桌面文件..."
     safe_remove_file "$APP_DESKTOP_FILE"
+    safe_remove_file "/usr/share/applications/com.tangsangsimida.easykiconverter.desktop"
 }
 
 # 删除系统级别的图标文件
 remove_system_icons() {
     log_info "删除系统级别的图标文件..."
     for size in 16x16 32x32 48x48 64x64 128x128 256x256 512x512; do
-        local icon_file="/usr/share/icons/hicolor/$size/apps/${APP_DESKTOP_NAME}.png"
-        safe_remove_file "$icon_file"
+        safe_remove_file "/usr/share/icons/hicolor/$size/apps/${APP_DESKTOP_NAME}.png"
     done
+    if [ -d "/usr/share/icons/hicolor-dark" ]; then
+        for size in 16x16 32x32 48x48 64x64 128x128 256x256 512x512; do
+            safe_remove_file "/usr/share/icons/hicolor-dark/$size/apps/${APP_DESKTOP_NAME}.png"
+        done
+    fi
 }
 
 # 删除 AppStream 元数据文件
 remove_metainfo_file() {
     log_info "删除 AppStream 元数据文件..."
     safe_remove_file "$APP_METAINFO_FILE"
+    safe_remove_file "/usr/share/metainfo/com.tangsangsimida.easykiconverter.metainfo.xml"
 }
 
 # 删除自动启动文件
@@ -115,6 +128,36 @@ remove_autostart_files() {
 remove_user_scripts() {
     log_info "删除用户级别的脚本文件..."
     safe_remove_dir "$APP_SCRIPT_DIR"
+}
+
+# 删除用户数据（用户配置、日志、缓存等）
+remove_user_data() {
+    log_info "删除用户数据..."
+    safe_remove_dir "$USER_DATA_DIR"
+}
+
+# 删除用户配置
+remove_user_config() {
+    log_info "删除用户配置..."
+    safe_remove_dir "$USER_CONFIG_DIR"
+}
+
+# 删除 Flatpak 用户数据
+remove_flatpak_user_data() {
+    log_info "删除 Flatpak 用户数据..."
+    safe_remove_dir "$FLATPAK_USER_DATA_DIR"
+}
+
+# 删除 Flatpak 仓库引用
+remove_flatpak_repo_refs() {
+    log_info "删除 Flatpak 仓库引用..."
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/app/${APP_ID}"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/runtime/${APP_ID}.Debug"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/easykiconverter-origin"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/easykiconverter1-origin"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/debug-origin"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/local-repo"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/remotes/local-repo-local"
 }
 
 # 更新桌面数据库
@@ -133,12 +176,29 @@ update_desktop_database() {
 update_icon_cache() {
     log_info "更新图标缓存..."
     if command -v gtk-update-icon-cache >/dev/null 2>&1; then
-        for theme in hicolor Adwaita; do
+        for theme in hicolor hicolor-dark Adwaita; do
             if [ -d "/usr/share/icons/$theme" ]; then
                 if gtk-update-icon-cache -q -t -f "/usr/share/icons/$theme" 2>/dev/null; then
                     log_info "图标缓存更新成功: $theme"
                 else
                     log_warn "图标缓存更新失败: $theme"
+                fi
+            fi
+        done
+    fi
+}
+
+# 更新用户图标缓存
+update_user_icon_cache() {
+    log_info "更新用户图标缓存..."
+    if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+        for theme in hicolor hicolor-dark; do
+            local user_icon_dir="${HOME}/.local/share/icons/$theme"
+            if [ -d "$user_icon_dir" ]; then
+                if gtk-update-icon-cache -q -t -f "$user_icon_dir" 2>/dev/null; then
+                    log_info "用户图标缓存更新成功: $theme"
+                else
+                    log_warn "用户图标缓存更新失败: $theme"
                 fi
             fi
         done
@@ -153,13 +213,11 @@ validate_user() {
         return 1
     fi
 
-    # 检查用户名是否只包含安全字符（字母、数字、下划线、连字符）
     if ! echo "$user" | grep -qE '^[a-zA-Z0-9_-]+$'; then
         log_error "validate_user: 用户名包含不安全字符: $user"
         return 1
     fi
 
-    # 检查用户是否存在
     if ! getent passwd "$user" >/dev/null 2>&1; then
         log_error "validate_user: 用户不存在: $user"
         return 1
@@ -172,14 +230,13 @@ validate_user() {
 safe_run_as_user() {
     local user="$1"
     shift
-    local cmd="$@"
 
     if ! validate_user "$user"; then
         return 1
     fi
 
-    if ! sudo -u "$user" $cmd 2>/dev/null; then
-        log_warn "以用户 $user 执行命令失败: $cmd"
+    if ! sudo -u "$user" "$@" 2>/dev/null; then
+        log_warn "以用户 $user 执行命令失败"
         return 1
     fi
 
@@ -195,7 +252,6 @@ remove_user_desktop_files() {
         return 1
     fi
 
-    # 遍历所有普通用户（UID >= 1000）
     getent passwd | awk -F: '$3 >= 1000 {print $1, $6}' | while read -r user home; do
         if [ -z "$user" ] || [ -z "$home" ] || [ ! -d "$home" ]; then
             continue
@@ -206,43 +262,33 @@ remove_user_desktop_files() {
         fi
 
         local user_desktop="$home/.local/share/applications"
-        if [ ! -d "$user_desktop" ]; then
-            continue
-        fi
-
-        # 使用 find 命令查找所有匹配的文件
-        find "$user_desktop" -maxdepth 1 -type f \( -iname "*EasyKi*.desktop" -o -iname "*easykiconverter*.desktop" \) 2>/dev/null | while read -r desktop_file; do
-            if [ ! -f "$desktop_file" ]; then
-                continue
-            fi
-
-            # 检查文件内容，确保是当前应用的桌面文件
-            if grep -qi "EasyKiConverter\|easykiconverter\|tangsangsimida" "$desktop_file" 2>/dev/null; then
-                if safe_remove_file "$desktop_file"; then
+        if [ -d "$user_desktop" ]; then
+            find "$user_desktop" -maxdepth 1 -type f \( -iname "*EasyKi*.desktop" -o -iname "*easykiconverter*.desktop" \) 2>/dev/null | while read -r desktop_file; do
+                if [ -f "$desktop_file" ] && grep -qi "EasyKiConverter\|easykiconverter\|tangsangsimida" "$desktop_file" 2>/dev/null; then
+                    safe_remove_file "$desktop_file"
                     log_info "已删除用户级别桌面文件: $desktop_file"
                 fi
-            fi
-        done
+            done
 
-        # 更新用户桌面数据库
-        if command -v update-desktop-database >/dev/null 2>&1; then
-            if update-desktop-database "$user_desktop" 2>/dev/null; then
-                log_info "用户桌面数据库更新成功: $user"
-            else
-                log_warn "用户桌面数据库更新失败: $user"
+            if command -v update-desktop-database >/dev/null 2>&1; then
+                update-desktop-database "$user_desktop" 2>/dev/null
             fi
         fi
 
-        # 删除用户级别的应用注册标记文件
-        local marker_file="$home/.config/easykiconverter-registered"
-        safe_remove_file "$marker_file"
-
-        # 删除待处理刷新标记文件
-        local pending_file="$home/.config/easykiconverter/pending-refresh"
-        safe_remove_file "$pending_file"
+        safe_remove_file "$home/.config/easykiconverter-registered"
+        safe_remove_file "$home/.config/easykiconverter/pending-refresh"
     done
 
     return 0
+}
+
+# 删除用户图标
+remove_user_icons() {
+    log_info "删除用户图标..."
+    for size in 16 24 32 48 64 128 256 512; do
+        safe_remove_file "${HOME}/.local/share/icons/hicolor/${size}x${size}/apps/${APP_DESKTOP_NAME}.png"
+        safe_remove_file "${HOME}/.local/share/icons/hicolor-dark/${size}x${size}/apps/${APP_DESKTOP_NAME}.png"
+    done
 }
 
 # 刷新 GNOME Shell 应用缓存
@@ -254,65 +300,28 @@ refresh_gnome_cache() {
         return 1
     fi
 
-    # 获取所有已登录用户
-    loginctl list-users 2>/dev/null | awk '{print $2}' | while read -r user; do
-        if [ -z "$user" ] || [ "$user" = "USER" ]; then
+    loginctl list-users 2>/dev/null | awk 'NR>1 {print $2}' | while read -r user; do
+        if [ -z "$user" ] || ! validate_user "$user"; then
             continue
         fi
 
-        if ! validate_user "$user"; then
-            continue
-        fi
-
-        # 获取用户信息
         local user_info=$(getent passwd "$user" 2>/dev/null)
-        if [ -z "$user_info" ]; then
-            continue
-        fi
+        [ -z "$user_info" ] && continue
 
         local user_id=$(echo "$user_info" | cut -d: -f3)
+        [ "$user_id" -lt 1000 ] && continue
 
-        # 只为普通用户运行（UID >= 1000）
-        if [ "$user_id" -lt 1000 ]; then
-            continue
-        fi
-
-        # 获取用户的活动会话
         local sessions=$(loginctl list-sessions "$user" 2>/dev/null | awk '{print $1}' | grep -v "^$") || true
         for session in $sessions; do
-            # 获取会话的 XDG_RUNTIME_DIR
             local runtime_dir=$(loginctl show-session "$session" -p XDG_RUNTIME_DIR --value 2>/dev/null)
-            if [ -z "$runtime_dir" ]; then
-                continue
-            fi
+            [ -z "$runtime_dir" ] && continue
 
-            # 检查 D-Bus 会话总线是否存在
             local dbus_bus="$runtime_dir/bus"
-            if [ ! -S "$dbus_bus" ]; then
-                continue
-            fi
+            [ ! -S "$dbus_bus" ] && continue
 
-            # 方法1：调用 GNOME Shell 的 appSystem.reload() 方法
-            if safe_run_as_user "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval "appSystem.reload()"; then
-                log_info "GNOME Shell 应用列表刷新成功: $user"
-            else
-                log_warn "GNOME Shell 应用列表刷新失败: $user"
-            fi
-
-            # 方法2：强制刷新应用数据库
-            if safe_run_as_user "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" gio monitor --cancel "$home/.local/share/applications"; then
-                log_info "应用数据库刷新成功: $user"
-            else
-                log_warn "应用数据库刷新失败: $user"
-            fi
-
-            # 方法3：清除 GNOME Shell 的应用图标缓存
-            if [ -d "$runtime_dir" ]; then
-                # 删除应用图标缓存文件
-                find "$runtime_dir" -name "*.desktop" -type f -delete 2>/dev/null
-                find "$runtime_dir" -name "*easykiconverter*" -type f -delete 2>/dev/null
-                log_info "GNOME Shell 应用图标缓存清除成功: $user"
-            fi
+            safe_run_as_user "$user" env XDG_RUNTIME_DIR="$runtime_dir" DBUS_SESSION_BUS_ADDRESS="unix:path=$dbus_bus" \
+                gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval "appSystem.reload()" 2>/dev/null && \
+                log_info "GNOME Shell 应用列表刷新成功: $user" || log_warn "GNOME Shell 应用列表刷新失败: $user"
         done
     done
 
@@ -326,36 +335,26 @@ purge_dpkg_metadata() {
     local purge_flag_file="/tmp/${APP_NAME}-purge-in-progress"
 
     if [ "$1" = "purge" ]; then
-        # 已在 purge 模式，清理标志文件
         safe_remove_file "$purge_flag_file"
         return 0
     elif [ "$1" = "remove" ]; then
-        # 在 remove 模式下，等待短暂时间后自动执行 purge
         (
             sleep 2
 
-            # 检查标志文件，防止并发执行
             if [ -f "$purge_flag_file" ]; then
                 exit 0
             fi
 
-            # 创建标志文件（使用更安全的临时文件创建方法）
             if ! mktemp "$purge_flag_file.XXXXXX" >/dev/null 2>&1; then
                 log_error "无法创建标志文件: $purge_flag_file"
                 exit 1
             fi
 
-            # 检查包状态
             if dpkg-query -W -f='${Status}' "$APP_NAME" 2>/dev/null | grep -q "config-files"; then
                 log_info "包处于 config-files 状态，执行 purge"
-                if dpkg --purge "$APP_NAME" >/dev/null 2>&1; then
-                    log_info "dpkg purge 成功"
-                else
-                    log_error "dpkg purge 失败"
-                fi
+                dpkg --purge "$APP_NAME" >/dev/null 2>&1 || log_error "dpkg purge 失败"
             fi
 
-            # 清理标志文件
             safe_remove_file "$purge_flag_file*"
         ) >/dev/null 2>&1 &
 

--- a/deploy/scripts/uninstall-flatpak.sh
+++ b/deploy/scripts/uninstall-flatpak.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Flatpak 卸载脚本
+# 卸载 EasyKiConverter Flatpak 并清理相关文件
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_ID="io.github.tangsangsimida.easykiconverter"
+
+# 颜色输出
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# 加载公共函数库
+load_common() {
+    if [ -f "${SCRIPT_DIR}/uninstall-common.sh" ]; then
+        . "${SCRIPT_DIR}/uninstall-common.sh"
+    else
+        log_error "找不到 uninstall-common.sh"
+        exit 1
+    fi
+}
+
+# 检查是否以 root 身份运行
+check_root() {
+    if [ "$(id -u)" = "0" ]; then
+        log_warn "检测到 root 身份运行，Flatpak 卸载可能需要用户确认"
+    fi
+}
+
+# 检查 flatpak 是否可用
+check_flatpak() {
+    if ! command -v flatpak >/dev/null 2>&1; then
+        log_error "flatpak 命令不可用，请安装 flatpak"
+        exit 1
+    fi
+}
+
+# 检查 desktop 文件
+check_desktop_file() {
+    local desktop_file="${HOME}/.local/share/applications/${APP_ID}.desktop"
+    if [ -f "$desktop_file" ]; then
+        log_info "找到用户 desktop 文件: $desktop_file"
+        return 0
+    fi
+    return 1
+}
+
+# 卸载 Flatpak
+uninstall_flatpak_app() {
+    log_info "正在卸载 Flatpak 应用..."
+
+    if flatpak uninstall "$APP_ID" -y 2>/dev/null; then
+        log_info "Flatpak 应用卸载成功"
+    else
+        log_warn "Flatpak 应用未安装或卸载失败"
+    fi
+
+    log_info "清理未使用的 Flatpak 运行时..."
+    flatpak uninstall --unused -y 2>/dev/null || true
+}
+
+# 删除用户数据
+clean_user_data() {
+    log_info "删除用户数据..."
+
+    safe_remove_dir "${HOME}/.local/share/EasyKiConverter"
+    safe_remove_dir "${HOME}/.var/app/${APP_ID}"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/app/${APP_ID}"
+    safe_remove_dir "${HOME}/.local/share/flatpak/repo/refs/heads/deploy/runtime/${APP_ID}.Debug"
+}
+
+# 删除用户配置文件
+clean_user_config() {
+    log_info "删除用户配置..."
+    safe_remove_dir "${HOME}/.config/EasyKiConverter"
+}
+
+# 删除桌面文件
+remove_desktop_file() {
+    local desktop_file="${HOME}/.local/share/applications/${APP_ID}.desktop"
+    safe_remove_file "$desktop_file"
+}
+
+# 删除用户图标
+remove_user_icons() {
+    log_info "删除用户图标..."
+    for size in 16 24 32 48 64 128 256 512; do
+        safe_remove_file "${HOME}/.local/share/icons/hicolor/${size}x${size}/apps/${APP_ID}.png"
+        safe_remove_file "${HOME}/.local/share/icons/hicolor-dark/${size}x${size}/apps/${APP_ID}.png"
+    done
+}
+
+# 更新桌面数据库
+update_desktop_database() {
+    log_info "更新桌面数据库..."
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database "${HOME}/.local/share/applications" 2>/dev/null || true
+    fi
+}
+
+# 更新图标缓存
+update_icon_cache() {
+    log_info "更新图标缓存..."
+    if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+        for theme in hicolor hicolor-dark; do
+            local icon_dir="${HOME}/.local/share/icons/$theme"
+            if [ -d "$icon_dir" ]; then
+                gtk-update-icon-cache -q -t -f "$icon_dir" 2>/dev/null || true
+            fi
+        done
+    fi
+}
+
+# 刷新 GNOME Shell
+refresh_gnome() {
+    log_info "刷新 GNOME Shell..."
+
+    if ! command -v loginctl >/dev/null 2>&1; then
+        log_warn "loginctl 不可用，跳过 GNOME 刷新"
+        return
+    fi
+
+    local user=$(whoami)
+    local session=$(loginctl list-sessions "$user" 2>/dev/null | awk 'NR>1 {print $1}' | head -1)
+
+    if [ -n "$session" ]; then
+        local runtime_dir=$(loginctl show-session "$session" -p XDG_RUNTIME_DIR --value 2>/dev/null)
+        if [ -n "$runtime_dir" ]; then
+            export XDG_RUNTIME_DIR="$runtime_dir"
+            export DBUS_SESSION_BUS_ADDRESS="unix:path=$runtime_dir/bus"
+            gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell \
+                --method org.gnome.Shell.Eval "appSystem.reload()" 2>/dev/null && \
+                log_info "GNOME Shell 刷新成功" || log_warn "GNOME Shell 刷新失败"
+        fi
+    fi
+}
+
+# 主函数
+main() {
+    echo "=========================================="
+    echo "  EasyKiConverter Flatpak 卸载工具"
+    echo "=========================================="
+    echo ""
+
+    load_common
+    check_root
+    check_flatpak
+
+    local remove_data=false
+    local remove_config=false
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --remove-data)
+                remove_data=true
+                shift
+                ;;
+            --remove-config)
+                remove_config=true
+                shift
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+
+    echo ""
+    log_info "即将执行以下清理："
+    echo "    - 卸载 Flatpak 应用"
+    echo "    - 删除 desktop 文件"
+    echo "    - 删除用户图标"
+    echo ""
+
+    if [ "$remove_data" = true ]; then
+        echo "    - 删除用户数据 (~/.local/share/EasyKiConverter)"
+        echo "    - 删除 Flatpak 用户数据 (~/.var/app/${APP_ID})"
+    fi
+
+    if [ "$remove_config" = true ]; then
+        echo "    - 删除用户配置 (~/.config/EasyKiConverter)"
+    fi
+
+    echo ""
+    read -p "确认卸载？(y/N): " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        log_info "卸载已取消"
+        exit 0
+    fi
+
+    echo ""
+    log_info "开始卸载..."
+    echo ""
+
+    uninstall_flatpak_app
+    remove_desktop_file
+    remove_user_icons
+    update_desktop_database
+    update_icon_cache
+    refresh_gnome
+
+    if [ "$remove_data" = true ]; then
+        clean_user_data
+    fi
+
+    if [ "$remove_config" = true ]; then
+        clean_user_config
+    fi
+
+    echo ""
+    log_info "卸载完成！"
+    echo ""
+    log_info "提示：如果任务栏图标仍然显示，请注销并重新登录或重启桌面环境"
+    echo ""
+}
+
+main "$@"

--- a/deploy/scripts/uninstall.sh
+++ b/deploy/scripts/uninstall.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# 统一卸载脚本
+# 支持 deb、flatpak、appimage 三种卸载方式
+#
+# 用法:
+#   uninstall.sh --type deb          # Debian/Ubuntu 包卸载
+#   uninstall.sh --type flatpak      # Flatpak 卸载
+#   uninstall.sh --type appimage     # AppImage 卸载
+#   uninstall.sh --type all         # 全部清理（包括用户数据）
+#   uninstall.sh --help              # 显示帮助
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# 颜色输出
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+usage() {
+    cat << EOF
+用法: $(basename "$0") [选项]
+
+EasyKiConverter 统一卸载工具
+
+选项:
+    --type TYPE     指定卸载类型: deb, flatpak, appimage, all
+    --remove-data   同时删除用户数据（~/.local/share/EasyKiConverter）
+    --remove-config 同时删除用户配置（~/.config/EasyKiConverter）
+    --help          显示此帮助信息
+
+示例:
+    $(basename "$0") --type deb
+    $(basename "$0") --type flatpak --remove-data
+    $(basename "$0") --type all
+
+EOF
+}
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# 加载公共函数库
+load_common() {
+    if [ -f "${SCRIPT_DIR}/uninstall-common.sh" ]; then
+        . "${SCRIPT_DIR}/uninstall-common.sh"
+    else
+        log_error "找不到 uninstall-common.sh"
+        exit 1
+    fi
+}
+
+# 卸载 DEB 包
+uninstall_deb() {
+    log_info "开始卸载 DEB 包..."
+
+    remove_app_files
+    remove_system_desktop_file
+    remove_system_icons
+    remove_metainfo_file
+    remove_autostart_files
+    remove_user_scripts
+    update_desktop_database
+    update_icon_cache
+    remove_user_desktop_files
+    refresh_gnome_cache
+    purge_dpkg_metadata "remove"
+}
+
+# 卸载 Flatpak
+uninstall_flatpak() {
+    log_info "开始卸载 Flatpak..."
+
+    if command -v flatpak >/dev/null 2>&1; then
+        if flatpak uninstall "$APP_ID" -y 2>/dev/null; then
+            log_info "Flatpak 卸载成功"
+        else
+            log_warn "Flatpak 未安装或卸载失败"
+        fi
+
+        flatpak uninstall --unused -y 2>/dev/null || true
+    else
+        log_warn "flatpak 命令不可用"
+    fi
+
+    remove_flatpak_user_data
+    remove_flatpak_repo_refs
+    remove_user_desktop_files
+    update_user_icon_cache
+    refresh_gnome_cache
+}
+
+# 卸载 AppImage
+uninstall_appimage() {
+    log_info "开始卸载 AppImage..."
+
+    remove_user_desktop_files
+    remove_user_icons
+    update_user_icon_cache
+    refresh_gnome_cache
+}
+
+# 删除用户数据
+clean_user_data() {
+    log_info "删除用户数据..."
+    remove_user_data
+    remove_user_config
+    remove_flatpak_user_data
+    remove_flatpak_repo_refs
+    log_info "用户数据清理完成"
+}
+
+# 主函数
+main() {
+    local uninstall_type=""
+    local remove_data=false
+    local remove_config=false
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --type)
+                uninstall_type="$2"
+                shift 2
+                ;;
+            --remove-data)
+                remove_data=true
+                shift
+                ;;
+            --remove-config)
+                remove_config=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                log_error "未知选项: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$uninstall_type" ]; then
+        log_error "请指定 --type"
+        usage
+        exit 1
+    fi
+
+    load_common
+
+    echo ""
+    echo "=========================================="
+    echo "  EasyKiConverter 卸载工具"
+    echo "=========================================="
+    echo ""
+
+    case "$uninstall_type" in
+        deb)
+            uninstall_deb
+            ;;
+        flatpak)
+            uninstall_flatpak
+            ;;
+        appimage)
+            uninstall_appimage
+            ;;
+        all)
+            uninstall_deb
+            uninstall_flatpak
+            uninstall_appimage
+            ;;
+        *)
+            log_error "未知卸载类型: $uninstall_type"
+            usage
+            exit 1
+            ;;
+    esac
+
+    if [ "$remove_data" = true ]; then
+        clean_user_data
+    fi
+
+    if [ "$remove_config" = true ]; then
+        remove_user_config
+    fi
+
+    echo ""
+    log_info "卸载完成！"
+    echo ""
+    if [ "$remove_data" = false ]; then
+        log_warn "提示: 用户数据未删除。如需删除，请运行:"
+        echo "    $(basename "$0") --type $uninstall_type --remove-data"
+    fi
+}
+
+main "$@"

--- a/tools/linux/build-packages.sh
+++ b/tools/linux/build-packages.sh
@@ -397,6 +397,12 @@ export APPIMAGE_PATH="$APPIMAGE"
 
 # 自动安装 desktop 文件和图标到用户目录（支持路径检测和更新）
 install_desktop_file() {
+    # 只有在 AppImage 模式下才安装 desktop 文件到用户目录
+    # DEB/RPM 包使用系统目录 /usr/share/applications/ 中的 desktop 文件
+    if [ -z "$APPIMAGE" ]; then
+        return 0
+    fi
+    
     # 创建用户目录
     mkdir -p "$USER_DESKTOP_DIR"
     
@@ -622,6 +628,7 @@ build_deb() {
         -e "s|deploy/scripts/easykiconverter-register.desktop|$PROJECT_ROOT/deploy/scripts/easykiconverter-register.desktop|g" \
         -e "s|deploy/scripts/trigger-gnome-refresh.sh|$PROJECT_ROOT/deploy/scripts/trigger-gnome-refresh.sh|g" \
         -e "s|deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|$PROJECT_ROOT/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml|g" \
+        -e "s|deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|$PROJECT_ROOT/deploy/linux/io.github.tangsangsimida.easykiconverter.desktop|g" \
         "$PROJECT_ROOT/deploy/nfpm.yaml" > "$temp_nfpm_config"
     
     # 运行 nfpm 构建（必须指定 --packager）


### PR DESCRIPTION
## 描述

修复 Linux 桌面环境集成问题，优化卸载清理流程：

### 主要修复

1. **修复桌面图标启动后消失问题**
   - 将 `StartupNotify=true` 改为 `StartupNotify=false`
   - 原因：`StartupNotify=true` 时 GNOME Shell 会跟踪应用启动状态，但 FramelessWindowHint + 延迟显示导致启动通知握手未完成，应用关闭后 Shell 仍认为应用在启动中，显示"点"且无法再次启动

2. **修复 DEB 包 desktop 文件错误**
   - `nfpm.yaml` 之前从 AppDir 复制 desktop 文件（`Exec=AppRun`），应该使用 `deploy/linux/` 中的正确版本（`Exec=easykiconverter`）
   - `build-packages.sh` 添加了 `deploy/linux/` 路径替换

3. **优化卸载清理流程**
   - 新增 `uninstall.sh` 统一卸载入口，支持 `--type deb|flatpak|appimage|all`
   - 新增 `uninstall-flatpak.sh` Flatpak 卸载脚本
   - 重构 `uninstall-appimage.sh` 使用公共函数库
   - 简化 `prerm.sh` 和 `postrm.sh`，使其自包含不依赖外部文件

4. **修复用户数据清理**
   - `postrm.sh`之前使用 `$HOME`（dpkg 以 root 运行时会指向 `/root`），现在遍历所有用户正确清理 `~/.local/share/EasyKiConverter/`

5. **AppRun 脚本修复**
   - 修复 `install_desktop_file()` 函数，在非 AppImage 模式下错误地在用户目录创建 desktop 文件
   - 添加 `APPIMAGE` 环境变量检查，只有在 AppImage 模式下才在用户目录安装 desktop 文件
