### PR TITLE
feat: 增强构建配置支持、调试导出及元件列表清空逻辑

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -384,12 +384,24 @@ int main(int argc, char* argv[]) {
         QQuickWindow tempWindow;
         const char* apiName = "Unknown";
         switch (tempWindow.graphicsApi()) {
-            case QSGRendererInterface::OpenGL: apiName = "OpenGL"; break;
-            case QSGRendererInterface::Vulkan: apiName = "Vulkan"; break;
-            case QSGRendererInterface::Software: apiName = "Software"; break;
-            case QSGRendererInterface::Direct3D11: apiName = "Direct3D 11"; break;
-            case QSGRendererInterface::Metal: apiName = "Metal"; break;
-            default: apiName = "Other/Unknown"; break;
+            case QSGRendererInterface::OpenGL:
+                apiName = "OpenGL";
+                break;
+            case QSGRendererInterface::Vulkan:
+                apiName = "Vulkan";
+                break;
+            case QSGRendererInterface::Software:
+                apiName = "Software";
+                break;
+            case QSGRendererInterface::Direct3D11:
+                apiName = "Direct3D 11";
+                break;
+            case QSGRendererInterface::Metal:
+                apiName = "Metal";
+                break;
+            default:
+                apiName = "Other/Unknown";
+                break;
         }
         qInfo() << "当前实际运行的渲染 API:" << apiName;
     });

--- a/src/models/ComponentData.h
+++ b/src/models/ComponentData.h
@@ -171,14 +171,29 @@ public:
     }
 
     // Debug 导出用的原始数据访问器
-    QByteArray cinfoJsonRaw() const { return m_cinfoJsonRaw; }
-    void setCinfoJsonRaw(const QByteArray& data) { m_cinfoJsonRaw = data; }
+    QByteArray cinfoJsonRaw() const {
+        return m_cinfoJsonRaw;
+    }
 
-    QByteArray cadJsonRaw() const { return m_cadJsonRaw; }
-    void setCadJsonRaw(const QByteArray& data) { m_cadJsonRaw = data; }
+    void setCinfoJsonRaw(const QByteArray& data) {
+        m_cinfoJsonRaw = data;
+    }
 
-    QByteArray model3DObjRaw() const { return m_model3DObjRaw; }
-    void setModel3DObjRaw(const QByteArray& data) { m_model3DObjRaw = data; }
+    QByteArray cadJsonRaw() const {
+        return m_cadJsonRaw;
+    }
+
+    void setCadJsonRaw(const QByteArray& data) {
+        m_cadJsonRaw = data;
+    }
+
+    QByteArray model3DObjRaw() const {
+        return m_model3DObjRaw;
+    }
+
+    void setModel3DObjRaw(const QByteArray& data) {
+        m_model3DObjRaw = data;
+    }
 
     // JSON 序列
     QJsonObject toJson() const;

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -1,8 +1,8 @@
 #include "SymbolExportStage.h"
 
+#include "DebugExportHelper.h"
 #include "core/kicad/ExporterSymbol.h"
 #include "models/ComponentData.h"
-#include "DebugExportHelper.h"
 
 #include <QDateTime>
 #include <QDebug>

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -63,6 +63,15 @@ Card {
             }
         },
         Connections {
+            target: componentListCard.componentListController
+            function onListCleared() {
+                searchInput.text = ""; // 清空搜索
+                if (componentListCard.exportProgressController) {
+                    componentListCard.exportProgressController.resetExport(); // 重置导出状态
+                }
+            }
+        },
+        Connections {
             target: componentListCard.exportProgressController
             function onIsExportingChanged() {
                 if (componentListCard.exportProgressController && componentListCard.exportProgressController.isExporting && componentListCard.componentListController) {

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -296,30 +296,33 @@ void ComponentListViewModel::addComponent(const QString& componentId) {
 
 void ComponentListViewModel::removeComponent(int index) {
     clearAttentionHints();
-    // 获取要删除的 item 和 ID（需要锁保护）
-    ComponentListItemData* item = nullptr;
-    QString removedId;
-    int listCount;
 
+    // 检查是否是最后一个元器件（需要锁保护）
+    int listCount;
     {
         QMutexLocker locker(&m_listMutex);
         listCount = m_componentList.count();
         if (index < 0 || index >= listCount) {
             return;
         }
-        item = m_componentList.takeAt(index);
-        removedId = item->componentId();
-        m_componentIdIndex.remove(removedId);
-        m_validatedComponentIds.removeAll(removedId);
     }
 
     // 当删除最后一个元器件时，触发与清空列表相同的效果
     if (listCount == 1) {
-        // 先释放即将删除的 item
-        delete item;
-        // 调用 clearComponentList 执行完整的清空逻辑
         clearComponentList();
         return;
+    }
+
+    // 获取要删除的 item 和 ID（需要锁保护）
+    ComponentListItemData* item = nullptr;
+    QString removedId;
+
+    {
+        QMutexLocker locker(&m_listMutex);
+        item = m_componentList.takeAt(index);
+        removedId = item->componentId();
+        m_componentIdIndex.remove(removedId);
+        m_validatedComponentIds.removeAll(removedId);
     }
 
     // 检查是否正在获取中（锁外操作，因为 m_pendingValidationCount 有自己的逻辑）

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -313,6 +313,15 @@ void ComponentListViewModel::removeComponent(int index) {
         m_validatedComponentIds.removeAll(removedId);
     }
 
+    // 当删除最后一个元器件时，触发与清空列表相同的效果
+    if (listCount == 1) {
+        // 先释放即将删除的 item
+        delete item;
+        // 调用 clearComponentList 执行完整的清空逻辑
+        clearComponentList();
+        return;
+    }
+
     // 检查是否正在获取中（锁外操作，因为 m_pendingValidationCount 有自己的逻辑）
     if (item->isFetching()) {
         m_pendingValidationCount--;


### PR DESCRIPTION
本次提交包含三个独立的功能增强：                                              
  
  1. 多平台构建配置：扩展 build_config.json                                     
  支持不同平台（Windows/Linux/macOS）的 Qt 路径和 CMake 生成器独立配置
  2. 调试数据导出功能：添加 DebugExportHelper
  实现导出数据的原子写入，提升数据可靠性                                        
  3.
  元件列表清空处理：优化最后一个元件删除时的边界情况处理，防止列表清空后状态异常