### PR TITLE
fix/uninstall-user-data

### DIFF
--- a/resources/windows_setup.iss
+++ b/resources/windows_setup.iss
@@ -4,6 +4,8 @@
 #define MyAppPublisher "tangsangsimida"
 #define MyAppURL "https://github.com/tangsangsimida/EasyKiConverter"
 #define MyAppExeName "easykiconverter.exe"
+; 用户数据目录名称（需与 ConfigService 中一致）
+#define UserDataDirName "EasyKiConverter_Cpp_Version"
 
 ; 这些变量将通过命令行定义传入
 ;#define MyAppVersion "3.0.0"
@@ -139,7 +141,7 @@ begin
   begin
     if DeleteUserDataCheckBox.Checked then
     begin
-      UserDataDir := ExpandConstant('{localappdata}\EasyKiConverter_Cpp_Version');
+      UserDataDir := ExpandConstant('{localappdata}') + '\' + '{#UserDataDirName}';
       if DirExists(UserDataDir) then
         DelTree(UserDataDir, True, True, True);
     end;
@@ -149,8 +151,8 @@ end;
 // 支持静默安装/卸载参数
 procedure CurPageChanged(CurPageID: Integer);
 begin
-  // 静默模式下自动勾选删除用户数据选项
-  if CurPageID = UninstallPage.ID then
+  // 静默卸载模式下自动勾选删除用户数据选项
+  if Uninstall and (CurPageID = UninstallPage.ID) then
   begin
     if WizardSilent() then
       DeleteUserDataCheckBox.Checked := True;
@@ -159,4 +161,4 @@ end;
 
 
 [UninstallDelete]
-Type: filesandordirectories; Name: "{localappdata}\EasyKiConverter_Cpp_Version"
+Type: filesandordirectories; Name: "{localappdata}\{#UserDataDirName}"

--- a/resources/windows_setup.iss
+++ b/resources/windows_setup.iss
@@ -62,3 +62,36 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: de
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+var
+  DeleteUserDataCheckBox: TNewCheckBox;
+
+procedure InitializeWizard();
+begin
+  DeleteUserDataCheckBox := TNewCheckBox.Create(WizardForm);
+  DeleteUserDataCheckBox.Caption := '删除用户配置和数据 (Delete user data)';
+  DeleteUserDataCheckBox.Left := ScaleX(20);
+  DeleteUserDataCheckBox.Top := ScaleY(150);
+  DeleteUserDataCheckBox.Width := ScaleX(350);
+  DeleteUserDataCheckBox.Checked := False;
+  DeleteUserDataCheckBox.Parent := WizardForm.SelectTasksPage;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  UserDataDir: String;
+begin
+  if CurUninstallStep = usPostUninstall then
+  begin
+    if DeleteUserDataCheckBox.Checked then
+    begin
+      UserDataDir := ExpandConstant('{localappdata}\EasyKiConverter_Cpp_Version');
+      if DirExists(UserDataDir) then
+        DelTree(UserDataDir, True, True, True);
+    end;
+  end;
+end;
+
+[UninstallDelete]
+Type: filesandordirectories; Name: "{localappdata}\EasyKiConverter_Cpp_Version"

--- a/resources/windows_setup.iss
+++ b/resources/windows_setup.iss
@@ -27,6 +27,12 @@ DisableProgramGroupPage=yes
 ; the "ArchitecturesAllowed=x64" directive specifies that this setup is for 64-bit Windows only
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
+; 要求管理员权限
+PrivilegesRequired=admin
+; 最低 Windows 10 版本 (Windows 10 1809+)
+MinimumVersion=10.0.17763
+; 卸载时显示程序图标
+UninstallDisplayIcon={app}\{#MyAppExeName}
 #ifdef LicensePath
 LicenseFile={#LicensePath}
 #else
@@ -66,16 +72,63 @@ Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChang
 [Code]
 var
   DeleteUserDataCheckBox: TNewCheckBox;
+  UninstallPage: TWizardPage;
+  AppMutex: String;
+
+// 创建卸载选项页面
+procedure CreateUninstallPage();
+begin
+  UninstallPage := CreateCustomPage(wpWelcome, '卸载选项 (Uninstall Options)', '选择是否删除用户数据');
+  DeleteUserDataCheckBox := TNewCheckBox.Create(UninstallPage);
+  DeleteUserDataCheckBox.Parent := UninstallPage.Surface;
+  DeleteUserDataCheckBox.Caption := '删除用户配置和数据 (Delete user data)';
+  DeleteUserDataCheckBox.Left := ScaleX(20);
+  DeleteUserDataCheckBox.Top := ScaleY(10);
+  DeleteUserDataCheckBox.Width := ScaleX(350);
+  DeleteUserDataCheckBox.Checked := False;
+end;
 
 procedure InitializeWizard();
 begin
-  DeleteUserDataCheckBox := TNewCheckBox.Create(WizardForm);
-  DeleteUserDataCheckBox.Caption := '删除用户配置和数据 (Delete user data)';
-  DeleteUserDataCheckBox.Left := ScaleX(20);
-  DeleteUserDataCheckBox.Top := ScaleY(150);
-  DeleteUserDataCheckBox.Width := ScaleX(350);
-  DeleteUserDataCheckBox.Checked := False;
-  DeleteUserDataCheckBox.Parent := WizardForm.SelectTasksPage;
+  AppMutex := 'EasyKiConverter_SingleInstance';
+  // 仅在卸载时创建自定义页面
+  if Uninstall then
+    CreateUninstallPage();
+end;
+
+// 安装前检查程序是否在运行（静默和非静默都支持）
+function InitializeSetup(): Boolean;
+begin
+  Result := True;
+  if CheckForMutexes(AppMutex, 0) then
+  begin
+    if WizardSilent() then
+    begin
+      // 静默安装时直接退出，不弹框
+      Result := False;
+    end
+    else
+    begin
+      MsgBox('请先关闭 EasyKiConverter，然后再继续安装。'#13#10#13#10'Please close EasyKiConverter before continuing.',
+            mbError, MB_OK);
+      Result := False;
+    end;
+  end;
+end;
+
+// 安装页面点击"下一步"前检查程序是否在运行
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  if CurPageID = wpWelcome then
+  begin
+    if CheckForMutexes(AppMutex, 0) then
+    begin
+      MsgBox('请先关闭 EasyKiConverter，然后再继续安装。'#13#10#13#10'Please close EasyKiConverter before continuing.',
+            mbError, MB_OK);
+      Result := False;
+    end;
+  end;
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
@@ -92,6 +145,18 @@ begin
     end;
   end;
 end;
+
+// 支持静默安装/卸载参数
+procedure CurPageChanged(CurPageID: Integer);
+begin
+  // 静默模式下自动勾选删除用户数据选项
+  if CurPageID = UninstallPage.ID then
+  begin
+    if WizardSilent() then
+      DeleteUserDataCheckBox.Checked := True;
+  end;
+end;
+
 
 [UninstallDelete]
 Type: filesandordirectories; Name: "{localappdata}\EasyKiConverter_Cpp_Version"


### PR DESCRIPTION
## 提交内容

### 1. feat(installer): 添加用户数据删除选项到Windows安装程序
- 在卸载向导页面添加"删除用户配置和数据"复选框
- 支持静默卸载时自动删除用户数据
- 添加 [UninstallDelete] 段确保用户数据目录可被删除

### 2. feat(installer): 更新 Windows 安装脚本以增强用户体验
- 添加 `PrivilegesRequired=admin` 要求管理员权限
- 添加 `MinimumVersion=10.0.17763` 限定最低 Windows 10 版本
- 添加 `UninstallDisplayIcon` 在卸载列表显示程序图标
- 修复复选框位置 Bug（使用 CreateCustomPage）
- 添加安装前进程检查（检测 mutex）
- 支持静默安装时程序在运行则直接退出
## 相关 Issue
- Fixes #138

## 验证方案
1. 使用 Inno Setup 编译生成新的安装包
2. 安装应用并修改配置
3. 执行卸载，确认复选框显示
4. 勾选复选框后卸载，确认用户数据目录被删除
5. 不勾选时卸载，确认用户数据目录保留
6. 测试静默安装/卸载：`/SILENT /DIR="..."`
