### PR TITLE
feat(main+ui): 优化Windows平台渲染后端及窗口背景渲染

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include <QScreen>
 #include <QSize>
 #include <QStandardPaths>
+#include <QSurfaceFormat>
 #include <QTextStream>
 #include <QTimer>
 #include <QUrl>
@@ -221,9 +222,21 @@ QString resolveProjectRootFromAppDir(QString appDir) {
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-    // 优先尝试 Vulkan 后端，若不支持则自动回退到默认后端
+    QSurfaceFormat surfaceFormat = QSurfaceFormat::defaultFormat();
+    surfaceFormat.setAlphaBufferSize(8);
+    QSurfaceFormat::setDefaultFormat(surfaceFormat);
+    QQuickWindow::setDefaultAlphaBuffer(true);
+
+#ifdef _WIN32
+    // Windows 透明无边框窗口在 Vulkan 后端下可能出现圆角透明区域被合成为黑色。
+    // Direct3D 11 是 Qt Quick 在 Windows 上更稳定的默认路径。
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::Direct3D11);
+    qInfo() << "已将 Windows 渲染后端设置为 Direct3D 11，并启用 alpha buffer";
+#else
+    // 非 Windows 平台保留 Vulkan 优先策略。
     QQuickWindow::setGraphicsApi(QSGRendererInterface::Vulkan);
     qInfo() << "已将渲染后端优先设置为 Vulkan";
+#endif
 
     // 设置 stdout 为无缓冲模式，确保日志颜色正常显示
     setbuf(stdout, nullptr);

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Dialogs
 import QtQuick.Window
-import QtQuick.Effects
 import QtQml.Models
 import "styles"
 import "components"
@@ -230,39 +229,55 @@ Item {
         anchors.fill: parent
         color: "transparent"
         radius: AppStyle.radius.lg
-        // 圆角背景容器（GPU 加速，MultiEffect mask 实现真正圆角裁切）
-        Rectangle {
-            id: backgroundShape
+        // 使用 Canvas 裁剪顶层窗口背景，避免 Windows + Vulkan 透明窗口下的 mask 区域变黑。
+        Image {
+            id: bgSource
+            visible: false
+            source: "qrc:/qt/qml/EasyKiconverter_Cpp_Version/resources/imgs/background.jpg"
+            asynchronous: true
+            cache: true
+            onStatusChanged: if (status === Image.Ready) {
+                backgroundCanvas.requestPaint();
+            }
+        }
+
+        Canvas {
+            id: backgroundCanvas
             anchors.fill: parent
-            color: AppStyle.colors.background
-            radius: windowRadius
+            onPaint: {
+                const ctx = getContext("2d");
+                ctx.reset();
 
-            Image {
-                id: bgImage
-                anchors.fill: parent
-                fillMode: Image.PreserveAspectCrop
-                source: "qrc:/qt/qml/EasyKiconverter_Cpp_Version/resources/imgs/background.jpg"
-                asynchronous: true
-                cache: true
-                visible: false
-                layer.enabled: true
+                const r = windowRadius;
+                ctx.beginPath();
+                ctx.roundedRect(0, 0, width, height, r, r);
+                ctx.closePath();
+                ctx.clip();
+
+                ctx.fillStyle = AppStyle.colors.background;
+                ctx.fill();
+
+                if (bgSource.status === Image.Ready) {
+                    const sw = bgSource.sourceSize.width;
+                    const sh = bgSource.sourceSize.height;
+                    if (sw > 0 && sh > 0) {
+                        const scale = Math.max(width / sw, height / sh);
+                        const dw = sw * scale;
+                        const dh = sh * scale;
+                        const dx = (width - dw) / 2;
+                        const dy = (height - dh) / 2;
+                        ctx.drawImage(bgSource, dx, dy, dw, dh);
+                    }
+                }
             }
 
-            Rectangle {
-                id: maskRect
-                anchors.fill: parent
-                radius: windowRadius
-                color: "white"
-                visible: false
-                layer.enabled: true
-            }
-
-            MultiEffect {
-                anchors.fill: parent
-                source: bgImage
-                maskEnabled: true
-                maskSource: maskRect
-            }
+            onWidthChanged: requestPaint()
+            onHeightChanged: requestPaint()
+            onVisibleChanged: requestPaint()
+            property int radiusTrigger: windowRadius
+            onRadiusTriggerChanged: requestPaint()
+            property color backgroundTrigger: AppStyle.colors.background
+            onBackgroundTriggerChanged: requestPaint()
         }
         // 半透明遮罩层（确保内容可读性）
         Rectangle {


### PR DESCRIPTION
改动目的

  1. 解决 Windows 平台下 Vulkan 后端透明无边框窗口圆角区域变黑 的问题
  2. 改进窗口背景渲染的跨平台兼容性，移除对 MultiEffect 的依赖

  ---
  主要变更

  1. src/main.cpp - 渲染后端适配

  - 添加 QSurfaceFormat 配置，启用 8-bit alpha buffer
  - Windows 平台: 改用 Direct3D11 渲染后端（更稳定）
  - 非 Windows 平台: 保留 Vulkan 优先策略

  2. src/ui/qml/MainWindow.qml - 窗口背景渲染重构

  - 移除 QtQuick.Effects (MultiEffect) 依赖
  - 使用 Canvas 自行绘制圆角裁剪背景
  - 移除中间的 maskRect 遮罩层，直接在 Canvas 上实现圆角裁切

---
close issue:
#151 
