### PR TITLE
feat: 支持 KiCad 库描述导出与元器件描述编辑

### DIFF
--- a/.github/workflows/pack-macos.yml
+++ b/.github/workflows/pack-macos.yml
@@ -38,7 +38,7 @@ jobs:
               arch: arm64
             }
           - {
-              os: macos-15,
+              os: macos-15-intel,
               arch: intel
             }
     env:
@@ -97,13 +97,13 @@ jobs:
             cp resources/icons/app_icon.icns ${APP_NAME}.app/Contents/Resources/AppIcon.icns
           fi
 
-          cat > ${APP_NAME}.app/Contents/Info.plist << 'EOF'
+          cat > ${APP_NAME}.app/Contents/Info.plist << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
           <dict>
               <key>CFBundleExecutable</key>
-              <string>EasyKiconverter_Cpp_Version</string>
+              <string>easykiconverter</string>
               <key>CFBundleIdentifier</key>
               <string>com.tangsangsimida.EasyKiConverter</string>
               <key>CFBundleName</key>
@@ -137,7 +137,7 @@ jobs:
       - name: 'SHA256Sum of DMG'
         run: |
           cd "$GITHUB_WORKSPACE/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/'!"; exit 11 ; }
-          shasum ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg | tee ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg.sha256sum
+          shasum -a 256 ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg | tee ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg.sha256sum
 
       - name: 'Artifact Upload'
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(QML_FILES
     src/ui/qml/components/WindowPersistenceManager.qml
     src/ui/qml/components/WindowStartupManager.qml
     src/ui/qml/components/ConfirmDialog.qml
+    src/ui/qml/components/DescriptionEditDialog.qml
     src/ui/qml/components/WindowResizeHandles.qml
     src/ui/qml/components/ExitDialog.qml
     src/ui/qml/components/SliderDialogBase.qml

--- a/docs/developer/KICAD_FIELD_FORMATS.md
+++ b/docs/developer/KICAD_FIELD_FORMATS.md
@@ -1,0 +1,331 @@
+# KiCad 字段格式分析
+
+本文档分析了 KiCad 符号库 (.kicad_sym) 和封装库 (.kicad_mod) 的字段格式，用于指导导出功能的实现。
+
+## 符号库 (.kicad_sym) 格式
+
+### 文件结构
+
+```lisp
+(kicad_symbol_lib (version 20220914) (generator kicad_symbol_editor)
+  (symbol "元件名" (in_bom yes) (on_board yes)
+    ;; 标准属性
+    (property "Reference" "U" (at 3.81 6.35 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "元件名" (at 3.81 -6.35 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" "" (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Datasheet" "https://..." (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    
+    ;; 描述和关键词属性（可选，用于库管理）
+    (property "ki_keywords" "CMOS BUFFER 3State" (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "ki_description" "8-bit D-flip-flop with 3-State outputs" (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    
+    ;; 符号图形定义（unit 0 通常用于电源引脚）
+    (symbol "元件名_0_0"
+      ;; 电源引脚、图形等
+    )
+    
+    ;; 功能单元定义
+    (symbol "元件名_1_1"
+      ;; 引脚定义
+      (pin input line (at -12.7 2.54 0) (length 7.62)
+        (name "引脚名" (effects (font (size 1.27 1.27))))
+        (number "引脚号" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)
+```
+
+### 描述字段说明
+
+| 字段 | 说明 | 示例 |
+|------|------|------|
+| `ki_description` | 元件描述 | `"8-bit D-flip-flop with 3-State outputs"` |
+| `ki_keywords` | 关键词（空格分隔） | `"CMOS BUFFER 3State"` |
+| `Reference` | 参考标识符前缀 | `"U"` (集成电路), `"R"` (电阻), `"C"` (电容) |
+| `Value` | 元件值/型号 | `"40374"` |
+| `Footprint` | 默认封装 | `""` (可为空) |
+| `Datasheet` | 数据手册链接 | `"https://..."` |
+
+### 实际示例
+
+从 `4xxx_IEEE.kicad_sym` 文件中提取的示例：
+
+```lisp
+(symbol "40374" (in_bom yes) (on_board yes)
+  (property "Reference" "U" (at 7.62 8.89 0)
+    (effects (font (size 1.27 1.27)))
+  )
+  (property "Value" "40374" (at 6.35 -15.24 0)
+    (effects (font (size 1.27 1.27)))
+  )
+  (property "Footprint" "" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  (property "Datasheet" "https://www.digchip.com/datasheets/download_datasheet.php?id=369790&part-number=HEF40374BDB" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  (property "ki_keywords" "CMOS BUFFER 3State" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  (property "ki_description" "8-bit D-flip-flop with 3-State outputs" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  ;; ... 符号定义 ...
+)
+```
+
+---
+
+## 封装库 (.kicad_mod) 格式
+
+### 文件结构
+
+```lisp
+(footprint "封装名" (version 20211014) (generator pcbnew)
+  (layer "F.Cu")
+  (tedit 5A030281)
+  (descr "封装描述文本")
+  (tags "标签1 标签2")
+  (attr through_hole)  ;; 或 smd
+  
+  ;; 参考标识符
+  (fp_text reference "REF**" (at 3.8 -7.2) (layer "F.SilkS")
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  
+  ;; 元件值
+  (fp_text value "封装名" (at 3.8 7.4) (layer "F.Fab")
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  
+  ;; 图形元素（丝印、阻焊、装配层等）
+  (fp_line (start x1 y1) (end x2 y2) (layer "F.SilkS") (width 0.12))
+  (fp_circle (center x y) (end x y) (layer "F.SilkS") (width 0.12))
+  
+  ;; 焊盘定义
+  (pad "1" thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad "2" smd rect (at 4 0) (size 2 4.2) (layers "F.Cu" "F.Paste" "F.Mask"))
+  
+  ;; 3D 模型引用
+  (model "${KICAD6_3DMODEL_DIR}/路径/模型.wrl"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0))
+  )
+)
+```
+
+### 描述字段说明
+
+| 字段 | 说明 | 示例 |
+|------|------|------|
+| `descr` | 封装描述 | `"Generic Buzzer, D12mm height 9.5mm with RM7.6mm"` |
+| `tags` | 标签（空格分隔） | `"buzzer piezo"` |
+| `attr` | 封装属性 | `through_hole` / `smd` |
+
+### 实际示例
+
+#### 通孔封装示例
+
+```lisp
+(footprint "Buzzer_12x9.5RM7.6" (version 20211014) (generator pcbnew)
+  (layer "F.Cu")
+  (tedit 5A030281)
+  (descr "Generic Buzzer, D12mm height 9.5mm with RM7.6mm")
+  (tags "buzzer")
+  (attr through_hole)
+  ;; ...
+  (pad "1" thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad "2" thru_hole circle (at 7.6 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+)
+```
+
+#### SMD 封装示例
+
+```lisp
+(footprint "Buzzer_CUI_CPT-9019S-SMT" (version 20211014) (generator pcbnew)
+  (layer "F.Cu")
+  (tedit 5C12D246)
+  (descr "https://www.cui.com/product/resource/cpt-9019s-smt.pdf")
+  (tags "buzzer piezo")
+  (attr smd)
+  ;; ...
+  (pad "1" smd rect (at -4 0) (size 2 4.2) (layers "F.Cu" "F.Paste" "F.Mask"))
+  (pad "2" smd rect (at 4 0) (size 2 4.2) (layers "F.Cu" "F.Paste" "F.Mask"))
+)
+```
+
+---
+
+## 当前代码导出状态（基于 v3.1.7）
+
+### 符号库导出（ExporterSymbol.cpp）
+
+当前代码实际导出的属性：
+
+| 属性名 | 数据来源 | 说明 |
+|--------|----------|------|
+| `Reference` | `symbolData.info().prefix` | 参考标识符前缀（如 "U", "R", "C"） |
+| `Value` | `symbolData.info().name` | 元件名（如 "4001", "RESISTOR"） |
+| `Footprint` | `symbolData.info().package` | 封装名（格式：`libName:packageName`） |
+| `Datasheet` | `symbolData.info().datasheet` | 数据手册链接 |
+| `Manufacturer` | `symbolData.info().manufacturer` | 制造商 |
+| `LCSC Part` | `symbolData.info().lcscId` | LCSC 编号（如 "C12345"） |
+
+**当前未导出的字段（待实现）**：
+- `ki_description` - 符号描述
+- `ki_keywords` - 关键词
+
+### 封装库导出（ExporterFootprint.cpp）
+
+当前代码**未导出**描述和标签字段：
+
+| 字段 | 状态 | 说明 |
+|------|------|------|
+| `descr` | ❌ 未实现 | 封装描述 |
+| `tags` | ❌ 未实现 | 标签 |
+| `attr` | ✅ 已实现 | 根据焊盘类型自动判断 `through_hole` 或 `smd` |
+
+---
+
+## 数据结构字段分析
+
+### SymbolInfo 结构体字段
+
+```cpp
+struct SymbolInfo {
+    QString name;           // 元件名 → Value
+    QString prefix;         // 前缀 → Reference
+    QString package;        // 封装 → Footprint
+    QString manufacturer;   // 制造商 → Manufacturer
+    QString description;    // 描述 → ki_description（待实现）
+    QString datasheet;      // 数据手册 → Datasheet
+    QString lcscId;         // LCSC 编号 → LCSC Part
+    QString jlcId;          // JLC 编号
+    // ... 其他字段
+};
+```
+
+### FootprintInfo 结构体字段
+
+```cpp
+struct FootprintInfo {
+    QString name;           // 封装名
+    QString type;           // 类型
+    QString model3DName;    // 3D 模型名
+    // 注意：没有 description 和 keywords 字段
+    // ... 其他字段
+};
+```
+
+---
+
+## 数据映射表（修正版）
+
+### 符号库映射
+
+| 数据源 | KiCad 属性 | 代码位置 | 状态 |
+|--------|-----------|----------|------|
+| `symbolData.info().prefix` | `Reference` | ExporterSymbol.cpp:510 | ✅ 已实现 |
+| `symbolData.info().name` | `Value` | ExporterSymbol.cpp:524 | ✅ 已实现 |
+| `symbolData.info().package` | `Footprint` | ExporterSymbol.cpp:537 | ✅ 已实现 |
+| `symbolData.info().datasheet` | `Datasheet` | ExporterSymbol.cpp:554 | ✅ 已实现 |
+| `symbolData.info().manufacturer` | `Manufacturer` | ExporterSymbol.cpp:569 | ✅ 已实现 |
+| `symbolData.info().lcscId` | `LCSC Part` | ExporterSymbol.cpp:584 | ✅ 已实现 |
+| `symbolData.info().description` | `ki_description` | - | ❌ 待实现 |
+| 无数据源 | `ki_keywords` | - | ❌ 待实现（需添加字段） |
+
+### 封装库映射
+
+| 数据源 | KiCad 关键字 | 代码位置 | 状态 |
+|--------|-------------|----------|------|
+| 无数据源 | `descr` | - | ❌ 待实现（FootprintInfo 无 description 字段） |
+| 无数据源 | `tags` | - | ❌ 待实现（FootprintInfo 无 keywords 字段） |
+| 焊盘类型判断 | `attr` | ExporterFootprint.cpp:186 | ✅ 已实现 |
+
+---
+
+## 待实现功能
+
+### 1. 符号库添加 ki_description
+
+在 `ExporterSymbol.cpp` 中添加：
+
+```cpp
+// ki_description 属性（从 SymbolInfo.description 获取）
+if (!symbolData.info().description.isEmpty()) {
+    fieldOffset += 2.54;
+    content += QString("    (property\n");
+    content += QString("      \"ki_description\"\n");
+    content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+    content += "      (id 6)\n";
+    content += QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
+    content += QString("      (effects (font (size %1 %2) (thickness 0) ) hide)\n")
+                   .arg(fontSize, 0, 'f', 2)
+                   .arg(fontSize, 0, 'f', 2);
+    content += "    )\n";
+}
+```
+
+**插入位置**：在 LCSC Part 属性之后（约第 593 行）
+
+### 2. 封装库添加 descr
+
+需要先在 `FootprintInfo` 结构体中添加 `description` 字段：
+
+```cpp
+// FootprintData.h 中添加
+struct FootprintInfo {
+    // ... 现有字段
+    QString description;    // 封装描述
+    QString keywords;       // 关键词
+};
+```
+
+然后在 `ExporterFootprint.cpp` 中添加导出逻辑。
+
+### 3. 添加 ki_keywords 字段
+
+需要在 `SymbolInfo` 结构体中添加 `keywords` 字段（如果 EasyEDA API 提供）。
+
+---
+
+## 注意事项
+
+1. **转义字符**：描述文本中的引号需要转义为 `\"`
+
+2. **空值处理**：当前代码已使用 `isEmpty()` 检查，只在有值时才导出
+
+3. **ID 编号**：属性的 `id` 必须连续递增（0-5 已使用，新属性从 6 开始）
+
+4. **编码**：所有文本使用 UTF-8 编码
+
+5. **坐标**：属性的坐标 `(at 0 0 0)` 表示默认位置，hide 表示在原理图中隐藏
+
+---
+
+## 参考文件
+
+- 符号库示例：`/home/dennis/Desktop/4xxx_IEEE.kicad_sym`
+- 封装库示例：`/home/dennis/Desktop/Buzzer_Beeper.pretty/`
+- 符号导出器：`src/core/kicad/ExporterSymbol.cpp`
+- 封装导出器：`src/core/kicad/ExporterFootprint.cpp`
+- 符号数据模型：`src/models/SymbolData.h`
+- 封装数据模型：`src/models/FootprintData.h`
+
+---
+
+*最后更新：2026-05-02*

--- a/resources/translations/translations_easykiconverter_en.ts
+++ b/resources/translations/translations_easykiconverter_en.ts
@@ -315,8 +315,8 @@
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="493"/>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="523"/>
-        <source>覆盖已存在的元器件</source>
-        <translation>Overwrite</translation>
+        <source>覆盖已经存在的元器件数据，并追加新的元器件</source>
+        <translation>Overwrite existing component data and append new components</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportProgressCard.qml" line="10"/>
@@ -556,8 +556,8 @@
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="444"/>
-        <source>保留已存在的元器件，只追加新的元器件</source>
-        <translation>Preserve existing components and only append new ones</translation>
+        <source>保留已经存在的元器件数据，并追加新的元器件</source>
+        <translation>Preserve existing component data and append new components</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/UpdateBanner.qml" line="45"/>

--- a/resources/translations/translations_easykiconverter_zh_CN.ts
+++ b/resources/translations/translations_easykiconverter_zh_CN.ts
@@ -440,8 +440,8 @@
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="444"/>
-        <source>保留已存在的元器件，只追加新的元器件</source>
-        <translation>保留已存在的元器件，只追加新的元器件</translation>
+        <source>保留已经存在的元器件数据，并追加新的元器件</source>
+        <translation>保留已经存在的元器件数据，并追加新的元器件</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="474"/>
@@ -456,8 +456,8 @@
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="493"/>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="523"/>
-        <source>覆盖已存在的元器件</source>
-        <translation>覆盖已存在的元器件</translation>
+        <source>覆盖已经存在的元器件数据，并追加新的元器件</source>
+        <translation>覆盖已经存在的元器件数据，并追加新的元器件</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportProgressCard.qml" line="10"/>

--- a/src/core/easyeda/EasyedaFootprintImporter.cpp
+++ b/src/core/easyeda/EasyedaFootprintImporter.cpp
@@ -413,7 +413,8 @@ void EasyedaFootprintImporter::importSvgNodeData(const QString& svgNodeData,
                     const double originX = originParts[0].toDouble();
                     const double originY = originParts[1].toDouble();
                     const double originZ = attrs.contains("z") ? attrs["z"].toDouble() : 0.0;
-                    const Model3DBase translation = normalizeModelOrigin(originX, originY, originZ, footprintData->bbox());
+                    const Model3DBase translation =
+                        normalizeModelOrigin(originX, originY, originZ, footprintData->bbox());
                     model3D.setTranslation(translation);
                 }
             }

--- a/src/core/kicad/CMakeLists.txt
+++ b/src/core/kicad/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(EasyKiConverterKicad STATIC
     ExporterFootprint.cpp
     FootprintGraphicsGenerator.cpp
     Exporter3DModel.cpp
+    KiCadLibTable.cpp
 )
 
 target_include_directories(EasyKiConverterKicad

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -189,9 +189,10 @@ void ExporterFootprint::generateFootprintBaseContent(const FootprintData& footpr
     content += QString("(footprint easykiconverter:%1\n").arg(footprintData.info().name);
     content += "  (version 20221018)\n";
 
-    // 导出封装描述 (descr) - 用户输入
-    if (!libraryDescription.isEmpty()) {
-        content += QString("  (descr \"%1\")\n").arg(libraryDescription);
+    // 导出封装描述 (descr) - 单个元器件描述；库描述写入 fp-lib-table
+    const QString footprintDescription = footprintData.info().description.trimmed();
+    if (!footprintDescription.isEmpty()) {
+        content += QString("  (descr \"%1\")\n").arg(footprintDescription);
     }
 
     // 导出封装标签 (tags) - 用户输入

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -1,5 +1,6 @@
 #include "ExporterFootprint.h"
 
+#include "KiCadLibTable.h"
 #include "core/utils/GeometryUtils.h"
 #include "utils/PathSecurity.h"
 
@@ -161,6 +162,13 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
     qDebug() << "Footprint library exported to:" << filePath;
 
     return true;
+}
+
+bool ExporterFootprint::generateFpLibTable(const QString& libName,
+                                           const QString& libDirPath,
+                                           const QString& outputDir,
+                                           const QString& libraryDescription) {
+    return generateKiCadLibTable("fp_lib_table", "fp-lib-table", libName, libDirPath, outputDir, libraryDescription);
 }
 
 QString ExporterFootprint::generateHeader(const QString& libName) const {

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -64,11 +64,15 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
                                                const QString& libName,
                                                const QString& filePath,
                                                bool preferWrl,
-                                               bool exportStep) {
+                                               bool exportStep,
+                                               const QString& libraryDescription,
+                                               const QString& libraryKeywords) {
     qDebug() << "=== Export Footprint Library ===";
     qDebug() << "Library name:" << libName;
     qDebug() << "Output path:" << filePath;
     qDebug() << "Footprint count:" << footprints.count();
+    qDebug() << "Library description:" << libraryDescription;
+    qDebug() << "Library keywords:" << libraryKeywords;
 
     QDir libDir(filePath);
 
@@ -125,18 +129,18 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
             if (useWrl && useStep) {
                 QString wrlPath = QStringLiteral("../%1.3dmodels/%2.wrl").arg(safeLibName, modelName);
                 QString stepPath = QStringLiteral("../%1.3dmodels/%2.step").arg(safeLibName, modelName);
-                content = generateFootprintContent(footprint, wrlPath, stepPath);
+                content = generateFootprintContent(footprint, wrlPath, stepPath, libraryDescription, libraryKeywords);
             } else if (useWrl) {
                 QString wrlPath = QStringLiteral("../%1.3dmodels/%2.wrl").arg(safeLibName, modelName);
-                content = generateFootprintContent(footprint, wrlPath);
+                content = generateFootprintContent(footprint, wrlPath, libraryDescription, libraryKeywords);
             } else if (useStep) {
                 QString stepPath = QStringLiteral("../%1.3dmodels/%2.step").arg(safeLibName, modelName);
-                content = generateFootprintContent(footprint, stepPath);
+                content = generateFootprintContent(footprint, stepPath, libraryDescription, libraryKeywords);
             } else {
-                content = generateFootprintContent(footprint);
+                content = generateFootprintContent(footprint, QString(), libraryDescription, libraryKeywords);
             }
         } else {
-            content = generateFootprintContent(footprint);
+            content = generateFootprintContent(footprint, QString(), libraryDescription, libraryKeywords);
         }
 
         QFile file(fullPath);
@@ -171,9 +175,21 @@ QString ExporterFootprint::generateHeader(const QString& libName) const {
 void ExporterFootprint::generateFootprintBaseContent(const FootprintData& footprintData,
                                                      QString& content,
                                                      double& outBboxX,
-                                                     double& outBboxY) const {
+                                                     double& outBboxY,
+                                                     const QString& libraryDescription,
+                                                     const QString& libraryKeywords) const {
     content += QString("(footprint easykiconverter:%1\n").arg(footprintData.info().name);
     content += "  (version 20221018)\n";
+
+    // 导出封装描述 (descr) - 用户输入
+    if (!libraryDescription.isEmpty()) {
+        content += QString("  (descr \"%1\")\n").arg(libraryDescription);
+    }
+
+    // 导出封装标签 (tags) - 用户输入
+    if (!libraryKeywords.isEmpty()) {
+        content += QString("  (tags \"%1\")\n").arg(libraryKeywords);
+    }
 
     bool isThroughHole = false;
     for (const FootprintPad& pad : footprintData.pads()) {
@@ -272,9 +288,24 @@ void ExporterFootprint::generateFootprintBaseContent(const FootprintData& footpr
 
 QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
                                                     const QString& model3DPath) const {
+    // 委托给带 libraryDescription/libraryKeywords 参数的版本
+    return generateFootprintContent(footprintData, model3DPath, QString(), QString());
+}
+
+QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
+                                                    const QString& model3DWrlPath,
+                                                    const QString& model3DStepPath) const {
+    // 委托给带 libraryDescription/libraryKeywords 参数的版本
+    return generateFootprintContent(footprintData, model3DWrlPath, model3DStepPath, QString(), QString());
+}
+
+QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
+                                                    const QString& model3DPath,
+                                                    const QString& libraryDescription,
+                                                    const QString& libraryKeywords) const {
     QString content;
     double bboxX = 0, bboxY = 0;
-    generateFootprintBaseContent(footprintData, content, bboxX, bboxY);
+    generateFootprintBaseContent(footprintData, content, bboxX, bboxY, libraryDescription, libraryKeywords);
 
     if (!footprintData.model3D().name().isEmpty() || !model3DPath.isEmpty()) {
         content += m_graphicsGenerator.generateModel3D(
@@ -287,10 +318,12 @@ QString ExporterFootprint::generateFootprintContent(const FootprintData& footpri
 
 QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
                                                     const QString& model3DWrlPath,
-                                                    const QString& model3DStepPath) const {
+                                                    const QString& model3DStepPath,
+                                                    const QString& libraryDescription,
+                                                    const QString& libraryKeywords) const {
     QString content;
     double bboxX = 0, bboxY = 0;
-    generateFootprintBaseContent(footprintData, content, bboxX, bboxY);
+    generateFootprintBaseContent(footprintData, content, bboxX, bboxY, libraryDescription, libraryKeywords);
 
     if (!footprintData.model3D().name().isEmpty() || !model3DWrlPath.isEmpty() || !model3DStepPath.isEmpty()) {
         if (!model3DWrlPath.isEmpty()) {

--- a/src/core/kicad/ExporterFootprint.h
+++ b/src/core/kicad/ExporterFootprint.h
@@ -64,14 +64,30 @@ public:
                                 const QString& libName,
                                 const QString& filePath,
                                 bool preferWrl = true,
-                                bool exportStep = false);
+                                bool exportStep = false,
+                                const QString& libraryDescription = QString(),
+                                const QString& libraryKeywords = QString());
 
 private:
     QString generateHeader(const QString& libName) const;
     void generateFootprintBaseContent(const FootprintData& footprintData,
                                       QString& content,
                                       double& outBboxX,
-                                      double& outBboxY) const;
+                                      double& outBboxY,
+                                      const QString& libraryDescription = QString(),
+                                      const QString& libraryKeywords = QString()) const;
+    // 基础版本：支持描述和关键词，内部委托到双路径重载
+    QString generateFootprintContent(const FootprintData& footprintData,
+                                     const QString& model3DPath,
+                                     const QString& libraryDescription,
+                                     const QString& libraryKeywords) const;
+    // 双3D模型路径版本：支持描述和关键词
+    QString generateFootprintContent(const FootprintData& footprintData,
+                                     const QString& model3DWrlPath,
+                                     const QString& model3DStepPath,
+                                     const QString& libraryDescription,
+                                     const QString& libraryKeywords) const;
+    // 兼容旧调用：无描述/关键词，内部委托到基础版本
     QString generateFootprintContent(const FootprintData& footprintData, const QString& model3DPath = QString()) const;
     QString generateFootprintContent(const FootprintData& footprintData,
                                      const QString& model3DWrlPath,

--- a/src/core/kicad/ExporterFootprint.h
+++ b/src/core/kicad/ExporterFootprint.h
@@ -68,6 +68,20 @@ public:
                                 const QString& libraryDescription = QString(),
                                 const QString& libraryKeywords = QString());
 
+    /**
+     * @brief 生成 fp-lib-table 文件
+     *
+     * @param libName 库名称
+     * @param libDirPath 封装库目录路径（.pretty 目录）
+     * @param outputDir 输出目录
+     * @param libraryDescription 库描述
+     * @return bool 是否成功
+     */
+    bool generateFpLibTable(const QString& libName,
+                            const QString& libDirPath,
+                            const QString& outputDir,
+                            const QString& libraryDescription = QString());
+
 private:
     QString generateHeader(const QString& libName) const;
     void generateFootprintBaseContent(const FootprintData& footprintData,

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -76,7 +76,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName);
+            out << generateSymbolContent(symbol, libName, libraryDescription);
         }
 
         // 生成尾部
@@ -356,7 +356,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName);
+        out << generateSymbolContent(symbol, libName, libraryDescription);
     }
 
     // 生成尾部
@@ -384,7 +384,9 @@ QString ExporterSymbol::generateHeader(const QString& libName, const QString& li
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
+                                              const QString& libName,
+                                              const QString& libraryDescription) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -600,11 +602,13 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, cons
     }
 
     // ki_description 属性（符号库描述）
-    if (!symbolData.info().description.isEmpty()) {
+    // 优先使用元器件自身的描述，如果为空则使用库描述
+    QString kiDescription = symbolData.info().description.isEmpty() ? libraryDescription : symbolData.info().description;
+    if (!kiDescription.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");
         content += QString("      \"ki_description\"\n");
-        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(kiDescription));
         content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -41,7 +41,8 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
                                          const QString& libName,
                                          const QString& filePath,
                                          bool appendMode,
-                                         bool updateMode) {
+                                         bool updateMode,
+                                         const QString& libraryDescription) {
     qDebug() << "=== Export Symbol Library ===";
     qDebug() << "Library name:" << libName;
     qDebug() << "Output path:" << filePath;
@@ -49,6 +50,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     qDebug() << "KiCad version: V6";
     qDebug() << "Append mode:" << appendMode;
     qDebug() << "Update mode:" << updateMode;
+    qDebug() << "Library description:" << libraryDescription;
 
     // 重置检测到的版本，避免影响后续调用
     m_detectedVersion.clear();
@@ -181,8 +183,6 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     qDebug() << "Existing symbols count:" << existingSymbols.count();
     qDebug() << "Sub-symbol names:" << subSymbolNames;
 
-    qDebug() << "Existing symbols count:" << existingSymbols.count();
-
     // 确定要导出的符号
     QList<SymbolData> symbolsToExport;
     int overwriteCount = 0;
@@ -230,7 +230,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     out.setEncoding(QStringConverter::Utf8);
 
     // 生成头部
-    out << generateHeader(libName);
+    out << generateHeader(libName, libraryDescription);
 
     // 生成所有符号（包括未覆盖的现有符号和新导出的符号）
     int index = 0;
@@ -367,14 +367,21 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     return true;
 }
 
-QString ExporterSymbol::generateHeader(const QString& libName) const {
-    Q_UNUSED(libName);
+QString ExporterSymbol::generateHeader(const QString& libName, const QString& libraryDescription) const {
+    Q_UNUSED(libName);  // 库名在符号内容中使用，不在头部使用
     QString version = m_detectedVersion.isEmpty() ? "20211014" : m_detectedVersion;
-    return QString(
-               "(kicad_symbol_lib\n"
-               "  (version %1)\n"
-               "  (generator https://github.com/tangsangsimida/EasyKiConverter)\n")
-        .arg(version);
+    QString header = QString(
+                         "(kicad_symbol_lib\n"
+                         "  (version %1)\n"
+                         "  (generator https://github.com/tangsangsimida/EasyKiConverter)\n")
+                         .arg(version);
+
+    // 添加库描述（如果提供）
+    if (!libraryDescription.isEmpty()) {
+        header += QString("  (description \"%1\")\n").arg(libraryDescription);
+    }
+
+    return header;
 }
 
 QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
@@ -584,6 +591,21 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, cons
         content += QString("      \"LCSC Part\"\n");
         content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().lcscId));
         content += "      (id 5)\n";
+        content +=
+            QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
+        content += QString("      (effects (font (size %1 %2) (thickness 0) ) hide)\n")
+                       .arg(fontSize, 0, 'f', 2)
+                       .arg(fontSize, 0, 'f', 2);
+        content += "    )\n";
+    }
+
+    // ki_description 属性（符号库描述）
+    if (!symbolData.info().description.isEmpty()) {
+        fieldOffset += 2.54;
+        content += QString("    (property\n");
+        content += QString("      \"ki_description\"\n");
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+        content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
         content += QString("      (effects (font (size %1 %2) (thickness 0) ) hide)\n")

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -1,10 +1,12 @@
 #include "ExporterSymbol.h"
 
+#include "KiCadLibTable.h"
 #include "core/utils/GeometryUtils.h"
 #include "core/utils/SvgPathParser.h"
 
 #include <QDebug>
 #include <QFile>
+#include <QFileInfo>
 #include <QRegularExpression>
 #include <QTextStream>
 
@@ -76,7 +78,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName, libraryDescription);
+            out << generateSymbolContent(symbol, libName);
         }
 
         // 生成尾部
@@ -230,7 +232,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     out.setEncoding(QStringConverter::Utf8);
 
     // 生成头部
-    out << generateHeader(libName, libraryDescription);
+    out << generateHeader(libName);
 
     // 生成所有符号（包括未覆盖的现有符号和新导出的符号）
     int index = 0;
@@ -356,7 +358,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName, libraryDescription);
+        out << generateSymbolContent(symbol, libName);
     }
 
     // 生成尾部
@@ -367,7 +369,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     return true;
 }
 
-QString ExporterSymbol::generateHeader(const QString& libName, const QString& libraryDescription) const {
+QString ExporterSymbol::generateHeader(const QString& libName) const {
     Q_UNUSED(libName);  // 库名在符号内容中使用，不在头部使用
     QString version = m_detectedVersion.isEmpty() ? "20211014" : m_detectedVersion;
     QString header = QString(
@@ -376,17 +378,10 @@ QString ExporterSymbol::generateHeader(const QString& libName, const QString& li
                          "  (generator https://github.com/tangsangsimida/EasyKiConverter)\n")
                          .arg(version);
 
-    // 添加库描述（如果提供）
-    if (!libraryDescription.isEmpty()) {
-        header += QString("  (description \"%1\")\n").arg(libraryDescription);
-    }
-
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
-                                              const QString& libName,
-                                              const QString& libraryDescription) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -601,14 +596,12 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
         content += "    )\n";
     }
 
-    // ki_description 属性（符号库描述）
-    // 优先使用元器件自身的描述，如果为空则使用库描述
-    QString kiDescription = symbolData.info().description.isEmpty() ? libraryDescription : symbolData.info().description;
-    if (!kiDescription.isEmpty()) {
+    // ki_description 属性（仅使用元器件自身描述，库描述写入 sym-lib-table）
+    if (!symbolData.info().description.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");
         content += QString("      \"ki_description\"\n");
-        content += QString("      \"%1\"\n").arg(escapePropertyValue(kiDescription));
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
         content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
@@ -687,6 +680,13 @@ QString ExporterSymbol::generateSubSymbol(const SymbolData& symbolData,
     content += "    )\n";  // 结束子符号
 
     return content;
+}
+
+bool ExporterSymbol::generateSymLibTable(const QString& libName,
+                                         const QString& libFilePath,
+                                         const QString& outputDir,
+                                         const QString& libraryDescription) {
+    return generateKiCadLibTable("sym_lib_table", "sym-lib-table", libName, libFilePath, outputDir, libraryDescription);
 }
 
 }  // namespace EasyKiConverter

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -78,7 +78,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName, libraryDescription);
+            out << generateSymbolContent(symbol, libName);
         }
 
         // 生成尾部
@@ -358,7 +358,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName, libraryDescription);
+        out << generateSymbolContent(symbol, libName);
     }
 
     // 生成尾部
@@ -381,9 +381,7 @@ QString ExporterSymbol::generateHeader(const QString& libName) const {
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
-                                              const QString& libName,
-                                              const QString& libraryDescription) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -598,8 +596,8 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
         content += "    )\n";
     }
 
-    // ki_description 属性 - 用户输入；留空时不写入
-    const QString symbolDescription = libraryDescription.trimmed();
+    // ki_description 属性 - 单个元器件描述；库描述写入 sym-lib-table
+    const QString symbolDescription = symbolData.info().description.trimmed();
     if (!symbolDescription.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -78,7 +78,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName);
+            out << generateSymbolContent(symbol, libName, libraryDescription);
         }
 
         // 生成尾部
@@ -358,7 +358,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName);
+        out << generateSymbolContent(symbol, libName, libraryDescription);
     }
 
     // 生成尾部
@@ -381,7 +381,9 @@ QString ExporterSymbol::generateHeader(const QString& libName) const {
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
+                                              const QString& libName,
+                                              const QString& libraryDescription) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -596,12 +598,13 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, cons
         content += "    )\n";
     }
 
-    // ki_description 属性（仅使用元器件自身描述，库描述写入 sym-lib-table）
-    if (!symbolData.info().description.isEmpty()) {
+    // ki_description 属性 - 用户输入；留空时不写入
+    const QString symbolDescription = libraryDescription.trimmed();
+    if (!symbolDescription.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");
         content += QString("      \"ki_description\"\n");
-        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolDescription));
         content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -81,9 +81,7 @@ private:
      * @param libName 库名称（用于 Footprint 前缀
      * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData,
-                                  const QString& libName,
-                                  const QString& libraryDescription = QString()) const;
+    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -81,7 +81,9 @@ private:
      * @param libName 库名称（用于 Footprint 前缀
      * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
+    QString generateSymbolContent(const SymbolData& symbolData,
+                                  const QString& libName,
+                                  const QString& libraryDescription = QString()) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -51,6 +51,20 @@ public:
                              bool updateMode = false,
                              const QString& libraryDescription = QString());
 
+    /**
+     * @brief 生成 sym-lib-table 文件
+     *
+     * @param libName 库名称
+     * @param libFilePath 符号库文件路径
+     * @param outputDir 输出目录
+     * @param libraryDescription 库描述
+     * @return bool 是否成功
+     */
+    bool generateSymLibTable(const QString& libName,
+                             const QString& libFilePath,
+                             const QString& outputDir,
+                             const QString& libraryDescription = QString());
+
 private:
     /**
      * @brief 生成 KiCad 符号
@@ -58,19 +72,16 @@ private:
      * @param libName 库名称
          * @return QString 头部文本
      */
-    QString generateHeader(const QString& libName, const QString& libraryDescription = QString()) const;
+    QString generateHeader(const QString& libName) const;
 
     /**
      * @brief 生成 KiCad 符号内容
      *
      * @param symbolData 符号数据
      * @param libName 库名称（用于 Footprint 前缀
-     * @param libraryDescription 库描述（用于 ki_description 字段）
-         * @return QString 符号内容
+     * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData,
-                                  const QString& libName,
-                                  const QString& libraryDescription = QString()) const;
+    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -65,9 +65,12 @@ private:
      *
      * @param symbolData 符号数据
      * @param libName 库名称（用于 Footprint 前缀
+     * @param libraryDescription 库描述（用于 ki_description 字段）
          * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
+    QString generateSymbolContent(const SymbolData& symbolData,
+                                  const QString& libName,
+                                  const QString& libraryDescription = QString()) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -48,7 +48,8 @@ public:
                              const QString& libName,
                              const QString& filePath,
                              bool appendMode = true,
-                             bool updateMode = false);
+                             bool updateMode = false,
+                             const QString& libraryDescription = QString());
 
 private:
     /**
@@ -57,7 +58,7 @@ private:
      * @param libName 库名称
          * @return QString 头部文本
      */
-    QString generateHeader(const QString& libName) const;
+    QString generateHeader(const QString& libName, const QString& libraryDescription = QString()) const;
 
     /**
      * @brief 生成 KiCad 符号内容

--- a/src/core/kicad/KiCadLibTable.cpp
+++ b/src/core/kicad/KiCadLibTable.cpp
@@ -1,0 +1,49 @@
+#include "KiCadLibTable.h"
+
+#include "core/utils/KiCadTableUtils.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+#include <QTextStream>
+
+namespace EasyKiConverter {
+
+bool generateKiCadLibTable(const QString& tableType,
+                           const QString& fileName,
+                           const QString& libName,
+                           const QString& libPath,
+                           const QString& outputDir,
+                           const QString& libraryDescription) {
+    QString filePath = QDir(outputDir).filePath(fileName);
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "Failed to create" << fileName << ":" << filePath;
+        return false;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+
+    QFileInfo libInfo(libPath);
+    QString relativePath = libInfo.fileName();
+
+    out << "(" << tableType << "\n";
+    out << "  (version 7)\n";
+    out << QString("  (lib (name \"%1\")(type \"KiCad\")(uri \"%2\")(options \"\")")
+               .arg(KiCadTableUtils::escapeTableValue(libName), KiCadTableUtils::escapeTableValue(relativePath));
+    if (!libraryDescription.isEmpty()) {
+        out << QString("(descr \"%1\")").arg(KiCadTableUtils::escapeTableValue(libraryDescription));
+    }
+    out << ")\n";
+    out << ")\n";
+
+    file.close();
+    qDebug() << "Generated" << fileName << ":" << filePath;
+    return true;
+}
+
+}  // namespace EasyKiConverter

--- a/src/core/kicad/KiCadLibTable.h
+++ b/src/core/kicad/KiCadLibTable.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QString>
+
+namespace EasyKiConverter {
+
+/**
+ * @brief 生成 KiCad 库表文件（sym-lib-table / fp-lib-table）
+ *
+ * @param tableType 表类型名（"sym_lib_table" 或 "fp_lib_table"）
+ * @param fileName 输出文件名（"sym-lib-table" 或 "fp-lib-table"）
+ * @param libName 库名称
+ * @param libPath 库文件/目录路径
+ * @param outputDir 输出目录
+ * @param libraryDescription 库描述（可选）
+ * @return bool 是否成功
+ */
+bool generateKiCadLibTable(const QString& tableType,
+                           const QString& fileName,
+                           const QString& libName,
+                           const QString& libPath,
+                           const QString& outputDir,
+                           const QString& libraryDescription);
+
+}  // namespace EasyKiConverter

--- a/src/core/utils/CMakeLists.txt
+++ b/src/core/utils/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(EasyKiConverterUtils STATIC
     SvgPathParser.cpp
     AtomicFileWriter.cpp
     GzipUtils.cpp
+    KiCadTableUtils.cpp
     UrlUtils.cpp
 )
 

--- a/src/core/utils/KiCadTableUtils.cpp
+++ b/src/core/utils/KiCadTableUtils.cpp
@@ -1,0 +1,14 @@
+#include "KiCadTableUtils.h"
+
+namespace EasyKiConverter {
+namespace KiCadTableUtils {
+
+QString escapeTableValue(const QString& value) {
+    QString escaped = value;
+    escaped.replace("\\", "\\\\");
+    escaped.replace("\"", "\\\"");
+    return escaped;
+}
+
+}  // namespace KiCadTableUtils
+}  // namespace EasyKiConverter

--- a/src/core/utils/KiCadTableUtils.h
+++ b/src/core/utils/KiCadTableUtils.h
@@ -1,0 +1,14 @@
+#ifndef KICADTABLEUTILS_H
+#define KICADTABLEUTILS_H
+
+#include <QString>
+
+namespace EasyKiConverter {
+namespace KiCadTableUtils {
+
+QString escapeTableValue(const QString& value);
+
+}  // namespace KiCadTableUtils
+}  // namespace EasyKiConverter
+
+#endif  // KICADTABLEUTILS_H

--- a/src/models/ComponentListItemData.cpp
+++ b/src/models/ComponentListItemData.cpp
@@ -29,6 +29,17 @@ void ComponentListItemData::setPackage(const QString& package) {
     }
 }
 
+void ComponentListItemData::setDescription(const QString& description) {
+    m_descriptionEdited = true;
+    if (m_description != description) {
+        m_description = description;
+        applyDescriptionToComponentData();
+        emit dataChanged();
+        return;
+    }
+    applyDescriptionToComponentData();
+}
+
 void ComponentListItemData::setNameSilent(const QString& name) {
     m_name = name;
 }
@@ -44,8 +55,29 @@ void ComponentListItemData::setComponentData(const QSharedPointer<ComponentData>
             setName(data->name());
         if (!data->package().isEmpty())
             setPackage(data->package());
+        if (!m_descriptionEdited) {
+            m_description = data->name();
+        }
+        applyDescriptionToComponentData();
     }
     emit dataChanged();
+}
+
+void ComponentListItemData::applyDescriptionToComponentData() {
+    if (!m_componentData) {
+        return;
+    }
+
+    if (m_componentData->symbolData()) {
+        SymbolInfo info = m_componentData->symbolData()->info();
+        info.description = m_description;
+        m_componentData->symbolData()->setInfo(info);
+    }
+    if (m_componentData->footprintData()) {
+        FootprintInfo info = m_componentData->footprintData()->info();
+        info.description = m_description;
+        m_componentData->footprintData()->setInfo(info);
+    }
 }
 
 void ComponentListItemData::setValid(bool valid) {

--- a/src/models/ComponentListItemData.h
+++ b/src/models/ComponentListItemData.h
@@ -21,6 +21,7 @@ class ComponentListItemData : public QObject {
     Q_PROPERTY(QString componentId READ componentId CONSTANT)
     Q_PROPERTY(QString name READ name NOTIFY dataChanged)
     Q_PROPERTY(QString package READ package NOTIFY dataChanged)
+    Q_PROPERTY(QString description READ description NOTIFY dataChanged)
     Q_PROPERTY(QVariantList previewImages READ previewImages NOTIFY previewImagesChanged)
     Q_PROPERTY(int previewImageCount READ previewImageCount NOTIFY previewImagesChanged)
     Q_PROPERTY(bool isValid READ isValid NOTIFY validationStatusChanged)
@@ -52,6 +53,10 @@ public:
 
     QString package() const {
         return m_package;
+    }
+
+    QString description() const {
+        return m_description;
     }
 
     QVariantList previewImages() const;
@@ -95,6 +100,7 @@ public:
     // Setter 方法
     void setName(const QString& name);
     void setPackage(const QString& package);
+    void setDescription(const QString& description);
     void setNameSilent(const QString& name);
     void setPackageSilent(const QString& package);
     void addPreviewImage(const QImage& image);
@@ -134,10 +140,13 @@ signals:
 
 private:
     void updatePreviewImagesCache() const;
+    void applyDescriptionToComponentData();
 
     QString m_componentId;
     QString m_name;
     QString m_package;
+    QString m_description;
+    bool m_descriptionEdited = false;
     QList<QImage> m_previewImages;
     mutable QVariantList m_previewImagesCache;
     bool m_isValid;

--- a/src/models/FootprintData.h
+++ b/src/models/FootprintData.h
@@ -17,6 +17,7 @@ struct FootprintInfo {
     QString name;
     QString type;
     QString model3DName;
+    QString description;
 
     // EasyEDA API 原始字段
     QString uuid;

--- a/src/models/FootprintDataSerializer.cpp
+++ b/src/models/FootprintDataSerializer.cpp
@@ -12,6 +12,7 @@ QJsonObject FootprintDataSerializer::toJson(const FootprintInfo& info) {
     json["name"] = info.name;
     json["type"] = info.type;
     json["model_3d_name"] = info.model3DName;
+    json["description"] = info.description;
 
     // EasyEDA API 原始字段
     json["uuid"] = info.uuid;
@@ -51,6 +52,7 @@ bool FootprintDataSerializer::fromJson(FootprintInfo& info, const QJsonObject& j
     info.name = json["name"].toString();
     info.type = json["type"].toString();
     info.model3DName = json["model_3d_name"].toString();
+    info.description = json["description"].toString();
 
     // EasyEDA API 原始字段
     info.uuid = json["uuid"].toString();

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -243,7 +243,7 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
         }
 
         if (!result.success) {
-            emit fetchError(result.componentId, result.errorMessage);
+            emitFetchErrorAndClearState(result.componentId, result.errorMessage);
             return;
         }
 
@@ -317,6 +317,13 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
             }
         }
 
+        if (!result.symbolData || !result.footprintData) {
+            qWarning() << "Cache load incomplete for" << normalizedId << "- symbol:" << (result.symbolData != nullptr)
+                       << "footprint:" << (result.footprintData != nullptr);
+            result.success = false;
+            return result;
+        }
+
         result.cachedData = cachedData;
         result.success = true;
 
@@ -369,7 +376,7 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
                 }
 
                 if (!result.success) {
-                    emit fetchError(result.componentId, result.errorMessage);
+                    emitFetchErrorAndClearState(result.componentId, result.errorMessage);
                     return;
                 }
 
@@ -777,7 +784,7 @@ void ComponentService::handleCadDataFetched(const QString& componentId, const QJ
         watcher->deleteLater();
 
         if (!parsed.success) {
-            emit fetchError(parsed.componentId, parsed.errorMessage);
+            emitFetchErrorAndClearState(parsed.componentId, parsed.errorMessage);
             return;
         }
 
@@ -806,15 +813,7 @@ void ComponentService::handleCadDataFetched(const QString& componentId, const QJ
 }
 
 void ComponentService::handleFetchError(const QString& errorMessage) {
-    qDebug() << "Fetch error:" << errorMessage;
-
-    // 如果在并行模式下，处理并行错误
-    if (m_parallelContext != nullptr) {
-        handleParallelFetchError(m_currentComponentId, errorMessage);
-    }
-
-    // 最后发送信号，防止信号连接的槽函数删除了本对象导致后续访问成员变量崩溃
-    emit fetchError(m_currentComponentId, errorMessage);
+    emitFetchErrorAndClearState(m_currentComponentId, errorMessage);
 }
 
 void ComponentService::handleFetchErrorWithId(const QString& idOrUuid, const QString& error) {
@@ -833,14 +832,7 @@ void ComponentService::handleFetchErrorWithId(const QString& idOrUuid, const QSt
         }
     }
 
-    qDebug() << "Fetch error for component:" << componentId << "Error:" << error;
-
-    // 如果在并行模式下，处理并行错误
-    if (m_parallelContext != nullptr) {
-        handleParallelFetchError(componentId, error);
-    }
-
-    emit fetchError(componentId, error);
+    emitFetchErrorAndClearState(componentId, error);
 }
 
 void ComponentService::setOutputPath(const QString& path) {
@@ -1020,11 +1012,24 @@ void ComponentService::cancelRequestForComponent(const QString& componentId) {
     qDebug() << "ComponentService: Request cancelled for component" << normalizedId;
 }
 
-void ComponentService::handleFetchErrorForComponent(const QString& componentId, const QString& error) {
+void ComponentService::emitFetchErrorAndClearState(const QString& componentId, const QString& error) {
     qWarning() << "Fetch error for component" << componentId << ":" << error;
-    if (m_parallelContext != nullptr) {
-        handleParallelFetchError(componentId, error);
+
+    {
+        QMutexLocker locker(&m_fetchingComponentsMutex);
+        m_fetchingComponents.remove(componentId);
     }
+    {
+        QMutexLocker locker(&m_componentCacheMutex);
+        const auto it = m_componentCache.find(componentId);
+        if (it != m_componentCache.end() && !it.value().isValid()) {
+            m_componentCache.erase(it);
+        }
+    }
+
+    handleParallelFetchError(componentId, error);
+
+    // fetchError 必须最后发送，因为连接的槽函数可能会删除本对象
     emit fetchError(componentId, error);
 }
 

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -954,6 +954,24 @@ void ComponentService::updateComponentCache(const QString& componentId, const Co
     qDebug() << "ComponentService: Updated cache for" << componentId;
 }
 
+void ComponentService::updateComponentDescription(const QString& componentId, const QString& description) {
+    QMutexLocker locker(&m_componentCacheMutex);
+    auto it = m_componentCache.find(componentId);
+    if (it == m_componentCache.end()) {
+        return;
+    }
+    if (it->symbolData()) {
+        SymbolInfo info = it->symbolData()->info();
+        info.description = description;
+        it->symbolData()->setInfo(info);
+    }
+    if (it->footprintData()) {
+        FootprintInfo info = it->footprintData()->info();
+        info.description = description;
+        it->footprintData()->setInfo(info);
+    }
+}
+
 void ComponentService::clearCache() {
     m_componentCache.clear();
 

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -130,6 +130,13 @@ public:
     void updateComponentCache(const QString& componentId, const ComponentData& data);
 
     /**
+     * @brief 更新元件的符号/封装描述
+     * @param componentId 元件ID
+     * @param description 用户编辑后的描述
+     */
+    void updateComponentDescription(const QString& componentId, const QString& description);
+
+    /**
      * @brief 取消所有正在进行的预览图获取操作
      *
      * 当用户点击开始导出时调用，以确保取消所有未完成的预览图获取工作

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -339,7 +339,7 @@ private:
      * @param componentId 元件ID
      * @param error 错误信息
      */
-    void handleFetchErrorForComponent(const QString& componentId, const QString& error);
+    void emitFetchErrorAndClearState(const QString& componentId, const QString& error);
 
     /**
      * @brief 处理并行数据收集完成

--- a/src/services/ConfigService.cpp
+++ b/src/services/ConfigService.cpp
@@ -279,6 +279,10 @@ void ConfigService::setDarkMode(bool enabled) {
     QMutexLocker locker(&m_configMutex);
     m_config["darkMode"] = enabled;
     emit configChanged();
+
+    // 释放锁后保存
+    locker.unlock();
+    saveConfig();
 }
 
 bool ConfigService::getDebugMode() const {

--- a/src/services/export/CMakeLists.txt
+++ b/src/services/export/CMakeLists.txt
@@ -19,6 +19,7 @@ set(EXPORT_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/ComponentDataCache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/TempFileManager.h
     ${CMAKE_CURRENT_SOURCE_DIR}/DebugExportHelper.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/KiCadLibraryTableManager.h
     PARENT_SCOPE
 )
 
@@ -40,5 +41,6 @@ set(EXPORT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ExportWorkerHelpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TempFileManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/DebugExportHelper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/KiCadLibraryTableManager.cpp
     PARENT_SCOPE
 )

--- a/src/services/export/ExportProgress.h
+++ b/src/services/export/ExportProgress.h
@@ -47,6 +47,11 @@ struct ExportOptions {
     bool weakNetworkSupport = false;  ///< 是否启用客户端弱网络适配
     bool updateMode = false;  ///< 更新模式：仅导出缺失或已更改的文件
     bool debugMode = false;  ///< 调试模式：输出详细调试信息
+    bool exportSymbolDescription = true;  ///< 是否导出符号库描述 (ki_description)
+    bool exportFootprintDescription = true;  ///< 是否导出封装库描述 (descr)
+    QString symbolLibraryDescription;  ///< 用户输入的符号库描述文本
+    QString footprintLibraryDescription;  ///< 用户输入的封装库描述文本
+    QString footprintLibraryKeywords;  ///< 用户输入的封装库关键词文本
 };
 
 /**

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -154,6 +154,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
 
     if (m_cancelled.load()) {
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
@@ -161,6 +162,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (footprintList.isEmpty()) {
         qWarning() << "FootprintExportStage: No valid footprints to export";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
@@ -179,6 +181,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (!dir.mkpath(outputDir)) {
         qCritical() << "FootprintExportStage: Failed to create output directory:" << outputDir;
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -188,6 +191,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (tempDirPath.isEmpty()) {
         qCritical() << "FootprintExportStage: Failed to create temp dir path";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -196,14 +200,13 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 5. 执行封装库导出
     bool exportSuccess = false;
-    QString libraryDescription =
-        m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
+    QString libraryDescription = m_options.footprintLibraryDescription;
     {
         ExporterFootprint exporter;
         // 传入3D模型格式标志：WRL和STEP可以同时导出，生成两个 (model ...) 块
         const bool preferWrl = m_options.needsModel3DWrl();
         const bool exportStep = m_options.needsModel3DStep();
-        QString libraryKeywords = m_options.exportFootprintDescription ? m_options.footprintLibraryKeywords : QString();
+        QString libraryKeywords = m_options.footprintLibraryKeywords;
         exportSuccess = exporter.exportFootprintLibrary(
             footprintList, libName, tempDirPath, preferWrl, exportStep, libraryDescription, libraryKeywords);
     }
@@ -211,6 +214,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (m_cancelled.load()) {
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -219,6 +223,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         qCritical() << "FootprintExportStage: Failed to export footprint library";
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -230,6 +235,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         qCritical() << "FootprintExportStage: Failed to commit temp dir";
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -200,7 +200,11 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         // 传入3D模型格式标志：WRL和STEP可以同时导出，生成两个 (model ...) 块
         const bool preferWrl = m_options.needsModel3DWrl();
         const bool exportStep = m_options.needsModel3DStep();
-        exportSuccess = exporter.exportFootprintLibrary(footprintList, libName, tempDirPath, preferWrl, exportStep);
+        QString libraryDescription =
+            m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
+        QString libraryKeywords = m_options.exportFootprintDescription ? m_options.footprintLibraryKeywords : QString();
+        exportSuccess = exporter.exportFootprintLibrary(
+            footprintList, libName, tempDirPath, preferWrl, exportStep, libraryDescription, libraryKeywords);
     }
 
     if (m_cancelled.load()) {

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -1,5 +1,6 @@
 #include "FootprintExportStage.h"
 
+#include "KiCadLibraryTableManager.h"
 #include "core/kicad/ExporterFootprint.h"
 #include "models/ComponentData.h"
 
@@ -195,13 +196,13 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 5. 执行封装库导出
     bool exportSuccess = false;
+    QString libraryDescription =
+        m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
     {
         ExporterFootprint exporter;
         // 传入3D模型格式标志：WRL和STEP可以同时导出，生成两个 (model ...) 块
         const bool preferWrl = m_options.needsModel3DWrl();
         const bool exportStep = m_options.needsModel3DStep();
-        QString libraryDescription =
-            m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
         QString libraryKeywords = m_options.exportFootprintDescription ? m_options.footprintLibraryKeywords : QString();
         exportSuccess = exporter.exportFootprintLibrary(
             footprintList, libName, tempDirPath, preferWrl, exportStep, libraryDescription, libraryKeywords);
@@ -231,6 +232,13 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         m_isExporting.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
+    }
+
+    // 6.1 生成 fp-lib-table 文件（如果提供了库描述）
+    if (!libraryDescription.isEmpty()) {
+        ExporterFootprint fpTableExporter;
+        fpTableExporter.generateFpLibTable(libName, finalDir, outputDir, libraryDescription);
+        KiCadLibraryTableManager::registerFootprintLibrary(outputDir, libName, finalDir, libraryDescription);
     }
 
     // 7. 清理临时目录

--- a/src/services/export/FootprintExportWorker.cpp
+++ b/src/services/export/FootprintExportWorker.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
-#include <QtConcurrent>
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 
@@ -81,9 +81,10 @@ void FootprintExportWorker::run() {
             qDebug() << "FootprintExportWorker: Successfully exported" << filePath;
 
             if (m_options.debugMode) {
-                QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
-                    DebugExportHelper::exportDebugData(componentId, data, outputPath);
-                });
+                QThreadPool::globalInstance()->start(
+                    [componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+                        DebugExportHelper::exportDebugData(componentId, data, outputPath);
+                    });
             }
 
             emit completed(m_componentId, true, QString());

--- a/src/services/export/KiCadLibraryTableManager.cpp
+++ b/src/services/export/KiCadLibraryTableManager.cpp
@@ -1,0 +1,217 @@
+#include "KiCadLibraryTableManager.h"
+
+#include "core/utils/KiCadTableUtils.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QTextStream>
+
+namespace EasyKiConverter {
+
+KiCadLibraryTableManager::RegistrationResult KiCadLibraryTableManager::registerSymbolLibrary(
+    const QString& outputDir,
+    const QString& libName,
+    const QString& libFilePath,
+    const QString& libraryDescription) {
+    const QString projectRoot = findKiCadProjectRoot(outputDir);
+    if (projectRoot.isEmpty()) {
+        return writeImportGuide(outputDir) ? RegistrationResult::ImportGuideWritten : RegistrationResult::Failed;
+    }
+
+    const QString uri = makeProjectUri(projectRoot, libFilePath);
+    return updateProjectLibraryTable(projectRoot,
+                                     QStringLiteral("sym-lib-table"),
+                                     QStringLiteral("sym_lib_table"),
+                                     libName,
+                                     uri,
+                                     libraryDescription)
+               ? RegistrationResult::Registered
+               : RegistrationResult::Failed;
+}
+
+KiCadLibraryTableManager::RegistrationResult KiCadLibraryTableManager::registerFootprintLibrary(
+    const QString& outputDir,
+    const QString& libName,
+    const QString& libDirPath,
+    const QString& libraryDescription) {
+    const QString projectRoot = findKiCadProjectRoot(outputDir);
+    if (projectRoot.isEmpty()) {
+        return writeImportGuide(outputDir) ? RegistrationResult::ImportGuideWritten : RegistrationResult::Failed;
+    }
+
+    const QString uri = makeProjectUri(projectRoot, libDirPath);
+    return updateProjectLibraryTable(projectRoot,
+                                     QStringLiteral("fp-lib-table"),
+                                     QStringLiteral("fp_lib_table"),
+                                     libName,
+                                     uri,
+                                     libraryDescription)
+               ? RegistrationResult::Registered
+               : RegistrationResult::Failed;
+}
+
+bool KiCadLibraryTableManager::writeImportGuide(const QString& outputDir) {
+    QDir dir(outputDir);
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        qWarning() << "KiCadLibraryTableManager: Failed to create output directory for import guide:" << outputDir;
+        return false;
+    }
+
+    const QString guidePath = dir.filePath(QStringLiteral("KiCad_IMPORT.md"));
+    QSaveFile file(guidePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "KiCadLibraryTableManager: Failed to open import guide:" << guidePath;
+        return false;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+
+    out << "# KiCad Library Import\n\n";
+    out << "EasyKiConverter did not find a KiCad project (`*.kicad_pro`) in this output path or its parent "
+           "directories, so it did not modify any project library table.\n\n";
+    out << "To show library descriptions in KiCad, add the exported libraries to the target project's library "
+           "tables or to KiCad's global library tables.\n\n";
+
+    const QString symTablePath = dir.filePath(QStringLiteral("sym-lib-table"));
+    if (QFileInfo::exists(symTablePath)) {
+        out << "## Symbol Library Entry\n\n";
+        out << "Use the entry from:\n\n";
+        out << "```text\n" << symTablePath << "\n```\n\n";
+    }
+
+    const QString fpTablePath = dir.filePath(QStringLiteral("fp-lib-table"));
+    if (QFileInfo::exists(fpTablePath)) {
+        out << "## Footprint Library Entry\n\n";
+        out << "Use the entry from:\n\n";
+        out << "```text\n" << fpTablePath << "\n```\n\n";
+    }
+
+    out << "Project-specific KiCad library tables are named `sym-lib-table` and `fp-lib-table` and live next to the "
+           "project's `.kicad_pro` file.\n";
+
+    if (!file.commit()) {
+        qWarning() << "KiCadLibraryTableManager: Failed to commit import guide:" << guidePath;
+        return false;
+    }
+
+    return true;
+}
+
+QString KiCadLibraryTableManager::findKiCadProjectRoot(const QString& outputDir) {
+    QDir dir(QFileInfo(outputDir).absoluteFilePath());
+    if (!dir.exists()) {
+        return QString();
+    }
+
+    while (true) {
+        const QStringList projectFiles = dir.entryList(QStringList(QStringLiteral("*.kicad_pro")), QDir::Files);
+        if (!projectFiles.isEmpty()) {
+            return dir.absolutePath();
+        }
+
+        if (!dir.cdUp()) {
+            break;
+        }
+    }
+
+    return QString();
+}
+
+bool KiCadLibraryTableManager::updateProjectLibraryTable(const QString& projectRoot,
+                                                         const QString& tableFileName,
+                                                         const QString& tableRootName,
+                                                         const QString& libName,
+                                                         const QString& uri,
+                                                         const QString& libraryDescription) {
+    QDir projectDir(projectRoot);
+    const QString tablePath = projectDir.filePath(tableFileName);
+
+    QString content;
+    QFile existingFile(tablePath);
+    if (existingFile.exists()) {
+        if (!existingFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            qWarning() << "KiCadLibraryTableManager: Failed to read library table:" << tablePath;
+            return false;
+        }
+        QTextStream in(&existingFile);
+        in.setEncoding(QStringConverter::Utf8);
+        content = in.readAll();
+    }
+
+    if (content.trimmed().isEmpty()) {
+        content = QStringLiteral("(%1\n  (version 7)\n)\n").arg(tableRootName);
+    }
+
+    QStringList lines = content.split('\n');
+    const QRegularExpression entryRegex(
+        QStringLiteral(R"(^\s*\(lib\s+\(name\s+"?%1"?\))").arg(QRegularExpression::escape(libName)));
+
+    QStringList filteredLines;
+    filteredLines.reserve(lines.size() + 1);
+    for (const QString& line : lines) {
+        if (!entryRegex.match(line).hasMatch()) {
+            filteredLines.append(line);
+        }
+    }
+
+    int insertIndex = filteredLines.size();
+    while (insertIndex > 0 && filteredLines.at(insertIndex - 1).trimmed().isEmpty()) {
+        --insertIndex;
+    }
+    if (insertIndex > 0 && filteredLines.at(insertIndex - 1).trimmed() == QStringLiteral(")")) {
+        --insertIndex;
+    }
+
+    filteredLines.insert(insertIndex, makeLibraryEntry(libName, uri, libraryDescription));
+    QString updatedContent = filteredLines.join('\n');
+    if (!updatedContent.endsWith('\n')) {
+        updatedContent += '\n';
+    }
+
+    QSaveFile file(tablePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "KiCadLibraryTableManager: Failed to write library table:" << tablePath;
+        return false;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+    out << updatedContent;
+    if (!file.commit()) {
+        qWarning() << "KiCadLibraryTableManager: Failed to commit library table:" << tablePath;
+        return false;
+    }
+
+    qDebug() << "KiCadLibraryTableManager: Updated project library table:" << tablePath;
+    return true;
+}
+
+QString KiCadLibraryTableManager::makeLibraryEntry(const QString& libName,
+                                                   const QString& uri,
+                                                   const QString& libraryDescription) {
+    QString entry = QStringLiteral("  (lib (name \"%1\")(type \"KiCad\")(uri \"%2\")(options \"\")")
+                        .arg(KiCadTableUtils::escapeTableValue(libName), KiCadTableUtils::escapeTableValue(uri));
+    if (!libraryDescription.isEmpty()) {
+        entry += QStringLiteral("(descr \"%1\")").arg(KiCadTableUtils::escapeTableValue(libraryDescription));
+    } else {
+        entry += QStringLiteral("(descr \"\")");
+    }
+    entry += QStringLiteral(")");
+    return entry;
+}
+
+QString KiCadLibraryTableManager::makeProjectUri(const QString& projectRoot, const QString& libraryPath) {
+    QString relativePath = QDir(projectRoot).relativeFilePath(QFileInfo(libraryPath).absoluteFilePath());
+    relativePath.replace(QDir::separator(), QLatin1Char('/'));
+    if (relativePath == QStringLiteral(".")) {
+        return QStringLiteral("${KIPRJMOD}");
+    }
+    return QStringLiteral("${KIPRJMOD}/%1").arg(relativePath);
+}
+
+}  // namespace EasyKiConverter

--- a/src/services/export/KiCadLibraryTableManager.h
+++ b/src/services/export/KiCadLibraryTableManager.h
@@ -1,0 +1,43 @@
+#ifndef KICADLIBRARYTABLEMANAGER_H
+#define KICADLIBRARYTABLEMANAGER_H
+
+#include <QString>
+
+namespace EasyKiConverter {
+
+class KiCadLibraryTableManager {
+public:
+    enum class RegistrationResult {
+        Registered,
+        ImportGuideWritten,
+        Failed,
+    };
+
+    static RegistrationResult registerSymbolLibrary(const QString& outputDir,
+                                                    const QString& libName,
+                                                    const QString& libFilePath,
+                                                    const QString& libraryDescription);
+
+    static RegistrationResult registerFootprintLibrary(const QString& outputDir,
+                                                       const QString& libName,
+                                                       const QString& libDirPath,
+                                                       const QString& libraryDescription);
+
+private:
+    static bool writeImportGuide(const QString& outputDir);
+    static QString findKiCadProjectRoot(const QString& outputDir);
+
+    static bool updateProjectLibraryTable(const QString& projectRoot,
+                                          const QString& tableFileName,
+                                          const QString& tableRootName,
+                                          const QString& libName,
+                                          const QString& uri,
+                                          const QString& libraryDescription);
+
+    static QString makeLibraryEntry(const QString& libName, const QString& uri, const QString& libraryDescription);
+    static QString makeProjectUri(const QString& projectRoot, const QString& libraryPath);
+};
+
+}  // namespace EasyKiConverter
+
+#endif  // KICADLIBRARYTABLEMANAGER_H

--- a/src/services/export/Model3DExportWorker.cpp
+++ b/src/services/export/Model3DExportWorker.cpp
@@ -160,7 +160,7 @@ void Model3DExportWorker::run() {
     if ((!needWrl || wrlFromCache) && (!needStep || stepFromCache)) {
         qDebug() << "Model3DExportWorker: Both WRL and STEP loaded from cache for" << m_componentId;
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+            (void)QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }
@@ -229,7 +229,7 @@ void Model3DExportWorker::run() {
                  << "for" << m_componentId;
 
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+            (void)QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }

--- a/src/services/export/PreviewImagesExportWorker.cpp
+++ b/src/services/export/PreviewImagesExportWorker.cpp
@@ -171,7 +171,7 @@ void PreviewImagesExportWorker::run() {
         qDebug() << "PreviewImagesExportWorker: Successfully exported all previews for" << m_componentId;
 
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+            (void)QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -1,6 +1,7 @@
 #include "SymbolExportStage.h"
 
 #include "DebugExportHelper.h"
+#include "KiCadLibraryTableManager.h"
 #include "core/kicad/ExporterSymbol.h"
 #include "models/ComponentData.h"
 
@@ -10,7 +11,7 @@
 #include <QFile>
 #include <QMutexLocker>
 #include <QThread>
-#include <QtConcurrent>
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 
@@ -151,7 +152,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         emit itemStatusChanged(componentId, status);
 
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId, data, outputPath = m_options.outputPath]() {
+            QThreadPool::globalInstance()->start([componentId, data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }
@@ -218,11 +219,10 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 6. 执行符号库导出
     bool exportSuccess = false;
+    QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
     {
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
-        QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
-        qDebug() << "SymbolExportStage: libraryDescription=" << libraryDescription;
         exportSuccess = exporter.exportSymbolLibrary(
             symbolList, libName, tempPath, appendMode, m_options.updateMode, libraryDescription);
     }
@@ -251,6 +251,13 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         m_isExporting.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
+    }
+
+    // 7.1 生成 sym-lib-table 文件（如果提供了库描述）
+    if (!libraryDescription.isEmpty()) {
+        ExporterSymbol symTableExporter;
+        symTableExporter.generateSymLibTable(libName, finalPath, outputDir, libraryDescription);
+        KiCadLibraryTableManager::registerSymbolLibrary(outputDir, libName, finalPath, libraryDescription);
     }
 
     // 8. 清理临时目录

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -106,6 +106,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 1. 收集所有有效的符号数据
     QList<SymbolData> symbolList;
+    QStringList collectedIds;
     QStringList failedIds;
     int successCount = 0;
     int skippedCount = 0;
@@ -144,6 +145,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
         // 添加到符号列表
         symbolList.append(*data->symbolData());
+        collectedIds.append(componentId);
         successCount++;
 
         // 发射 itemStatusChanged 信号通知 ViewModel
@@ -162,6 +164,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     if (m_cancelled.load()) {
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
@@ -169,9 +172,22 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (symbolList.isEmpty()) {
         qWarning() << "SymbolExportStage: No valid symbols to export";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
+
+    const auto failCollectedSymbols = [this, &collectedIds, &failedIds, &successCount](const QString& errorMessage) {
+        for (const QString& componentId : collectedIds) {
+            failedIds.append(componentId);
+            ExportItemStatus status;
+            status.status = ExportItemStatus::Status::Failed;
+            status.errorMessage = errorMessage;
+            status.endTime = QDateTime::currentDateTime();
+            emit itemStatusChanged(componentId, status);
+        }
+        successCount = 0;
+    };
 
     // 2. 构建输出路径
     QString libName = m_options.libName.isEmpty() ? QStringLiteral("EasyKiConverter") : m_options.libName;
@@ -187,6 +203,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (!dir.mkpath(outputDir)) {
         qCritical() << "SymbolExportStage: Failed to create output directory:" << outputDir;
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
     }
@@ -198,19 +215,35 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (tempPath.isEmpty()) {
         qCritical() << "SymbolExportStage: Failed to create temp file path";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
     }
 
     // 追加/更新到现有符号库时，先把最终文件复制到临时文件，再在临时文件上执行 merge。
     if (finalFileExists && (!m_options.overwriteExistingFiles || m_options.updateMode)) {
-        QFile::remove(tempPath);
-        if (!QFile::copy(finalPath, tempPath)) {
-            qCritical() << "SymbolExportStage: Failed to copy existing symbol library to temp:" << finalPath << "->"
-                        << tempPath;
+        QFile tempFile(tempPath);
+        if (tempFile.exists() && !tempFile.remove()) {
+            const QString errorMessage = QStringLiteral("Failed to remove stale temp symbol library: %1").arg(tempPath);
+            qCritical() << "SymbolExportStage:" << errorMessage << "error:" << tempFile.errorString();
+            failCollectedSymbols(errorMessage);
             m_tempManager.rollbackAll();
             m_isExporting.store(false);
-            emit completed(0, symbolList.size(), 0);
+            m_isRunning.store(false);
+            emit completed(0, failedIds.size(), 0);
+            return;
+        }
+
+        QFile sourceFile(finalPath);
+        if (!sourceFile.copy(tempPath)) {
+            const QString errorMessage =
+                QStringLiteral("Failed to copy existing symbol library to temp: %1 -> %2").arg(finalPath, tempPath);
+            qCritical() << "SymbolExportStage:" << errorMessage << "error:" << sourceFile.errorString();
+            failCollectedSymbols(errorMessage);
+            m_tempManager.rollbackAll();
+            m_isExporting.store(false);
+            m_isRunning.store(false);
+            emit completed(0, failedIds.size(), 0);
             return;
         }
     }
@@ -219,7 +252,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 6. 执行符号库导出
     bool exportSuccess = false;
-    QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
+    QString libraryDescription = m_options.symbolLibraryDescription;
     {
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
@@ -230,15 +263,19 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (m_cancelled.load()) {
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
     }
 
     if (!exportSuccess) {
-        qCritical() << "SymbolExportStage: Failed to export symbol library";
+        const QString errorMessage = QStringLiteral("Failed to export symbol library");
+        qCritical() << "SymbolExportStage:" << errorMessage;
+        failCollectedSymbols(errorMessage);
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
-        emit completed(0, symbolList.size(), 0);
+        m_isRunning.store(false);
+        emit completed(0, failedIds.size(), 0);
         return;
     }
 
@@ -246,10 +283,13 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (m_tempManager.commit(finalPath)) {
         qDebug() << "SymbolExportStage: Successfully exported to:" << finalPath;
     } else {
-        qCritical() << "SymbolExportStage: Failed to commit temp file";
+        const QString errorMessage = QStringLiteral("Failed to commit temp file");
+        qCritical() << "SymbolExportStage:" << errorMessage;
+        failCollectedSymbols(errorMessage);
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
-        emit completed(0, symbolList.size(), 0);
+        m_isRunning.store(false);
+        emit completed(0, failedIds.size(), 0);
         return;
     }
 

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -221,7 +221,9 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     {
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
-        exportSuccess = exporter.exportSymbolLibrary(symbolList, libName, tempPath, appendMode, m_options.updateMode);
+        QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
+        exportSuccess = exporter.exportSymbolLibrary(
+            symbolList, libName, tempPath, appendMode, m_options.updateMode, libraryDescription);
     }
 
     if (m_cancelled.load()) {

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -222,6 +222,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
         QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
+        qDebug() << "SymbolExportStage: libraryDescription=" << libraryDescription;
         exportSuccess = exporter.exportSymbolLibrary(
             symbolList, libName, tempPath, appendMode, m_options.updateMode, libraryDescription);
     }

--- a/src/services/export/SymbolExportWorker.cpp
+++ b/src/services/export/SymbolExportWorker.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
-#include <QtConcurrent>
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 
@@ -80,9 +80,10 @@ void SymbolExportWorker::run() {
             qDebug() << "SymbolExportWorker: Successfully exported" << filePath;
 
             if (m_options.debugMode) {
-                QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
-                    DebugExportHelper::exportDebugData(componentId, data, outputPath);
-                });
+                QThreadPool::globalInstance()->start(
+                    [componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+                        DebugExportHelper::exportDebugData(componentId, data, outputPath);
+                    });
             }
 
             emit completed(m_componentId, true, QString());

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -362,6 +362,7 @@ Item {
                     // 导出设置卡片
                     ExportSettingsCard {
                         Layout.fillWidth: true
+                        Layout.fillHeight: true
                         exportSettingsController: window.exportSettingsController
                         onOpenOutputFolderDialog: outputFolderDialog.open()
                     }

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -247,16 +247,13 @@ Item {
             onPaint: {
                 const ctx = getContext("2d");
                 ctx.reset();
-
                 const r = windowRadius;
                 ctx.beginPath();
                 ctx.roundedRect(0, 0, width, height, r, r);
                 ctx.closePath();
                 ctx.clip();
-
                 ctx.fillStyle = AppStyle.colors.background;
                 ctx.fill();
-
                 if (bgSource.status === Image.Ready) {
                     const sw = bgSource.sourceSize.width;
                     const sh = bgSource.sourceSize.height;

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -13,6 +13,7 @@ Card {
     readonly property bool showValidationHint: componentListController ? componentListController.validationReadyHint : false
     readonly property bool showPreviewHint: componentListController ? componentListController.previewReadyHint : false
     readonly property color hintColor: showPreviewHint ? "#31c36b" : (showValidationHint ? "#2f7ef8" : "transparent")
+    property string editingDescriptionComponentId: ""
     title: qsTranslate("MainWindow", "元器件列表")
     // 默认折叠，只有在有元器件时才展开
     isCollapsed: componentListController ? componentListController.componentCount === 0 : true
@@ -112,6 +113,11 @@ Card {
                         componentListCard.componentListController.refreshComponentInfo(index);
                     }
                 }
+                onDescriptionEditRequested: function (componentId, description) {
+                    componentListCard.editingDescriptionComponentId = componentId;
+                    descriptionDialog.descriptionText = description;
+                    descriptionDialog.open();
+                }
             }
 
             // 过滤函数
@@ -150,6 +156,17 @@ Card {
                     item.inDisplay = passFilter && passSearch;
                 }
             }
+        },
+        DescriptionEditDialog {
+            id: descriptionDialog
+            parent: componentListCard.Window.window ? componentListCard.Window.window.contentItem : componentListCard
+            onAccepted: function (description) {
+                if (componentListCard.componentListController && componentListCard.editingDescriptionComponentId !== "") {
+                    componentListCard.componentListController.updateComponentDescription(componentListCard.editingDescriptionComponentId, description);
+                }
+                componentListCard.editingDescriptionComponentId = "";
+            }
+            onRejected: componentListCard.editingDescriptionComponentId = ""
         }
     ]
     overlayContent: [

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -13,6 +13,7 @@ Rectangle {
     signal deleteClicked
     signal copyClicked
     signal retryClicked
+    signal descriptionEditRequested(string componentId, string description)
     height: 64 // 增加高度以容纳缩略图和更多信息
     // 悬停效果
     color: itemMouseArea.containsMouse ? AppStyle.colors.background : AppStyle.colors.surface
@@ -553,18 +554,44 @@ Rectangle {
                     if (phase === "failed")
                         return itemData.errorMessage || "验证失败";
                     if (phase === "completed" || itemData.isValid) {
-                        var info = [];
-                        if (itemData.name)
-                            info.push(itemData.name);
-                        if (itemData.package)
-                            info.push(itemData.package);
-                        return info.join(" | ");
+                        return itemData.description || itemData.name || "";
                     }
                     return "";
                 }
                 font.pixelSize: AppStyle.fontSizes.sm
                 color: (itemData && itemData.validationPhase === "failed") ? AppStyle.colors.danger : AppStyle.colors.textSecondary
                 elide: Text.ElideRight
+            }
+        }
+        // 重试按钮（仅对验证失败的元器件显示）
+        Button {
+            Layout.preferredWidth: 28
+            Layout.preferredHeight: 28
+            Layout.alignment: Qt.AlignVCenter
+            visible: itemData && itemData.isValid
+            background: Rectangle {
+                color: parent.pressed ? AppStyle.colors.primaryPressed : parent.hovered ? "#dbeafe" : "transparent"
+                radius: AppStyle.radius.sm
+                Behavior on color {
+                    ColorAnimation {
+                        duration: AppStyle.durations.fast
+                    }
+                }
+            }
+            contentItem: Text {
+                text: "✎"
+                font.pixelSize: AppStyle.fontSizes.lg
+                font.bold: true
+                color: parent.hovered ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+            ToolTip.visible: hovered
+            ToolTip.text: qsTr("编辑元器件描述")
+            onClicked: {
+                if (itemData) {
+                    rootItem.descriptionEditRequested(itemData.componentId, itemData.description || "");
+                }
             }
         }
         // 重试按钮（仅对验证失败的元器件显示）

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -222,9 +222,18 @@ Rectangle {
                             fillColor: "transparent"
                             capStyle: ShapePath.RoundCap
                             joinStyle: ShapePath.RoundJoin
-                            PathMove { x: checkShape.width / 2 - 6; y: checkShape.height / 2 }
-                            PathLine { x: checkShape.width / 2 - 2; y: checkShape.height / 2 + 3 }
-                            PathLine { x: checkShape.width / 2 + 6; y: checkShape.height / 2 - 3 }
+                            PathMove {
+                                x: checkShape.width / 2 - 6
+                                y: checkShape.height / 2
+                            }
+                            PathLine {
+                                x: checkShape.width / 2 - 2
+                                y: checkShape.height / 2 + 3
+                            }
+                            PathLine {
+                                x: checkShape.width / 2 + 6
+                                y: checkShape.height / 2 - 3
+                            }
                         }
                     }
                 }
@@ -247,16 +256,28 @@ Rectangle {
                             strokeWidth: 2
                             fillColor: "transparent"
                             capStyle: ShapePath.RoundCap
-                            PathMove { x: crossShape.width / 2 - 6; y: crossShape.height / 2 - 6 }
-                            PathLine { x: crossShape.width / 2 + 6; y: crossShape.height / 2 + 6 }
+                            PathMove {
+                                x: crossShape.width / 2 - 6
+                                y: crossShape.height / 2 - 6
+                            }
+                            PathLine {
+                                x: crossShape.width / 2 + 6
+                                y: crossShape.height / 2 + 6
+                            }
                         }
                         ShapePath {
                             strokeColor: AppStyle.colors.danger
                             strokeWidth: 2
                             fillColor: "transparent"
                             capStyle: ShapePath.RoundCap
-                            PathMove { x: crossShape.width / 2 + 6; y: crossShape.height / 2 - 6 }
-                            PathLine { x: crossShape.width / 2 - 6; y: crossShape.height / 2 + 6 }
+                            PathMove {
+                                x: crossShape.width / 2 + 6
+                                y: crossShape.height / 2 - 6
+                            }
+                            PathLine {
+                                x: crossShape.width / 2 - 6
+                                y: crossShape.height / 2 + 6
+                            }
                         }
                     }
                 }

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -186,7 +186,10 @@ Rectangle {
                             return "";
                         if (!itemData.previewImages || itemData.previewImages.length === 0)
                             return "";
-                        return "data:image/jpeg;base64," + itemData.previewImages[0];
+                        var imageData = itemData.previewImages[0];
+                        if (!imageData || imageData === "")
+                            return "";
+                        return "data:image/jpeg;base64," + imageData;
                     }
                     fillMode: Image.PreserveAspectFit
                     cache: true

--- a/src/ui/qml/components/ConfirmDialog.qml
+++ b/src/ui/qml/components/ConfirmDialog.qml
@@ -68,7 +68,7 @@ SliderDialogBase {
         visible = true;
         root.dialogBox.y = 0;
         root.dialogBoxTranslate.y = 0;
-        showAnim.start();
+        root.showAnimation.start();
         root.forceActiveFocus();
         // 默认聚焦在取消按钮（第一个非分隔线项）
         var childIndex = 0;

--- a/src/ui/qml/components/DescriptionEditDialog.qml
+++ b/src/ui/qml/components/DescriptionEditDialog.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "../styles"
+
+/**
+ * @brief 元器件描述编辑对话框
+ *
+ * 使用与退出确认对话框一致的滑块按钮和遮罩样式。
+ */
+SliderDialogBase {
+    id: root
+    hasOverlay: true
+    title: qsTr("元器件描述")
+    message: qsTr("编辑当前元器件导出到符号和封装中的描述。")
+
+    property string descriptionText: ""
+
+    signal accepted(string description)
+    signal rejected
+
+    mainContentSource: ColumnLayout {
+        spacing: AppStyle.spacing.sm
+
+        TextArea {
+            id: descriptionInput
+            Layout.fillWidth: true
+            Layout.preferredHeight: 128
+            text: root.descriptionText
+            wrapMode: TextEdit.Wrap
+            selectByMouse: true
+            font.pixelSize: AppStyle.fontSizes.sm
+            color: AppStyle.colors.textPrimary
+            placeholderText: qsTr("留空则不导出描述")
+            onTextChanged: root.descriptionText = text
+            Component.onCompleted: Qt.callLater(forceActiveFocus)
+
+            background: Rectangle {
+                color: AppStyle.colors.surface
+                border.color: descriptionInput.activeFocus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                border.width: descriptionInput.activeFocus ? 2 : 1
+                radius: AppStyle.radius.md
+            }
+        }
+    }
+
+    buttonSpecs: [
+        {
+            text: qsTr("取消"),
+            color: AppStyle.colors.textSecondary,
+            action: function () {
+                root.rejected();
+                root.closeWithAnimation();
+            }
+        },
+        {
+            isSeparator: true
+        },
+        {
+            text: qsTr("保存"),
+            color: AppStyle.colors.primary,
+            action: function () {
+                root.accepted(root.descriptionText);
+                root.close();
+            }
+        }
+    ]
+
+    Keys.onEscapePressed: {
+        root.rejected();
+        root.closeWithAnimation();
+    }
+
+    function open() {
+        visible = true;
+        root.dialogBox.y = 0;
+        root.dialogBoxTranslate.y = 0;
+        root.showAnimation.start();
+        root.forceActiveFocus();
+
+        var childIndex = 0;
+        for (var i = 0; i < buttonSpecs.length; i++) {
+            if (buttonSpecs[i].isSeparator) {
+                continue;
+            }
+            var loader = buttonColLayout.children[childIndex];
+            if (loader && loader.actualButton) {
+                root.updateSlider(loader.actualButton, AppStyle.colors.textSecondary);
+                break;
+            }
+            childIndex++;
+        }
+    }
+}

--- a/src/ui/qml/components/DescriptionEditDialog.qml
+++ b/src/ui/qml/components/DescriptionEditDialog.qml
@@ -13,15 +13,11 @@ SliderDialogBase {
     hasOverlay: true
     title: qsTr("元器件描述")
     message: qsTr("编辑当前元器件导出到符号和封装中的描述。")
-
     property string descriptionText: ""
-
     signal accepted(string description)
     signal rejected
-
     mainContentSource: ColumnLayout {
         spacing: AppStyle.spacing.sm
-
         TextArea {
             id: descriptionInput
             Layout.fillWidth: true
@@ -34,7 +30,6 @@ SliderDialogBase {
             placeholderText: qsTr("留空则不导出描述")
             onTextChanged: root.descriptionText = text
             Component.onCompleted: Qt.callLater(forceActiveFocus)
-
             background: Rectangle {
                 color: AppStyle.colors.surface
                 border.color: descriptionInput.activeFocus ? AppStyle.colors.borderFocus : AppStyle.colors.border
@@ -65,7 +60,6 @@ SliderDialogBase {
             }
         }
     ]
-
     Keys.onEscapePressed: {
         root.rejected();
         root.closeWithAnimation();
@@ -77,7 +71,6 @@ SliderDialogBase {
         root.dialogBoxTranslate.y = 0;
         root.showAnimation.start();
         root.forceActiveFocus();
-
         var childIndex = 0;
         for (var i = 0; i < buttonSpecs.length; i++) {
             if (buttonSpecs[i].isSeparator) {

--- a/src/ui/qml/components/ExportButtonsSection.qml
+++ b/src/ui/qml/components/ExportButtonsSection.qml
@@ -123,7 +123,7 @@ ColumnLayout {
                     var idList = exportButtonsSection.componentListController ? exportButtonsSection.componentListController.getAllComponentIds() : [];
                     var settingsController = exportButtonsSection.exportSettingsController;
                     if (progressController && settingsController) {
-                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false);
+                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false, settingsController.symbolLibraryDescription || "");
                     }
                 }
             }

--- a/src/ui/qml/components/ExportButtonsSection.qml
+++ b/src/ui/qml/components/ExportButtonsSection.qml
@@ -123,7 +123,7 @@ ColumnLayout {
                     var idList = exportButtonsSection.componentListController ? exportButtonsSection.componentListController.getAllComponentIds() : [];
                     var settingsController = exportButtonsSection.exportSettingsController;
                     if (progressController && settingsController) {
-                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false, settingsController.symbolLibraryDescription || "");
+                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false, settingsController.symbolLibraryDescription || "", settingsController.footprintLibraryDescription || "", settingsController.footprintLibraryKeywords || "");
                     }
                 }
             }

--- a/src/ui/qml/components/ExportResultsCard.qml
+++ b/src/ui/qml/components/ExportResultsCard.qml
@@ -10,26 +10,26 @@ Loader {
     property var exportProgressController
     active: resultsLoader.exportProgressController ? (resultsLoader.exportProgressController.isExporting || resultsLoader.exportProgressController.resultsList.length > 0) : false
     visible: active  // 确保 Loader 在没有结果时不占用空间
-    resources: [
-        // 防抖定时器，避免频繁调用 updateFilter()
-        Timer {
-            id: filterUpdateTimer
-            interval: 50
-            onTriggered: visualModel.updateFilter()
-        },
-        // 监听筛选模式变化，更新过滤
-        Connections {
-            target: resultsLoader.exportProgressController
-            function onFilterModeChanged() {
-                filterUpdateTimer.restart();
-            }
-            function onResultsListChanged() {
-                filterUpdateTimer.restart();
-            }
-        }
-    ]
     sourceComponent: Card {
         title: qsTranslate("MainWindow", "转换结果")
+        resources: [
+            // 防抖定时器，避免频繁调用 updateFilter()
+            Timer {
+                id: filterUpdateTimer
+                interval: 50
+                onTriggered: visualModel.updateFilter()
+            },
+            // 监听筛选模式变化，更新过滤
+            Connections {
+                target: resultsLoader.exportProgressController
+                function onFilterModeChanged() {
+                    filterUpdateTimer.restart();
+                }
+                function onResultsListChanged() {
+                    filterUpdateTimer.restart();
+                }
+            }
+        ]
         ColumnLayout {
             id: resultsContent
             width: parent.width

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -106,109 +106,80 @@ Card {
             }
         }
 
-        // ==================== 库元数据区块 ====================
+        // ==================== 库描述区块 ====================
         SectionHeader {
-            id: metadataHeader
-            sectionTitle: qsTranslate("MainWindow", "库元数据")
+            id: libraryDescriptionHeader
+            sectionTitle: qsTranslate("MainWindow", "库描述")
         }
 
         GridLayout {
             Layout.fillWidth: true
-            columns: 3
-            columnSpacing: AppStyle.spacing.md
-            rowSpacing: AppStyle.spacing.sm
-            // 符号库描述
+            columns: 2
+            columnSpacing: AppStyle.spacing.xl
+            rowSpacing: AppStyle.spacing.md
+
+            // 符号库描述：写入 sym-lib-table，不是单个符号描述
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.xs
                 Text {
-                    text: qsTranslate("MainWindow", "符号库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textSecondary
+                    text: qsTranslate("MainWindow", "符号库描述 (sym-lib-table)")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
                 }
                 TextField {
-                    id: symbolDescInput
+                    id: symbolLibraryDescriptionInput
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 32
+                    Layout.preferredHeight: 36
                     text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
                     onTextChanged: {
                         if (exportSettingsCard.exportSettingsController) {
                             exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
                         }
                     }
-                    placeholderText: qsTranslate("MainWindow", "符号库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
+                    placeholderText: qsTranslate("MainWindow", "输入符号库描述")
+                    font.pixelSize: AppStyle.fontSizes.sm
                     color: AppStyle.colors.textPrimary
                     placeholderTextColor: AppStyle.colors.textSecondary
                     background: Rectangle {
                         color: AppStyle.colors.surface
-                        border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: symbolDescInput.focus ? 2 : 1
-                        radius: AppStyle.radius.sm
+                        border.color: symbolLibraryDescriptionInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: symbolLibraryDescriptionInput.focus ? 2 : 1
+                        radius: AppStyle.radius.md
                     }
                 }
             }
 
-            // 封装库描述
+            // 封装库描述：写入 fp-lib-table，不是单个封装描述
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.xs
                 Text {
-                    text: qsTranslate("MainWindow", "封装库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textSecondary
+                    text: qsTranslate("MainWindow", "封装库描述 (fp-lib-table)")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
                 }
                 TextField {
-                    id: footprintDescInput
+                    id: footprintLibraryDescriptionInput
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 32
+                    Layout.preferredHeight: 36
                     text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
                     onTextChanged: {
                         if (exportSettingsCard.exportSettingsController) {
                             exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
                         }
                     }
-                    placeholderText: qsTranslate("MainWindow", "封装库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
+                    placeholderText: qsTranslate("MainWindow", "输入封装库描述")
+                    font.pixelSize: AppStyle.fontSizes.sm
                     color: AppStyle.colors.textPrimary
                     placeholderTextColor: AppStyle.colors.textSecondary
                     background: Rectangle {
                         color: AppStyle.colors.surface
-                        border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: footprintDescInput.focus ? 2 : 1
-                        radius: AppStyle.radius.sm
-                    }
-                }
-            }
-
-            // 封装库关键词
-            ColumnLayout {
-                Layout.fillWidth: true
-                spacing: AppStyle.spacing.xs
-                Text {
-                    text: qsTranslate("MainWindow", "关键词")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textSecondary
-                }
-                TextField {
-                    id: footprintKeywordsInput
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 32
-                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
-                    onTextChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
-                        }
-                    }
-                    placeholderText: qsTranslate("MainWindow", "关键词")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textPrimary
-                    placeholderTextColor: AppStyle.colors.textSecondary
-                    background: Rectangle {
-                        color: AppStyle.colors.surface
-                        border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: footprintKeywordsInput.focus ? 2 : 1
-                        radius: AppStyle.radius.sm
+                        border.color: footprintLibraryDescriptionInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: footprintLibraryDescriptionInput.focus ? 2 : 1
+                        radius: AppStyle.radius.md
                     }
                 }
             }

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -511,7 +511,7 @@ Card {
                 }
                 font.pixelSize: AppStyle.fontSizes.sm
                 ToolTip.visible: hovered
-                ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
+                ToolTip.text: qsTranslate("MainWindow", "保留已经存在的元器件数据，并追加新的元器件")
                 indicator: Rectangle {
                     implicitWidth: AppStyle.sizes.radioButton
                     implicitHeight: AppStyle.sizes.radioButton
@@ -558,7 +558,7 @@ Card {
                 }
                 font.pixelSize: AppStyle.fontSizes.sm
                 ToolTip.visible: hovered
-                ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                ToolTip.text: qsTranslate("MainWindow", "覆盖已经存在的元器件数据，并追加新的元器件")
                 indicator: Rectangle {
                     implicitWidth: AppStyle.sizes.radioButton
                     implicitHeight: AppStyle.sizes.radioButton

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -117,7 +117,6 @@ Card {
             columns: 2
             columnSpacing: AppStyle.spacing.xl
             rowSpacing: AppStyle.spacing.md
-
             // 符号库描述：写入 sym-lib-table，不是单个符号描述
             ColumnLayout {
                 Layout.fillWidth: true

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -5,139 +5,258 @@ import EasyKiconverter_Cpp_Version.src.ui.qml.styles 1.0
 
 Card {
     id: exportSettingsCard
-    // 外部依赖
     property var exportSettingsController
-    // 信号：请求打开输出目录对话框
     signal openOutputFolderDialog
     title: qsTranslate("MainWindow", "导出设置")
-    GridLayout {
+
+    ScrollView {
+        id: scrollView
         width: parent.width
-        columns: 2
-        columnSpacing: ResponsiveHelper.spacing.xl
-        rowSpacing: ResponsiveHelper.spacing.md
-        // 输出路径
+        height: parent.height
+        clip: true
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        ScrollBar.vertical.policy: ScrollBar.AsNeeded
+
         ColumnLayout {
-            Layout.fillWidth: true
-            spacing: ResponsiveHelper.spacing.sm
-            Text {
-                text: qsTranslate("MainWindow", "输出路径")
-                font.pixelSize: ResponsiveHelper.fontSizes.sm
-                font.bold: true
-                color: AppStyle.colors.textPrimary
-                horizontalAlignment: Text.AlignHCenter
-            }
-            RowLayout {
+            id: rootLayout
+            width: scrollView.availableWidth > 0 ? scrollView.availableWidth : parent.width
+            spacing: AppStyle.spacing.md
+
+            // ==================== SectionHeader 组件 ====================
+            component SectionHeader: RowLayout {
                 Layout.fillWidth: true
-                spacing: ResponsiveHelper.spacing.md
-                TextField {
-                    id: outputPathInput
-                    Layout.fillWidth: true
-                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
-                    onTextChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setOutputPath(text);
-                        }
-                    }
-                    placeholderText: qsTranslate("MainWindow", "选择输出目录")
-                    font.pixelSize: ResponsiveHelper.fontSizes.sm
-                    color: AppStyle.colors.textPrimary
-                    placeholderTextColor: AppStyle.colors.textSecondary
-                    background: Rectangle {
-                        color: AppStyle.colors.surface
-                        border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: outputPathInput.focus ? 2 : 1
-                        radius: AppStyle.radius.md
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: AppStyle.durations.fast
-                            }
-                        }
-                        Behavior on border.width {
-                            NumberAnimation {
-                                duration: AppStyle.durations.fast
-                            }
-                        }
-                    }
-                }
-                ModernButton {
-                    text: qsTranslate("MainWindow", "浏览")
-                    iconName: "folder"
+                spacing: AppStyle.spacing.sm
+                property string sectionTitle: ""
+                Text {
+                    text: sectionTitle
                     font.pixelSize: AppStyle.fontSizes.sm
-                    backgroundColor: AppStyle.colors.textSecondary
-                    hoverColor: AppStyle.colors.textPrimary
-                    pressedColor: AppStyle.colors.textPrimary
-                    onClicked: {
-                        exportSettingsCard.openOutputFolderDialog();
-                    }
+                    font.bold: true
+                    color: AppStyle.colors.textSecondary
+                }
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 1
+                    color: AppStyle.colors.border
+                    opacity: 0.5
                 }
             }
-        }
-        // 库名称
-        ColumnLayout {
-            Layout.fillWidth: true
-            spacing: ResponsiveHelper.spacing.sm
-            Text {
-                text: qsTranslate("MainWindow", "库名称")
-                font.pixelSize: ResponsiveHelper.fontSizes.sm
-                font.bold: true
-                color: AppStyle.colors.textPrimary
-                horizontalAlignment: Text.AlignHCenter
+
+            // ==================== 基础配置区块 ====================
+            SectionHeader {
+                id: basicConfigHeader
+                sectionTitle: qsTranslate("MainWindow", "基础配置")
             }
-            TextField {
-                id: libNameInput
+
+            GridLayout {
                 Layout.fillWidth: true
-                text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
-                onTextChanged: {
-                    if (exportSettingsCard.exportSettingsController) {
-                        exportSettingsCard.exportSettingsController.setLibName(text);
+                columns: 2
+                columnSpacing: AppStyle.spacing.xl
+                rowSpacing: AppStyle.spacing.md
+
+                // 输出路径
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "输出路径")
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        font.bold: true
+                        color: AppStyle.colors.textPrimary
+                        horizontalAlignment: Text.AlignHCenter
                     }
-                }
-                placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
-                font.pixelSize: ResponsiveHelper.fontSizes.sm
-                color: AppStyle.colors.textPrimary
-                placeholderTextColor: AppStyle.colors.textSecondary
-                background: Rectangle {
-                    color: AppStyle.colors.surface
-                    border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                    border.width: libNameInput.focus ? 2 : 1
-                    radius: AppStyle.radius.md
-                    Behavior on border.color {
-                        ColorAnimation {
-                            duration: AppStyle.durations.fast
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: AppStyle.spacing.md
+                        TextField {
+                            id: outputPathInput
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 36
+                            text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
+                            onTextChanged: {
+                                if (exportSettingsCard.exportSettingsController) {
+                                    exportSettingsCard.exportSettingsController.setOutputPath(text);
+                                }
+                            }
+                            placeholderText: qsTranslate("MainWindow", "选择输出目录")
+                            font.pixelSize: AppStyle.fontSizes.sm
+                            color: AppStyle.colors.textPrimary
+                            placeholderTextColor: AppStyle.colors.textSecondary
+                            background: Rectangle {
+                                color: AppStyle.colors.surface
+                                border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                                border.width: outputPathInput.focus ? 2 : 1
+                                radius: AppStyle.radius.md
+                            }
+                        }
+                        ModernButton {
+                            text: qsTranslate("MainWindow", "浏览")
+                            iconName: "folder"
+                            font.pixelSize: AppStyle.fontSizes.sm
+                            backgroundColor: AppStyle.colors.textSecondary
+                            hoverColor: AppStyle.colors.textPrimary
+                            pressedColor: AppStyle.colors.textPrimary
+                            onClicked: exportSettingsCard.openOutputFolderDialog()
                         }
                     }
-                    Behavior on border.width {
-                        NumberAnimation {
-                            duration: AppStyle.durations.fast
+                }
+
+                // 库名称
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "库名称")
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        font.bold: true
+                        color: AppStyle.colors.textPrimary
+                        horizontalAlignment: Text.AlignHCenter
+                    }
+                    TextField {
+                        id: libNameInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 36
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setLibName(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: libNameInput.focus ? 2 : 1
+                            radius: AppStyle.radius.md
                         }
                     }
                 }
             }
-        }
-    }
 
-    // 分隔
-    Item {
-        Layout.preferredHeight: 10
-        Layout.fillWidth: true
-    }
+            // ==================== 库元数据区块 ====================
+            SectionHeader {
+                id: metadataHeader
+                sectionTitle: qsTranslate("MainWindow", "库元数据")
+            }
 
-    // 原导出选项内容
-    Item {
-        Layout.fillWidth: true
-        Layout.columnSpan: 10  // 跨越10列
-        Layout.preferredHeight: exportOptionsLayout.implicitHeight
-        RowLayout {
-            id: exportOptionsLayout
-            anchors.fill: parent
-            spacing: 1
-            // 符号库选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+            GridLayout {
+                Layout.fillWidth: true
+                columns: 3
+                columnSpacing: AppStyle.spacing.md
+                rowSpacing: AppStyle.spacing.sm
+
+                // 符号库描述
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "符号库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textSecondary
+                    }
+                    TextField {
+                        id: symbolDescInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 32
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "符号库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: symbolDescInput.focus ? 2 : 1
+                            radius: AppStyle.radius.sm
+                        }
+                    }
+                }
+
+                // 封装库描述
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "封装库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textSecondary
+                    }
+                    TextField {
+                        id: footprintDescInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 32
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "封装库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: footprintDescInput.focus ? 2 : 1
+                            radius: AppStyle.radius.sm
+                        }
+                    }
+                }
+
+                // 封装库关键词
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "关键词")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textSecondary
+                    }
+                    TextField {
+                        id: footprintKeywordsInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 32
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "关键词")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: footprintKeywordsInput.focus ? 2 : 1
+                            radius: AppStyle.radius.sm
+                        }
+                    }
+                }
+            }
+
+            // ==================== 导出选项区块 ====================
+            SectionHeader {
+                id: exportOptionsHeader
+                sectionTitle: qsTranslate("MainWindow", "导出选项")
+            }
+
+            Flow {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.lg
+
+                // 符号库选项
                 CheckBox {
                     id: symbolCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "符号库")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportSymbol : false
                     onCheckedChanged: {
@@ -145,10 +264,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportSymbol(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出符号库文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -158,17 +276,6 @@ Card {
                         color: symbolCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: symbolCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -177,23 +284,18 @@ Card {
                             visible: symbolCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: symbolCheckbox.text
+                        font: symbolCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: symbolCheckbox.indicator.width + symbolCheckbox.spacing
                     }
                 }
-            }
-            // 封装库选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+
+                // 封装库选项
                 CheckBox {
                     id: footprintCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "封装库")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportFootprint : false
                     onCheckedChanged: {
@@ -201,10 +303,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportFootprint(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出封装库文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -214,17 +315,6 @@ Card {
                         color: footprintCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: footprintCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -233,159 +323,128 @@ Card {
                             visible: footprintCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: footprintCheckbox.text
+                        font: footprintCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: footprintCheckbox.indicator.width + footprintCheckbox.spacing
                     }
                 }
-            }
-            // 3D模型选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
-                CheckBox {
-                    id: model3dCheckbox
-                    Layout.fillWidth: true
-                    text: qsTranslate("MainWindow", "3D模型")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportModel3D(checked);
-                        }
-                    }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
-                    ToolTip.delay: 500
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: model3dCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
 
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: model3dCheckbox.checked
-                        }
-                    }
-
-                    contentItem: Text {
-                        text: parent.text
-                        font: parent.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
-                    }
-                }
-                // 3D模型格式按钮组 - 仅在3D模型启用时显示，独立切换
-                // 当两个格式都取消勾选时，自动取消3D模型主复选框
+                // 3D模型选项
                 RowLayout {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignHCenter
-                    spacing: ResponsiveHelper.spacing.xs
-                    visible: model3dCheckbox.checked
-                    // WRL 按钮 - 点击切换
-                    Rectangle {
-                        Layout.preferredWidth: 46
-                        Layout.preferredHeight: 26
-                        radius: AppStyle.radius.xs
-                        property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
-                        color: wrlActive ? AppStyle.colors.primary : "transparent"
-                        border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        MouseArea {
-                            id: wrlBtn
-                            anchors.fill: parent
-                            onClicked: {
-                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                if ((current & 1) !== 0) {
-                                    // WRL已选中，取消选中WRL
-                                    var newFormat = current & ~1;
-                                    if (newFormat === 0) {
-                                        // 两个都取消了，取消主复选框
-                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
-                                    } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
-                                    }
-                                } else {
-                                    // WRL未选中，勾选WRL
-                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
-                                }
+                    spacing: AppStyle.spacing.sm
+                    CheckBox {
+                        id: model3dCheckbox
+                        text: qsTranslate("MainWindow", "3D模型")
+                        checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
+                        onCheckedChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setExportModel3D(checked);
                             }
                         }
-                        Text {
-                            anchors.centerIn: parent
-                            text: "WRL"
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        ToolTip.visible: hovered
+                        ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
+                        indicator: Rectangle {
+                            implicitWidth: AppStyle.sizes.checkbox
+                            implicitHeight: AppStyle.sizes.checkbox
+                            x: model3dCheckbox.leftPadding
+                            y: parent.height / 2 - height / 2
+                            radius: AppStyle.radius.xs
+                            color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                            border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                            border.width: AppStyle.borderWidths.normal
+                            Text {
+                                anchors.centerIn: parent
+                                text: "✓"
+                                font.pixelSize: AppStyle.fontSizes.sm
+                                color: AppStyle.colors.textOnPrimary
+                                visible: model3dCheckbox.checked
+                            }
+                        }
+                        contentItem: Text {
+                            text: model3dCheckbox.text
+                            font: model3dCheckbox.font
+                            color: AppStyle.colors.textPrimary
+                            verticalAlignment: Text.AlignVCenter
+                            leftPadding: model3dCheckbox.indicator.width + model3dCheckbox.spacing
                         }
                     }
-                    // STEP 按钮 - 点击切换
-                    Rectangle {
-                        Layout.preferredWidth: 50
-                        Layout.preferredHeight: 26
-                        radius: AppStyle.radius.xs
-                        property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
-                        color: stepActive ? AppStyle.colors.primary : "transparent"
-                        border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        MouseArea {
-                            id: stepBtn
-                            anchors.fill: parent
-                            onClicked: {
-                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                if ((current & 2) !== 0) {
-                                    // STEP已选中，取消选中STEP
-                                    var newFormat = current & ~2;
-                                    if (newFormat === 0) {
-                                        // 两个都取消了，取消主复选框
-                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
+
+                    // 3D模型格式按钮组
+                    RowLayout {
+                        visible: model3dCheckbox.checked
+                        spacing: AppStyle.spacing.xs
+                        Rectangle {
+                            Layout.preferredWidth: 46
+                            Layout.preferredHeight: 26
+                            radius: AppStyle.radius.xs
+                            property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
+                            color: wrlActive ? AppStyle.colors.primary : "transparent"
+                            border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                            border.width: AppStyle.borderWidths.normal
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                    if ((current & 1) !== 0) {
+                                        var newFormat = current & ~1;
+                                        if (newFormat === 0) {
+                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                        } else {
+                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                        }
                                     } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
                                     }
-                                } else {
-                                    // STEP未选中，勾选STEP
-                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
                                 }
                             }
+                            Text {
+                                anchors.centerIn: parent
+                                text: "WRL"
+                                font.pixelSize: AppStyle.fontSizes.xs
+                                color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
+                            }
                         }
-                        Text {
-                            anchors.centerIn: parent
-                            text: "STEP"
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        Rectangle {
+                            Layout.preferredWidth: 50
+                            Layout.preferredHeight: 26
+                            radius: AppStyle.radius.xs
+                            property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
+                            color: stepActive ? AppStyle.colors.primary : "transparent"
+                            border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                            border.width: AppStyle.borderWidths.normal
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                    if ((current & 2) !== 0) {
+                                        var newFormat = current & ~2;
+                                        if (newFormat === 0) {
+                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                        } else {
+                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                        }
+                                    } else {
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
+                                    }
+                                }
+                            }
+                            Text {
+                                anchors.centerIn: parent
+                                text: "STEP"
+                                font.pixelSize: AppStyle.fontSizes.xs
+                                color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
+                            }
                         }
                     }
                 }
-            }
-            // 预览图选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+
+                // 预览图选项
                 CheckBox {
                     id: previewImagesCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "预览图")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportPreviewImages : false
                     onCheckedChanged: {
@@ -393,10 +452,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportPreviewImages(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出预览图文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -406,17 +464,6 @@ Card {
                         color: previewImagesCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: previewImagesCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -425,23 +472,18 @@ Card {
                             visible: previewImagesCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: previewImagesCheckbox.text
+                        font: previewImagesCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: previewImagesCheckbox.indicator.width + previewImagesCheckbox.spacing
                     }
                 }
-            }
-            // 手册选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+
+                // 手册选项
                 CheckBox {
                     id: datasheetCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "手册")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportDatasheet : false
                     onCheckedChanged: {
@@ -449,10 +491,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportDatasheet(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出数据手册文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -462,17 +503,6 @@ Card {
                         color: datasheetCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: datasheetCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -481,130 +511,118 @@ Card {
                             visible: datasheetCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: datasheetCheckbox.text
+                        font: datasheetCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: datasheetCheckbox.indicator.width + datasheetCheckbox.spacing
                     }
                 }
             }
-            // 导出模式选项
-            ColumnLayout {
-                Layout.columnSpan: 2  // 跨越两列，分配更多空间
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
-                Text {
-                    Layout.fillWidth: true
-                    text: qsTranslate("MainWindow", "导出模式")
-                    font.pixelSize: ResponsiveHelper.fontSizes.sm
-                    font.bold: true
-                    color: AppStyle.colors.textPrimary
-                    horizontalAlignment: Text.AlignLeft
+
+            // ==================== 导出模式区块 ====================
+            SectionHeader {
+                id: exportModeHeader
+                sectionTitle: qsTranslate("MainWindow", "导出模式")
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xl
+
+                // 追加模式
+                RadioButton {
+                    id: appendModeRadio
+                    text: qsTranslate("MainWindow", "追加模式")
+                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
+                    onCheckedChanged: {
+                        if (checked && exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setExportMode(0);
+                        }
+                    }
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
+                    indicator: Rectangle {
+                        implicitWidth: AppStyle.sizes.radioButton
+                        implicitHeight: AppStyle.sizes.radioButton
+                        x: appendModeRadio.leftPadding
+                        y: parent.height / 2 - height / 2
+                        radius: width / 2
+                        color: "transparent"
+                        border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: AppStyle.sizes.radioButtonIndicator
+                            height: AppStyle.sizes.radioButtonIndicator
+                            radius: width / 2
+                            color: AppStyle.colors.primary
+                            visible: appendModeRadio.checked
+                        }
+                    }
+                    contentItem: Text {
+                        text: appendModeRadio.text
+                        font: appendModeRadio.font
+                        color: AppStyle.colors.textPrimary
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: appendModeRadio.indicator.width + appendModeRadio.spacing
+                    }
                 }
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: ResponsiveHelper.spacing.xs
-                    // 追加模式
-                    RowLayout {
-                        spacing: ResponsiveHelper.spacing.sm
-                        RadioButton {
-                            id: appendModeRadio
-                            text: qsTranslate("MainWindow", "追加")
-                            checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
-                            onCheckedChanged: {
-                                if (checked && exportSettingsCard.exportSettingsController) {
-                                    exportSettingsCard.exportSettingsController.setExportMode(0);
-                                }
-                            }
-                            font.pixelSize: ResponsiveHelper.fontSizes.sm
-                            ToolTip.visible: hovered
-                            ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
-                            ToolTip.delay: 500
-                            indicator: Rectangle {
-                                implicitWidth: AppStyle.sizes.radioButton
-                                implicitHeight: AppStyle.sizes.radioButton
-                                x: appendModeRadio.leftPadding
-                                y: parent.height / 2 - height / 2
-                                radius: width / 2  // 声明式圆角
-                                color: "transparent"
-                                border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                                border.width: AppStyle.borderWidths.normal
-                                Rectangle {
-                                    anchors.centerIn: parent
-                                    width: AppStyle.sizes.radioButtonIndicator
-                                    height: AppStyle.sizes.radioButtonIndicator
-                                    radius: width / 2  // 声明式圆角
-                                    color: AppStyle.colors.primary
-                                    visible: appendModeRadio.checked
-                                }
-                            }
 
-                            contentItem: Text {
-                                text: parent.text
-                                font: parent.font
-                                color: AppStyle.colors.textPrimary
-                                verticalAlignment: Text.AlignVCenter
-                                leftPadding: parent.indicator.width + parent.spacing
-                            }
-                        }
-                        Text {
-                            text: qsTranslate("MainWindow", "保留已存在的元器件")
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: AppStyle.colors.textSecondary
+                Text {
+                    text: qsTranslate("MainWindow", "保留已存在的元器件")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    color: AppStyle.colors.textSecondary
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                // 更新模式
+                RadioButton {
+                    id: updateModeRadio
+                    text: qsTranslate("MainWindow", "更新模式")
+                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
+                    onCheckedChanged: {
+                        if (checked && exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setExportMode(1);
                         }
                     }
-                    // 更新模式
-                    RowLayout {
-                        spacing: ResponsiveHelper.spacing.sm
-                        RadioButton {
-                            id: updateModeRadio
-                            text: qsTranslate("MainWindow", "更新")
-                            checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
-                            onCheckedChanged: {
-                                if (checked && exportSettingsCard.exportSettingsController) {
-                                    exportSettingsCard.exportSettingsController.setExportMode(1);
-                                }
-                            }
-                            font.pixelSize: ResponsiveHelper.fontSizes.sm
-                            ToolTip.visible: hovered
-                            ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                            ToolTip.delay: 500
-                            indicator: Rectangle {
-                                implicitWidth: AppStyle.sizes.radioButton
-                                implicitHeight: AppStyle.sizes.radioButton
-                                x: updateModeRadio.leftPadding
-                                y: parent.height / 2 - height / 2
-                                radius: width / 2  // 声明式圆角
-                                color: "transparent"
-                                border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                                border.width: AppStyle.borderWidths.normal
-                                Rectangle {
-                                    anchors.centerIn: parent
-                                    width: AppStyle.sizes.radioButtonIndicator
-                                    height: AppStyle.sizes.radioButtonIndicator
-                                    radius: width / 2  // 声明式圆角
-                                    color: AppStyle.colors.primary
-                                    visible: updateModeRadio.checked
-                                }
-                            }
-
-                            contentItem: Text {
-                                text: parent.text
-                                font: parent.font
-                                color: AppStyle.colors.textPrimary
-                                verticalAlignment: Text.AlignVCenter
-                                leftPadding: parent.indicator.width + parent.spacing
-                            }
-                        }
-                        Text {
-                            text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: AppStyle.colors.textSecondary
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                    indicator: Rectangle {
+                        implicitWidth: AppStyle.sizes.radioButton
+                        implicitHeight: AppStyle.sizes.radioButton
+                        x: updateModeRadio.leftPadding
+                        y: parent.height / 2 - height / 2
+                        radius: width / 2
+                        color: "transparent"
+                        border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: AppStyle.sizes.radioButtonIndicator
+                            height: AppStyle.sizes.radioButtonIndicator
+                            radius: width / 2
+                            color: AppStyle.colors.primary
+                            visible: updateModeRadio.checked
                         }
                     }
+                    contentItem: Text {
+                        text: updateModeRadio.text
+                        font: updateModeRadio.font
+                        color: AppStyle.colors.textPrimary
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: updateModeRadio.indicator.width + updateModeRadio.spacing
+                    }
+                }
+
+                Text {
+                    text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    color: AppStyle.colors.textSecondary
+                    verticalAlignment: Text.AlignVCenter
                 }
             }
         }

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -8,38 +8,29 @@ Card {
     property var exportSettingsController
     signal openOutputFolderDialog
     title: qsTranslate("MainWindow", "导出设置")
-
-    ScrollView {
-        id: scrollView
+    ColumnLayout {
+        id: rootLayout
         width: parent.width
-        height: parent.height
-        clip: true
-        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-        ScrollBar.vertical.policy: ScrollBar.AsNeeded
-
-        ColumnLayout {
-            id: rootLayout
-            width: scrollView.availableWidth > 0 ? scrollView.availableWidth : parent.width
-            spacing: AppStyle.spacing.md
-
-            // ==================== SectionHeader 组件 ====================
-            component SectionHeader: RowLayout {
-                Layout.fillWidth: true
-                spacing: AppStyle.spacing.sm
-                property string sectionTitle: ""
-                Text {
-                    text: sectionTitle
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    font.bold: true
-                    color: AppStyle.colors.textSecondary
-                }
-                Rectangle {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 1
-                    color: AppStyle.colors.border
-                    opacity: 0.5
-                }
+        spacing: AppStyle.spacing.lg
+        anchors.margins: AppStyle.spacing.md
+        // ==================== SectionHeader 组件 ====================
+        component SectionHeader: RowLayout {
+            Layout.fillWidth: true
+            spacing: AppStyle.spacing.sm
+            property string sectionTitle: ""
+            Text {
+                text: sectionTitle
+                font.pixelSize: AppStyle.fontSizes.sm
+                font.bold: true
+                color: AppStyle.colors.textSecondary
             }
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 1
+                color: AppStyle.colors.border
+                opacity: 0.5
+            }
+        }
 
             // ==================== 基础配置区块 ====================
             SectionHeader {
@@ -52,7 +43,6 @@ Card {
                 columns: 2
                 columnSpacing: AppStyle.spacing.xl
                 rowSpacing: AppStyle.spacing.md
-
                 // 输出路径
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -81,7 +71,7 @@ Card {
                             font.pixelSize: AppStyle.fontSizes.sm
                             color: AppStyle.colors.textPrimary
                             placeholderTextColor: AppStyle.colors.textSecondary
-                            background: Rectangle {
+                                background: Rectangle {
                                 color: AppStyle.colors.surface
                                 border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
                                 border.width: outputPathInput.focus ? 2 : 1
@@ -146,7 +136,6 @@ Card {
                 columns: 3
                 columnSpacing: AppStyle.spacing.md
                 rowSpacing: AppStyle.spacing.sm
-
                 // 符号库描述
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -253,7 +242,6 @@ Card {
             Flow {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.lg
-
                 // 符号库选项
                 CheckBox {
                     id: symbolCheckbox
@@ -530,7 +518,6 @@ Card {
             RowLayout {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.xl
-
                 // 追加模式
                 RadioButton {
                     id: appendModeRadio
@@ -627,4 +614,3 @@ Card {
             }
         }
     }
-}

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -13,604 +13,603 @@ Card {
         width: parent.width
         spacing: AppStyle.spacing.lg
         anchors.margins: AppStyle.spacing.md
-        // ==================== SectionHeader 组件 ====================
-        component SectionHeader: RowLayout {
-            Layout.fillWidth: true
-            spacing: AppStyle.spacing.sm
-            property string sectionTitle: ""
-            Text {
-                text: sectionTitle
-                font.pixelSize: AppStyle.fontSizes.sm
-                font.bold: true
-                color: AppStyle.colors.textSecondary
-            }
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 1
-                color: AppStyle.colors.border
-                opacity: 0.5
-            }
+        // ==================== 基础配置区块 ====================
+        SectionHeader {
+            id: basicConfigHeader
+            sectionTitle: qsTranslate("MainWindow", "基础配置")
         }
 
-            // ==================== 基础配置区块 ====================
-            SectionHeader {
-                id: basicConfigHeader
-                sectionTitle: qsTranslate("MainWindow", "基础配置")
-            }
-
-            GridLayout {
+        GridLayout {
+            Layout.fillWidth: true
+            columns: 2
+            columnSpacing: AppStyle.spacing.xl
+            rowSpacing: AppStyle.spacing.md
+            // 输出路径
+            ColumnLayout {
                 Layout.fillWidth: true
-                columns: 2
-                columnSpacing: AppStyle.spacing.xl
-                rowSpacing: AppStyle.spacing.md
-                // 输出路径
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "输出路径")
-                        font.pixelSize: AppStyle.fontSizes.sm
-                        font.bold: true
-                        color: AppStyle.colors.textPrimary
-                        horizontalAlignment: Text.AlignHCenter
-                    }
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: AppStyle.spacing.md
-                        TextField {
-                            id: outputPathInput
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: 36
-                            text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
-                            onTextChanged: {
-                                if (exportSettingsCard.exportSettingsController) {
-                                    exportSettingsCard.exportSettingsController.setOutputPath(text);
-                                }
-                            }
-                            placeholderText: qsTranslate("MainWindow", "选择输出目录")
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textPrimary
-                            placeholderTextColor: AppStyle.colors.textSecondary
-                                background: Rectangle {
-                                color: AppStyle.colors.surface
-                                border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                                border.width: outputPathInput.focus ? 2 : 1
-                                radius: AppStyle.radius.md
-                            }
-                        }
-                        ModernButton {
-                            text: qsTranslate("MainWindow", "浏览")
-                            iconName: "folder"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            backgroundColor: AppStyle.colors.textSecondary
-                            hoverColor: AppStyle.colors.textPrimary
-                            pressedColor: AppStyle.colors.textPrimary
-                            onClicked: exportSettingsCard.openOutputFolderDialog()
-                        }
-                    }
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "输出路径")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
+                    horizontalAlignment: Text.AlignHCenter
                 }
-
-                // 库名称
-                ColumnLayout {
+                RowLayout {
                     Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "库名称")
-                        font.pixelSize: AppStyle.fontSizes.sm
-                        font.bold: true
-                        color: AppStyle.colors.textPrimary
-                        horizontalAlignment: Text.AlignHCenter
-                    }
+                    spacing: AppStyle.spacing.md
                     TextField {
-                        id: libNameInput
+                        id: outputPathInput
                         Layout.fillWidth: true
                         Layout.preferredHeight: 36
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
                         onTextChanged: {
                             if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setLibName(text);
+                                exportSettingsCard.exportSettingsController.setOutputPath(text);
                             }
                         }
-                        placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
+                        placeholderText: qsTranslate("MainWindow", "选择输出目录")
                         font.pixelSize: AppStyle.fontSizes.sm
                         color: AppStyle.colors.textPrimary
                         placeholderTextColor: AppStyle.colors.textSecondary
                         background: Rectangle {
                             color: AppStyle.colors.surface
-                            border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: libNameInput.focus ? 2 : 1
+                            border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: outputPathInput.focus ? 2 : 1
                             radius: AppStyle.radius.md
                         }
                     }
-                }
-            }
-
-            // ==================== 库元数据区块 ====================
-            SectionHeader {
-                id: metadataHeader
-                sectionTitle: qsTranslate("MainWindow", "库元数据")
-            }
-
-            GridLayout {
-                Layout.fillWidth: true
-                columns: 3
-                columnSpacing: AppStyle.spacing.md
-                rowSpacing: AppStyle.spacing.sm
-                // 符号库描述
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "符号库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textSecondary
-                    }
-                    TextField {
-                        id: symbolDescInput
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 32
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
-                        onTextChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
-                            }
-                        }
-                        placeholderText: qsTranslate("MainWindow", "符号库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textPrimary
-                        placeholderTextColor: AppStyle.colors.textSecondary
-                        background: Rectangle {
-                            color: AppStyle.colors.surface
-                            border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: symbolDescInput.focus ? 2 : 1
-                            radius: AppStyle.radius.sm
-                        }
-                    }
-                }
-
-                // 封装库描述
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "封装库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textSecondary
-                    }
-                    TextField {
-                        id: footprintDescInput
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 32
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
-                        onTextChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
-                            }
-                        }
-                        placeholderText: qsTranslate("MainWindow", "封装库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textPrimary
-                        placeholderTextColor: AppStyle.colors.textSecondary
-                        background: Rectangle {
-                            color: AppStyle.colors.surface
-                            border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: footprintDescInput.focus ? 2 : 1
-                            radius: AppStyle.radius.sm
-                        }
-                    }
-                }
-
-                // 封装库关键词
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "关键词")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textSecondary
-                    }
-                    TextField {
-                        id: footprintKeywordsInput
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 32
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
-                        onTextChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
-                            }
-                        }
-                        placeholderText: qsTranslate("MainWindow", "关键词")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textPrimary
-                        placeholderTextColor: AppStyle.colors.textSecondary
-                        background: Rectangle {
-                            color: AppStyle.colors.surface
-                            border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: footprintKeywordsInput.focus ? 2 : 1
-                            radius: AppStyle.radius.sm
-                        }
-                    }
-                }
-            }
-
-            // ==================== 导出选项区块 ====================
-            SectionHeader {
-                id: exportOptionsHeader
-                sectionTitle: qsTranslate("MainWindow", "导出选项")
-            }
-
-            Flow {
-                Layout.fillWidth: true
-                spacing: AppStyle.spacing.lg
-                // 符号库选项
-                CheckBox {
-                    id: symbolCheckbox
-                    text: qsTranslate("MainWindow", "符号库")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportSymbol : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportSymbol(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出符号库文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: symbolCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: symbolCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: symbolCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: symbolCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: symbolCheckbox.text
-                        font: symbolCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: symbolCheckbox.indicator.width + symbolCheckbox.spacing
-                    }
-                }
-
-                // 封装库选项
-                CheckBox {
-                    id: footprintCheckbox
-                    text: qsTranslate("MainWindow", "封装库")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportFootprint : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportFootprint(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出封装库文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: footprintCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: footprintCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: footprintCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: footprintCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: footprintCheckbox.text
-                        font: footprintCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: footprintCheckbox.indicator.width + footprintCheckbox.spacing
-                    }
-                }
-
-                // 3D模型选项
-                RowLayout {
-                    spacing: AppStyle.spacing.sm
-                    CheckBox {
-                        id: model3dCheckbox
-                        text: qsTranslate("MainWindow", "3D模型")
-                        checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
-                        onCheckedChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setExportModel3D(checked);
-                            }
-                        }
+                    ModernButton {
+                        text: qsTranslate("MainWindow", "浏览")
+                        iconName: "folder"
                         font.pixelSize: AppStyle.fontSizes.sm
-                        ToolTip.visible: hovered
-                        ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
-                        indicator: Rectangle {
-                            implicitWidth: AppStyle.sizes.checkbox
-                            implicitHeight: AppStyle.sizes.checkbox
-                            x: model3dCheckbox.leftPadding
-                            y: parent.height / 2 - height / 2
-                            radius: AppStyle.radius.xs
-                            color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                            border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                            border.width: AppStyle.borderWidths.normal
-                            Text {
-                                anchors.centerIn: parent
-                                text: "✓"
-                                font.pixelSize: AppStyle.fontSizes.sm
-                                color: AppStyle.colors.textOnPrimary
-                                visible: model3dCheckbox.checked
-                            }
-                        }
-                        contentItem: Text {
-                            text: model3dCheckbox.text
-                            font: model3dCheckbox.font
-                            color: AppStyle.colors.textPrimary
-                            verticalAlignment: Text.AlignVCenter
-                            leftPadding: model3dCheckbox.indicator.width + model3dCheckbox.spacing
-                        }
-                    }
-
-                    // 3D模型格式按钮组
-                    RowLayout {
-                        visible: model3dCheckbox.checked
-                        spacing: AppStyle.spacing.xs
-                        Rectangle {
-                            Layout.preferredWidth: 46
-                            Layout.preferredHeight: 26
-                            radius: AppStyle.radius.xs
-                            property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
-                            color: wrlActive ? AppStyle.colors.primary : "transparent"
-                            border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                            border.width: AppStyle.borderWidths.normal
-                            MouseArea {
-                                anchors.fill: parent
-                                onClicked: {
-                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                    if ((current & 1) !== 0) {
-                                        var newFormat = current & ~1;
-                                        if (newFormat === 0) {
-                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
-                                        } else {
-                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
-                                        }
-                                    } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
-                                    }
-                                }
-                            }
-                            Text {
-                                anchors.centerIn: parent
-                                text: "WRL"
-                                font.pixelSize: AppStyle.fontSizes.xs
-                                color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
-                            }
-                        }
-                        Rectangle {
-                            Layout.preferredWidth: 50
-                            Layout.preferredHeight: 26
-                            radius: AppStyle.radius.xs
-                            property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
-                            color: stepActive ? AppStyle.colors.primary : "transparent"
-                            border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                            border.width: AppStyle.borderWidths.normal
-                            MouseArea {
-                                anchors.fill: parent
-                                onClicked: {
-                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                    if ((current & 2) !== 0) {
-                                        var newFormat = current & ~2;
-                                        if (newFormat === 0) {
-                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
-                                        } else {
-                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
-                                        }
-                                    } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
-                                    }
-                                }
-                            }
-                            Text {
-                                anchors.centerIn: parent
-                                text: "STEP"
-                                font.pixelSize: AppStyle.fontSizes.xs
-                                color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
-                            }
-                        }
-                    }
-                }
-
-                // 预览图选项
-                CheckBox {
-                    id: previewImagesCheckbox
-                    text: qsTranslate("MainWindow", "预览图")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportPreviewImages : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportPreviewImages(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出预览图文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: previewImagesCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: previewImagesCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: previewImagesCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: previewImagesCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: previewImagesCheckbox.text
-                        font: previewImagesCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: previewImagesCheckbox.indicator.width + previewImagesCheckbox.spacing
-                    }
-                }
-
-                // 手册选项
-                CheckBox {
-                    id: datasheetCheckbox
-                    text: qsTranslate("MainWindow", "手册")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportDatasheet : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportDatasheet(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出数据手册文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: datasheetCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: datasheetCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: datasheetCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: datasheetCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: datasheetCheckbox.text
-                        font: datasheetCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: datasheetCheckbox.indicator.width + datasheetCheckbox.spacing
+                        backgroundColor: AppStyle.colors.textSecondary
+                        hoverColor: AppStyle.colors.textPrimary
+                        pressedColor: AppStyle.colors.textPrimary
+                        onClicked: exportSettingsCard.openOutputFolderDialog()
                     }
                 }
             }
 
-            // ==================== 导出模式区块 ====================
-            SectionHeader {
-                id: exportModeHeader
-                sectionTitle: qsTranslate("MainWindow", "导出模式")
-            }
-
-            RowLayout {
+            // 库名称
+            ColumnLayout {
                 Layout.fillWidth: true
-                spacing: AppStyle.spacing.xl
-                // 追加模式
-                RadioButton {
-                    id: appendModeRadio
-                    text: qsTranslate("MainWindow", "追加模式")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
-                    onCheckedChanged: {
-                        if (checked && exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportMode(0);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.radioButton
-                        implicitHeight: AppStyle.sizes.radioButton
-                        x: appendModeRadio.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: width / 2
-                        color: "transparent"
-                        border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Rectangle {
-                            anchors.centerIn: parent
-                            width: AppStyle.sizes.radioButtonIndicator
-                            height: AppStyle.sizes.radioButtonIndicator
-                            radius: width / 2
-                            color: AppStyle.colors.primary
-                            visible: appendModeRadio.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: appendModeRadio.text
-                        font: appendModeRadio.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: appendModeRadio.indicator.width + appendModeRadio.spacing
-                    }
-                }
-
+                spacing: AppStyle.spacing.xs
                 Text {
-                    text: qsTranslate("MainWindow", "保留已存在的元器件")
+                    text: qsTranslate("MainWindow", "库名称")
                     font.pixelSize: AppStyle.fontSizes.sm
-                    color: AppStyle.colors.textSecondary
-                    verticalAlignment: Text.AlignVCenter
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
+                    horizontalAlignment: Text.AlignHCenter
                 }
-
-                // 更新模式
-                RadioButton {
-                    id: updateModeRadio
-                    text: qsTranslate("MainWindow", "更新模式")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
-                    onCheckedChanged: {
-                        if (checked && exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportMode(1);
+                TextField {
+                    id: libNameInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setLibName(text);
                         }
                     }
+                    placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
                     font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.radioButton
-                        implicitHeight: AppStyle.sizes.radioButton
-                        x: updateModeRadio.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: width / 2
-                        color: "transparent"
-                        border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Rectangle {
-                            anchors.centerIn: parent
-                            width: AppStyle.sizes.radioButtonIndicator
-                            height: AppStyle.sizes.radioButtonIndicator
-                            radius: width / 2
-                            color: AppStyle.colors.primary
-                            visible: updateModeRadio.checked
-                        }
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: libNameInput.focus ? 2 : 1
+                        radius: AppStyle.radius.md
                     }
-                    contentItem: Text {
-                        text: updateModeRadio.text
-                        font: updateModeRadio.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: updateModeRadio.indicator.width + updateModeRadio.spacing
-                    }
-                }
-
-                Text {
-                    text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    color: AppStyle.colors.textSecondary
-                    verticalAlignment: Text.AlignVCenter
                 }
             }
         }
+
+        // ==================== 库元数据区块 ====================
+        SectionHeader {
+            id: metadataHeader
+            sectionTitle: qsTranslate("MainWindow", "库元数据")
+        }
+
+        GridLayout {
+            Layout.fillWidth: true
+            columns: 3
+            columnSpacing: AppStyle.spacing.md
+            rowSpacing: AppStyle.spacing.sm
+            // 符号库描述
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "符号库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textSecondary
+                }
+                TextField {
+                    id: symbolDescInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 32
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
+                        }
+                    }
+                    placeholderText: qsTranslate("MainWindow", "符号库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: symbolDescInput.focus ? 2 : 1
+                        radius: AppStyle.radius.sm
+                    }
+                }
+            }
+
+            // 封装库描述
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "封装库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textSecondary
+                }
+                TextField {
+                    id: footprintDescInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 32
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
+                        }
+                    }
+                    placeholderText: qsTranslate("MainWindow", "封装库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: footprintDescInput.focus ? 2 : 1
+                        radius: AppStyle.radius.sm
+                    }
+                }
+            }
+
+            // 封装库关键词
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "关键词")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textSecondary
+                }
+                TextField {
+                    id: footprintKeywordsInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 32
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
+                        }
+                    }
+                    placeholderText: qsTranslate("MainWindow", "关键词")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: footprintKeywordsInput.focus ? 2 : 1
+                        radius: AppStyle.radius.sm
+                    }
+                }
+            }
+        }
+
+        // ==================== 导出选项区块 ====================
+        SectionHeader {
+            id: exportOptionsHeader
+            sectionTitle: qsTranslate("MainWindow", "导出选项")
+        }
+
+        Flow {
+            Layout.fillWidth: true
+            spacing: AppStyle.spacing.lg
+            // 符号库选项
+            CheckBox {
+                id: symbolCheckbox
+                text: qsTranslate("MainWindow", "符号库")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportSymbol : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportSymbol(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出符号库文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: symbolCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: symbolCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: symbolCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: symbolCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: symbolCheckbox.text
+                    font: symbolCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: symbolCheckbox.indicator.width + symbolCheckbox.spacing
+                }
+            }
+
+            // 封装库选项
+            CheckBox {
+                id: footprintCheckbox
+                text: qsTranslate("MainWindow", "封装库")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportFootprint : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportFootprint(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出封装库文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: footprintCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: footprintCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: footprintCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: footprintCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: footprintCheckbox.text
+                    font: footprintCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: footprintCheckbox.indicator.width + footprintCheckbox.spacing
+                }
+            }
+
+            // 3D模型选项
+            RowLayout {
+                spacing: AppStyle.spacing.sm
+                CheckBox {
+                    id: model3dCheckbox
+                    text: qsTranslate("MainWindow", "3D模型")
+                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
+                    onCheckedChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setExportModel3D(checked);
+                        }
+                    }
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
+                    indicator: Rectangle {
+                        implicitWidth: AppStyle.sizes.checkbox
+                        implicitHeight: AppStyle.sizes.checkbox
+                        x: model3dCheckbox.leftPadding
+                        y: parent.height / 2 - height / 2
+                        radius: AppStyle.radius.xs
+                        color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                        border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        Text {
+                            anchors.centerIn: parent
+                            text: "✓"
+                            font.pixelSize: AppStyle.fontSizes.sm
+                            color: AppStyle.colors.textOnPrimary
+                            visible: model3dCheckbox.checked
+                        }
+                    }
+                    contentItem: Text {
+                        text: model3dCheckbox.text
+                        font: model3dCheckbox.font
+                        color: AppStyle.colors.textPrimary
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: model3dCheckbox.indicator.width + model3dCheckbox.spacing
+                    }
+                }
+
+                // 3D模型格式按钮组
+                RowLayout {
+                    visible: model3dCheckbox.checked
+                    spacing: AppStyle.spacing.xs
+                    Rectangle {
+                        Layout.preferredWidth: 46
+                        Layout.preferredHeight: 26
+                        radius: AppStyle.radius.xs
+                        property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
+                        color: wrlActive ? AppStyle.colors.primary : "transparent"
+                        border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                if ((current & 1) !== 0) {
+                                    var newFormat = current & ~1;
+                                    if (newFormat === 0) {
+                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                    } else {
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                    }
+                                } else {
+                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
+                                }
+                            }
+                        }
+                        Text {
+                            anchors.centerIn: parent
+                            text: "WRL"
+                            font.pixelSize: AppStyle.fontSizes.xs
+                            color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        }
+                    }
+                    Rectangle {
+                        Layout.preferredWidth: 50
+                        Layout.preferredHeight: 26
+                        radius: AppStyle.radius.xs
+                        property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
+                        color: stepActive ? AppStyle.colors.primary : "transparent"
+                        border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                if ((current & 2) !== 0) {
+                                    var newFormat = current & ~2;
+                                    if (newFormat === 0) {
+                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                    } else {
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                    }
+                                } else {
+                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
+                                }
+                            }
+                        }
+                        Text {
+                            anchors.centerIn: parent
+                            text: "STEP"
+                            font.pixelSize: AppStyle.fontSizes.xs
+                            color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        }
+                    }
+                }
+            }
+
+            // 预览图选项
+            CheckBox {
+                id: previewImagesCheckbox
+                text: qsTranslate("MainWindow", "预览图")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportPreviewImages : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportPreviewImages(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出预览图文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: previewImagesCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: previewImagesCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: previewImagesCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: previewImagesCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: previewImagesCheckbox.text
+                    font: previewImagesCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: previewImagesCheckbox.indicator.width + previewImagesCheckbox.spacing
+                }
+            }
+
+            // 手册选项
+            CheckBox {
+                id: datasheetCheckbox
+                text: qsTranslate("MainWindow", "手册")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportDatasheet : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportDatasheet(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出数据手册文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: datasheetCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: datasheetCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: datasheetCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: datasheetCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: datasheetCheckbox.text
+                    font: datasheetCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: datasheetCheckbox.indicator.width + datasheetCheckbox.spacing
+                }
+            }
+        }
+
+        // ==================== 导出模式区块 ====================
+        SectionHeader {
+            id: exportModeHeader
+            sectionTitle: qsTranslate("MainWindow", "导出模式")
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: AppStyle.spacing.xl
+            // 追加模式
+            RadioButton {
+                id: appendModeRadio
+                text: qsTranslate("MainWindow", "追加模式")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
+                onCheckedChanged: {
+                    if (checked && exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportMode(0);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.radioButton
+                    implicitHeight: AppStyle.sizes.radioButton
+                    x: appendModeRadio.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: width / 2
+                    color: "transparent"
+                    border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: AppStyle.sizes.radioButtonIndicator
+                        height: AppStyle.sizes.radioButtonIndicator
+                        radius: width / 2
+                        color: AppStyle.colors.primary
+                        visible: appendModeRadio.checked
+                    }
+                }
+                contentItem: Text {
+                    text: appendModeRadio.text
+                    font: appendModeRadio.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: appendModeRadio.indicator.width + appendModeRadio.spacing
+                }
+            }
+
+            Text {
+                text: qsTranslate("MainWindow", "保留已存在的元器件")
+                font.pixelSize: AppStyle.fontSizes.sm
+                color: AppStyle.colors.textSecondary
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            // 更新模式
+            RadioButton {
+                id: updateModeRadio
+                text: qsTranslate("MainWindow", "更新模式")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
+                onCheckedChanged: {
+                    if (checked && exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportMode(1);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.radioButton
+                    implicitHeight: AppStyle.sizes.radioButton
+                    x: updateModeRadio.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: width / 2
+                    color: "transparent"
+                    border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: AppStyle.sizes.radioButtonIndicator
+                        height: AppStyle.sizes.radioButtonIndicator
+                        radius: width / 2
+                        color: AppStyle.colors.primary
+                        visible: updateModeRadio.checked
+                    }
+                }
+                contentItem: Text {
+                    text: updateModeRadio.text
+                    font: updateModeRadio.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: updateModeRadio.indicator.width + updateModeRadio.spacing
+                }
+            }
+
+            Text {
+                text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                font.pixelSize: AppStyle.fontSizes.sm
+                color: AppStyle.colors.textSecondary
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
     }
+    // ==================== SectionHeader 组件 ====================
+    component SectionHeader: RowLayout {
+        Layout.fillWidth: true
+        spacing: AppStyle.spacing.sm
+        property string sectionTitle: ""
+        Text {
+            text: sectionTitle
+            font.pixelSize: AppStyle.fontSizes.sm
+            font.bold: true
+            color: AppStyle.colors.textSecondary
+        }
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+            color: AppStyle.colors.border
+            opacity: 0.5
+        }
+    }
+}

--- a/src/ui/qml/components/HeaderSection.qml
+++ b/src/ui/qml/components/HeaderSection.qml
@@ -93,14 +93,25 @@ ColumnLayout {
                 y: languageComboBox.topPadding + (languageComboBox.availableHeight - height) / 2
                 width: 12
                 height: 8
-
                 ShapePath {
                     strokeWidth: 0
                     fillColor: AppStyle.colors.textSecondary
-                    PathMove { x: 0; y: 0 }
-                    PathLine { x: indicatorShape.width / 2; y: indicatorShape.height }
-                    PathLine { x: indicatorShape.width; y: 0 }
-                    PathLine { x: 0; y: 0 }
+                    PathMove {
+                        x: 0
+                        y: 0
+                    }
+                    PathLine {
+                        x: indicatorShape.width / 2
+                        y: indicatorShape.height
+                    }
+                    PathLine {
+                        x: indicatorShape.width
+                        y: 0
+                    }
+                    PathLine {
+                        x: 0
+                        y: 0
+                    }
                 }
             }
 

--- a/src/ui/qml/components/SliderDialogBase.qml
+++ b/src/ui/qml/components/SliderDialogBase.qml
@@ -28,6 +28,8 @@ FocusScope {
     focus: visible
     // ===== 子类可覆盖的属性 =====
     property bool hasOverlay: false
+    /** @property Component mainContentSource - 子类可通过此属性在按钮上方添加主要内容组件（如输入框） */
+    property Component mainContentSource: null
     /** @property Component extraContentSource - 子类可通过此属性添加额外内容组件（如复选框） */
     property Component extraContentSource: null
     // ===== 共用常量 =====
@@ -42,6 +44,7 @@ FocusScope {
     property alias dialogBox: dialogBox  // 对话框容器
     property alias dialogBoxTranslate: dialogBoxTranslate  // 对话框位移
     property alias buttonColLayout: buttonColLayout  // 按钮列布局
+    property alias showAnimation: showAnim  // 打开动画
     // ===== 按钮规格列表 =====
     // 格式: { text, color, action } 或 { isSeparator: true }
     property list<var> buttonSpecs
@@ -68,7 +71,7 @@ FocusScope {
     function open() {
         visible = true;
         if (hasOverlay) {
-            showAnim.start();
+            showAnimation.start();
         } else {
             dialogBox.rotation = 0;
             dialogBox.scale = 1.0;
@@ -167,6 +170,15 @@ FocusScope {
                 horizontalAlignment: Text.AlignHCenter
                 lineHeight: 1.3
                 text: root.message
+            }
+
+            // 主内容（由子类通过 mainContentSource 设置，位于按钮组上方）
+            Loader {
+                id: mainContentLoader
+                Layout.fillWidth: true
+                Layout.topMargin: AppStyle.spacing.sm
+                sourceComponent: root.mainContentSource
+                visible: root.mainContentSource
             }
 
             // 按钮组容器

--- a/src/ui/qml/components/qmldir
+++ b/src/ui/qml/components/qmldir
@@ -21,5 +21,6 @@ WindowPersistenceManager 1.0 WindowPersistenceManager.qml
 WindowStartupManager 1.0 WindowStartupManager.qml
 WindowResizeHandles 1.0 WindowResizeHandles.qml
 ConfirmDialog 1.0 ConfirmDialog.qml
+DescriptionEditDialog 1.0 DescriptionEditDialog.qml
 ExitDialog 1.0 ExitDialog.qml
 SliderDialogBase 1.0 SliderDialogBase.qml

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -1249,6 +1249,18 @@ void ComponentListViewModel::dismissAttentionHints() {
     clearAttentionHints();
 }
 
+void ComponentListViewModel::updateComponentDescription(const QString& componentId, const QString& description) {
+    ComponentListItemData* item = findItemData(componentId);
+    if (!item) {
+        return;
+    }
+
+    item->setDescription(description);
+    if (m_service) {
+        m_service->updateComponentDescription(componentId, description);
+    }
+}
+
 void ComponentListViewModel::clearAttentionHints() {
     const bool changed = m_validationReadyHint || m_previewReadyHint || !m_pendingPreviewFetchIds.isEmpty();
     m_validationReadyHint = false;

--- a/src/ui/viewmodels/ComponentListViewModel.h
+++ b/src/ui/viewmodels/ComponentListViewModel.h
@@ -130,6 +130,7 @@ public slots:
     Q_INVOKABLE void fetchPreviewImages(const QStringList& componentIds);
     Q_INVOKABLE void updateExportStatus(const QString& componentId, int previewImageExported, int datasheetExported);
     Q_INVOKABLE void dismissAttentionHints();
+    Q_INVOKABLE void updateComponentDescription(const QString& componentId, const QString& description);
 
 signals:
     void componentCountChanged();

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -137,7 +137,9 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
                                           bool overwriteExistingFiles,
                                           bool updateMode,
                                           bool debugMode,
-                                          const QString& symbolLibraryDescription) {
+                                          const QString& symbolLibraryDescription,
+                                          const QString& footprintLibraryDescription,
+                                          const QString& footprintLibraryKeywords) {
     qDebug() << "ExportProgressViewModel: Starting export for" << componentIds.size() << "components";
 
     if (m_isExporting) {
@@ -207,7 +209,10 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
     options.updateMode = updateMode;
     options.debugMode = debugMode;
     options.exportSymbolDescription = true;
+    options.exportFootprintDescription = true;
     options.symbolLibraryDescription = symbolLibraryDescription;
+    options.footprintLibraryDescription = footprintLibraryDescription;
+    options.footprintLibraryKeywords = footprintLibraryKeywords;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(outputPath);

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -136,7 +136,8 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
                                           bool exportDatasheet,
                                           bool overwriteExistingFiles,
                                           bool updateMode,
-                                          bool debugMode) {
+                                          bool debugMode,
+                                          const QString& symbolLibraryDescription) {
     qDebug() << "ExportProgressViewModel: Starting export for" << componentIds.size() << "components";
 
     if (m_isExporting) {
@@ -205,6 +206,8 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
     options.overwriteExistingFiles = overwriteExistingFiles;
     options.updateMode = updateMode;
     options.debugMode = debugMode;
+    options.exportSymbolDescription = true;
+    options.symbolLibraryDescription = symbolLibraryDescription;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(outputPath);

--- a/src/ui/viewmodels/ExportProgressViewModel.h
+++ b/src/ui/viewmodels/ExportProgressViewModel.h
@@ -155,7 +155,9 @@ public slots:
                      bool overwriteExistingFiles,
                      bool updateMode,
                      bool debugMode,
-                     const QString& symbolLibraryDescription = QString());
+                     const QString& symbolLibraryDescription = QString(),
+                     const QString& footprintLibraryDescription = QString(),
+                     const QString& footprintLibraryKeywords = QString());
     void cancelExport();
     void handleCloseRequest();
     void updateComponentExportStatus(const QString& componentId, int previewImageExported, int datasheetExported);

--- a/src/ui/viewmodels/ExportProgressViewModel.h
+++ b/src/ui/viewmodels/ExportProgressViewModel.h
@@ -154,7 +154,8 @@ public slots:
                      bool exportDatasheet,
                      bool overwriteExistingFiles,
                      bool updateMode,
-                     bool debugMode);
+                     bool debugMode,
+                     const QString& symbolLibraryDescription = QString());
     void cancelExport();
     void handleCloseRequest();
     void updateComponentExportStatus(const QString& componentId, int previewImageExported, int datasheetExported);

--- a/src/ui/viewmodels/ExportSettingsViewModel.cpp
+++ b/src/ui/viewmodels/ExportSettingsViewModel.cpp
@@ -33,6 +33,11 @@ ExportSettingsViewModel::ExportSettingsViewModel(ParallelExportService* exportSe
     , m_weakNetworkSupport(false)
     , m_exportMode(0)
     , m_debugMode(false)
+    , m_exportSymbolDescription(true)
+    , m_exportFootprintDescription(true)
+    , m_symbolLibraryDescription("")
+    , m_footprintLibraryDescription("")
+    , m_footprintLibraryKeywords("")
     , m_isExporting(false)
     , m_status("Ready") {
     // 初始化时检查调试模式（命令行参数优先，环境变量向后兼容）
@@ -176,6 +181,41 @@ void ExportSettingsViewModel::setDebugMode(bool enabled) {
     }
 }
 
+void ExportSettingsViewModel::setExportSymbolDescription(bool enabled) {
+    if (m_exportSymbolDescription != enabled) {
+        m_exportSymbolDescription = enabled;
+        emit exportSymbolDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setExportFootprintDescription(bool enabled) {
+    if (m_exportFootprintDescription != enabled) {
+        m_exportFootprintDescription = enabled;
+        emit exportFootprintDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setSymbolLibraryDescription(const QString& desc) {
+    if (m_symbolLibraryDescription != desc) {
+        m_symbolLibraryDescription = desc;
+        emit symbolLibraryDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setFootprintLibraryDescription(const QString& desc) {
+    if (m_footprintLibraryDescription != desc) {
+        m_footprintLibraryDescription = desc;
+        emit footprintLibraryDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setFootprintLibraryKeywords(const QString& keywords) {
+    if (m_footprintLibraryKeywords != keywords) {
+        m_footprintLibraryKeywords = keywords;
+        emit footprintLibraryKeywordsChanged();
+    }
+}
+
 void ExportSettingsViewModel::startExport(const QStringList& componentIds) {
     qDebug() << "Starting export for" << componentIds.size() << "components";
 
@@ -255,6 +295,11 @@ void ExportSettingsViewModel::buildExportOptions() {
     options.weakNetworkSupport = m_weakNetworkSupport;
     options.updateMode = (m_exportMode == 1);
     options.debugMode = m_debugMode;
+    options.exportSymbolDescription = m_exportSymbolDescription;
+    options.exportFootprintDescription = m_exportFootprintDescription;
+    options.symbolLibraryDescription = m_symbolLibraryDescription;
+    options.footprintLibraryDescription = m_footprintLibraryDescription;
+    options.footprintLibraryKeywords = m_footprintLibraryKeywords;
 
     qInfo() << "Export options:" << "OutputPath:" << options.outputPath << "LibName:" << options.libName
             << "Symbol:" << options.exportSymbol << "Footprint:" << options.exportFootprint
@@ -262,7 +307,8 @@ void ExportSettingsViewModel::buildExportOptions() {
             << "(1=WRL, 2=STEP, 3=Both)" << "Preview Images:" << options.exportPreviewImages
             << "Datasheet:" << options.exportDatasheet
             << "Client Weak Network Adaptation:" << options.weakNetworkSupport << "Update Mode:" << options.updateMode
-            << "Debug Mode:" << options.debugMode;
+            << "Debug Mode:" << options.debugMode << "Symbol Description:" << options.exportSymbolDescription
+            << "Footprint Description:" << options.exportFootprintDescription;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(absoluteOutputPath);
@@ -382,6 +428,13 @@ void ExportSettingsViewModel::loadFromConfig() {
         m_debugMode = m_configService->getDebugMode();
     }
 
+    // 新字段使用默认值（ConfigService 暂未支持持久化）
+    m_exportSymbolDescription = true;
+    m_exportFootprintDescription = true;
+    m_symbolLibraryDescription.clear();
+    m_footprintLibraryDescription.clear();
+    m_footprintLibraryKeywords.clear();
+
     emit outputPathChanged();
     emit libNameChanged();
     emit exportSymbolChanged();
@@ -393,6 +446,11 @@ void ExportSettingsViewModel::loadFromConfig() {
     emit overwriteExistingFilesChanged();
     emit weakNetworkSupportChanged();
     emit debugModeChanged();
+    emit exportSymbolDescriptionChanged();
+    emit exportFootprintDescriptionChanged();
+    emit symbolLibraryDescriptionChanged();
+    emit footprintLibraryDescriptionChanged();
+    emit footprintLibraryKeywordsChanged();
 }
 
 void ExportSettingsViewModel::saveConfig() {
@@ -412,6 +470,11 @@ void ExportSettingsViewModel::resetConfig() {
     m_weakNetworkSupport = false;
     m_exportMode = 0;
     m_debugMode = false;
+    m_exportSymbolDescription = true;
+    m_exportFootprintDescription = true;
+    m_symbolLibraryDescription.clear();
+    m_footprintLibraryDescription.clear();
+    m_footprintLibraryKeywords.clear();
 
     m_configService->setOutputPath(m_outputPath);
     m_configService->setLibName(m_libName);
@@ -437,6 +500,11 @@ void ExportSettingsViewModel::resetConfig() {
     emit weakNetworkSupportChanged();
     emit exportModeChanged();
     emit debugModeChanged();
+    emit exportSymbolDescriptionChanged();
+    emit exportFootprintDescriptionChanged();
+    emit symbolLibraryDescriptionChanged();
+    emit footprintLibraryDescriptionChanged();
+    emit footprintLibraryKeywordsChanged();
 }
 
 }  // namespace EasyKiConverter

--- a/src/ui/viewmodels/ExportSettingsViewModel.cpp
+++ b/src/ui/viewmodels/ExportSettingsViewModel.cpp
@@ -308,7 +308,9 @@ void ExportSettingsViewModel::buildExportOptions() {
             << "Datasheet:" << options.exportDatasheet
             << "Client Weak Network Adaptation:" << options.weakNetworkSupport << "Update Mode:" << options.updateMode
             << "Debug Mode:" << options.debugMode << "Symbol Description:" << options.exportSymbolDescription
-            << "Footprint Description:" << options.exportFootprintDescription;
+            << "Footprint Description:" << options.exportFootprintDescription
+            << "Symbol Library Description:" << options.symbolLibraryDescription
+            << "Footprint Library Description:" << options.footprintLibraryDescription;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(absoluteOutputPath);

--- a/src/ui/viewmodels/ExportSettingsViewModel.h
+++ b/src/ui/viewmodels/ExportSettingsViewModel.h
@@ -31,6 +31,16 @@ class ExportSettingsViewModel : public QObject {
         bool weakNetworkSupport READ weakNetworkSupport WRITE setWeakNetworkSupport NOTIFY weakNetworkSupportChanged)
     Q_PROPERTY(int exportMode READ exportMode WRITE setExportMode NOTIFY exportModeChanged)
     Q_PROPERTY(bool debugMode READ debugMode WRITE setDebugMode NOTIFY debugModeChanged)
+    Q_PROPERTY(bool exportSymbolDescription READ exportSymbolDescription WRITE setExportSymbolDescription NOTIFY
+                   exportSymbolDescriptionChanged)
+    Q_PROPERTY(bool exportFootprintDescription READ exportFootprintDescription WRITE setExportFootprintDescription
+                   NOTIFY exportFootprintDescriptionChanged)
+    Q_PROPERTY(QString symbolLibraryDescription READ symbolLibraryDescription WRITE setSymbolLibraryDescription NOTIFY
+                   symbolLibraryDescriptionChanged)
+    Q_PROPERTY(QString footprintLibraryDescription READ footprintLibraryDescription WRITE setFootprintLibraryDescription
+                   NOTIFY footprintLibraryDescriptionChanged)
+    Q_PROPERTY(QString footprintLibraryKeywords READ footprintLibraryKeywords WRITE setFootprintLibraryKeywords NOTIFY
+                   footprintLibraryKeywordsChanged)
     Q_PROPERTY(bool isExporting READ isExporting NOTIFY isExportingChanged)
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
 
@@ -88,6 +98,26 @@ public:
         return m_debugMode;
     }
 
+    bool exportSymbolDescription() const {
+        return m_exportSymbolDescription;
+    }
+
+    bool exportFootprintDescription() const {
+        return m_exportFootprintDescription;
+    }
+
+    QString symbolLibraryDescription() const {
+        return m_symbolLibraryDescription;
+    }
+
+    QString footprintLibraryDescription() const {
+        return m_footprintLibraryDescription;
+    }
+
+    QString footprintLibraryKeywords() const {
+        return m_footprintLibraryKeywords;
+    }
+
     bool isExporting() const {
         return m_isExporting;
     }
@@ -109,6 +139,11 @@ public:
     Q_INVOKABLE void setWeakNetworkSupport(bool enabled);
     Q_INVOKABLE void setExportMode(int mode);
     Q_INVOKABLE void setDebugMode(bool enabled);
+    Q_INVOKABLE void setExportSymbolDescription(bool enabled);
+    Q_INVOKABLE void setExportFootprintDescription(bool enabled);
+    Q_INVOKABLE void setSymbolLibraryDescription(const QString& desc);
+    Q_INVOKABLE void setFootprintLibraryDescription(const QString& desc);
+    Q_INVOKABLE void setFootprintLibraryKeywords(const QString& keywords);
 
 public slots:
     Q_INVOKABLE void saveConfig();
@@ -130,6 +165,11 @@ signals:
     void weakNetworkSupportChanged();
     void exportModeChanged();
     void debugModeChanged();
+    void exportSymbolDescriptionChanged();
+    void exportFootprintDescriptionChanged();
+    void symbolLibraryDescriptionChanged();
+    void footprintLibraryDescriptionChanged();
+    void footprintLibraryKeywordsChanged();
     void isExportingChanged();
     void statusChanged();
     void preloadStarted();
@@ -165,6 +205,11 @@ private:
     bool m_weakNetworkSupport;
     int m_exportMode;  // 0 = 追加模式, 1 = 更新模式
     bool m_debugMode;
+    bool m_exportSymbolDescription;
+    bool m_exportFootprintDescription;
+    QString m_symbolLibraryDescription;
+    QString m_footprintLibraryDescription;
+    QString m_footprintLibraryKeywords;
     bool m_isExporting;
     QString m_status;
     QStringList m_pendingComponentIds;

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -26,7 +26,11 @@ set(QML_FILES
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowController.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowPersistenceManager.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowStartupManager.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/ConfirmDialog.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/DescriptionEditDialog.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowResizeHandles.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/ExitDialog.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/SliderDialogBase.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/styles/AppStyle.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/styles/ResponsiveHelper.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_BasicComponents.qml

--- a/tests/unit/test_models.cpp
+++ b/tests/unit/test_models.cpp
@@ -1,8 +1,8 @@
+#include "core/easyeda/EasyedaFootprintImporter.h"
 #include "models/FootprintData.h"
 #include "models/FootprintDataSerializer.h"
 #include "models/SymbolData.h"
 #include "models/SymbolDataSerializer.h"
-#include "core/easyeda/EasyedaFootprintImporter.h"
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -183,7 +183,8 @@ private:
         svgNode.insert(QStringLiteral("attrs"), attrs);
 
         QJsonArray shapes;
-        shapes.append(QStringLiteral("SVGNODE~") + QString::fromUtf8(QJsonDocument(svgNode).toJson(QJsonDocument::Compact)));
+        shapes.append(QStringLiteral("SVGNODE~") +
+                      QString::fromUtf8(QJsonDocument(svgNode).toJson(QJsonDocument::Compact)));
 
         QJsonObject dataStr;
         dataStr.insert(QStringLiteral("head"), head);


### PR DESCRIPTION
- 新增 KiCad 库表生成与注册能力：
  - 新增 KiCadLibTable、KiCadTableUtils、KiCadLibraryTableManager。
  - 支持生成 sym-lib-table 和 fp-lib-table。
  - 支持在检测到 KiCad 工程时更新项目库表，未检测到工程时生成KiCad_IMPORT.md 导入说明。
- 扩展导出配置链路：
  - ExportOptions 增加符号库描述、封装库描述、封装关键词等字段。
  - ExportSettingsViewModel / ExportProgressViewModel / QML 导出按钮链路透传库描述配置。
  - 导出设置 UI 新增明确的“库描述”区域，标注写入 sym-lib-table / fp-lib-table。
- 完善符号和封装导出：
  - 符号导出支持库描述参数，并在需要时生成 sym-lib-table。
  - 封装导出支持库描述、关键词参数，并在需要时生成 fp-lib-table。
  - 封装数据模型新增 description 字段并支持序列化。
  - 单个封装导出使用元器件自身描述写入 (descr ...)，库描述不再混入单个封装描述。
- 新增元器件列表描述编辑能力：
  - ComponentListItemData 增加 description 属性。
  - 默认描述来自 API 提取的元器件标题。
  - 元器件列表新增编辑按钮和 DescriptionEditDialog。
  - 编辑后的描述同步写入当前元器件的 symbol/footprint data，导出时使用该描述。
- 修复导出和缓存相关问题：
  - 组件获取失败时清理失败状态，避免失败内容污染后续缓存加载。
  - 导出失败路径补齐 m_isRunning.store(false)，避免导出状态卡住。
  - 符号导出失败时正确标记已收集项目为失败，并补充更明确的错误日志。
  - 修复预览图 base64 为空/undefined 时 QML Image 解码警告。
  - 修复 ExportResultsCard 中 visualModel 作用域问题。
- 其他维护：
  - 新增 KiCad 字段格式分析文档。
  - 更新 macOS 打包 workflow：修正 Intel runner、bundle 可执行文件名、sha256生成方式。
  - 补充 QML 资源列表，确保新增描述编辑弹窗可在运行时加载。