### PR TITLE
feat: v3.1.7 符号库描述导出、元器件描述编辑、导出错误处理增强 

### DIFF
--- a/.github/workflows/pack-macos.yml
+++ b/.github/workflows/pack-macos.yml
@@ -38,7 +38,7 @@ jobs:
               arch: arm64
             }
           - {
-              os: macos-15,
+              os: macos-15-intel,
               arch: intel
             }
     env:
@@ -97,13 +97,13 @@ jobs:
             cp resources/icons/app_icon.icns ${APP_NAME}.app/Contents/Resources/AppIcon.icns
           fi
 
-          cat > ${APP_NAME}.app/Contents/Info.plist << 'EOF'
+          cat > ${APP_NAME}.app/Contents/Info.plist << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
           <dict>
               <key>CFBundleExecutable</key>
-              <string>EasyKiconverter_Cpp_Version</string>
+              <string>easykiconverter</string>
               <key>CFBundleIdentifier</key>
               <string>com.tangsangsimida.EasyKiConverter</string>
               <key>CFBundleName</key>
@@ -137,7 +137,7 @@ jobs:
       - name: 'SHA256Sum of DMG'
         run: |
           cd "$GITHUB_WORKSPACE/" || { >&2 echo "Cannot cd to '$GITHUB_WORKSPACE/'!"; exit 11 ; }
-          shasum ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg | tee ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg.sha256sum
+          shasum -a 256 ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg | tee ${PRODUCT}-${VERSION}-g${{ env.GIT_HASH }}-${{ matrix.dist.arch }}.dmg.sha256sum
 
       - name: 'Artifact Upload'
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # 从 CI 环境动态获取版本号，如果没有定义则使用默认版本
 if(NOT DEFINED VERSION_FROM_CI)
-    set(VERSION_FROM_CI "3.1.6")
+    set(VERSION_FROM_CI "3.1.7")
     message(STATUS "VERSION_FROM_CI not defined, using default: ${VERSION_FROM_CI}")
 else()
     message(STATUS "VERSION_FROM_CI defined: ${VERSION_FROM_CI}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(QML_FILES
     src/ui/qml/components/WindowPersistenceManager.qml
     src/ui/qml/components/WindowStartupManager.qml
     src/ui/qml/components/ConfirmDialog.qml
+    src/ui/qml/components/DescriptionEditDialog.qml
     src/ui/qml/components/WindowResizeHandles.qml
     src/ui/qml/components/ExitDialog.qml
     src/ui/qml/components/SliderDialogBase.qml

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 
 
-**EasyKiConverter** 是一个基于 Qt 6 和 MVVM 架构的现代化 C++ 桌面工具，专为电子工程师设计，旨在将嘉立创 (LCSC) 和 EasyEDA 的元件数据高效转换为 KiCad 库文件。
+**EasyKiConverter** 是一个基于 Qt 6 和 MVVM 架构的现代化 C++ 桌面工具，专为电子工程师设计，旨在将嘉立创 (LCSC) 和 EasyEDA 的元件数据高效转换为 KiCad 库文件。支持 GUI 和 CLI 两种运行模式。
 
 ## 主要特性
 
@@ -30,6 +30,7 @@
 *   **智能配置**：配置项实时自动保存，支持断点记忆与调试模式状态恢复。
 *   **智能辅助**：支持从剪贴板智能提取元件编号。
 *   **LCSC 预览图**：自动获取 LCSC 元件预览图，支持缩略图显示和悬停预览。
+*   **CLI 模式**：支持纯命令行模式，适用于批量处理和自动化脚本。
 
 ## 快速开始
 
@@ -45,7 +46,14 @@
 
 ## 系统架构
 
-EasyKiConverter 采用现代化的 MVVM 架构设计，实现了清晰的分层结构和高效的并行处理。
+EasyKiConverter 采用现代化的 MVVM 架构设计，支持 GUI 和 CLI 双模式运行，实现了清晰的分层结构和高效的并行处理。
+
+**核心架构特点：**
+- **双模式运行**：GUI 模式 (QApplication + QML) 和 CLI 模式 (QCoreApplication + CliConverter)
+- **MVVM 分层**：QML View ↔ C++ ViewModel ↔ C++ Service ↔ C++ Model
+- **导出流水线**：预加载（并行获取）→ 导出（按类型独立并行，各有线程池）
+- **网络架构**：NetworkClient 单例，专用网络线程 + QNetworkAccessManager，支持重试/退避
+- **异步日志系统**：支持 LogModule 分类和多种输出方式
 
 ![系统架构图](docs/diagrams/EasyKiConverter_Architecture.svg)
 

--- a/README_en.md
+++ b/README_en.md
@@ -18,7 +18,7 @@
 
 
 
-**EasyKiConverter** is a modern C++ desktop tool based on Qt 6 and MVVM architecture, designed for electronics engineers to efficiently convert component data from LCSC and EasyEDA into KiCad library files.
+**EasyKiConverter** is a modern C++ desktop tool based on Qt 6 and MVVM architecture, designed for electronics engineers to efficiently convert component data from LCSC and EasyEDA into KiCad library files. Supports both GUI and CLI modes.
 
 ## Key Features
 
@@ -29,6 +29,7 @@
 *   **Smart Configuration**: Real-time auto-save of settings, supporting breakpoint memory and debug mode state restoration.
 *   **Smart Assistance**: Support for intelligent extraction of component IDs from clipboard.
 *   **LCSC Preview Images**: Automatically fetch LCSC component preview images, supporting thumbnail display and hover preview.
+*   **CLI Mode**: Pure command-line mode for batch processing and automation scripts.
 
 ## Quick Start
 
@@ -44,7 +45,14 @@ This project has implemented full-platform CI/CD automated building. If you are 
 
 ## System Architecture
 
-EasyKiConverter adopts a modern MVVM architecture design, achieving a clear layered structure and efficient parallel processing.
+EasyKiConverter adopts a modern MVVM architecture design, supporting both GUI and CLI modes, achieving a clear layered structure and efficient parallel processing.
+
+**Core Architecture Features:**
+- **Dual Mode**: GUI (QApplication + QML) and CLI (QCoreApplication + CliConverter)
+- **MVVM Layering**: QML View ↔ C++ ViewModel ↔ C++ Service ↔ C++ Model
+- **Export Pipeline**: Preload (parallel fetch) → Export (per-type stages with independent thread pools)
+- **Network Architecture**: NetworkClient singleton with dedicated network thread + QNetworkAccessManager, retry/backoff support
+- **Async Logging System**: LogModule categories with multiple output appenders
 
 ![System Architecture](docs/diagrams/EasyKiConverter_Architecture.svg)
 

--- a/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml
+++ b/deploy/metainfo/io.github.tangsangsimida.easykiconverter.metainfo.xml
@@ -58,22 +58,22 @@
 
   <screenshots>
     <screenshot type="default">
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.6/resources/imgs/screenshot1.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.7/resources/imgs/screenshot1.png</image>
       <caption>Main application window with component conversion interface</caption>
       <caption xml:lang="zh_CN">主应用窗口 - 元件转换界面</caption>
     </screenshot>
     <screenshot>
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.6/resources/imgs/screenshot2.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.7/resources/imgs/screenshot2.png</image>
       <caption>Component input and list management</caption>
       <caption xml:lang="zh_CN">元件输入和列表管理</caption>
     </screenshot>
     <screenshot>
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.6/resources/imgs/screenshot3.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.7/resources/imgs/screenshot3.png</image>
       <caption>Export settings and progress tracking</caption>
       <caption xml:lang="zh_CN">导出设置和进度跟踪</caption>
     </screenshot>
     <screenshot>
-      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.6/resources/imgs/screenshot4.png</image>
+      <image type="source" width="1200" height="800">https://raw.githubusercontent.com/tangsangsimida/EasyKiConverter/v3.1.7/resources/imgs/screenshot4.png</image>
       <caption>Dark mode theme support</caption>
       <caption xml:lang="zh_CN">深色主题支持</caption>
     </screenshot>

--- a/deploy/windows/AppxManifest.xml
+++ b/deploy/windows/AppxManifest.xml
@@ -24,7 +24,7 @@
 
   <Identity Name="EasyKiConverter.EasyKiConverter"
             Publisher="CN=674ae893-5637-43c6-894d-d9a3976ec062"
-            Version="3.1.6.0" ProcessorArchitecture="x64" />
+            Version="3.1.7.0" ProcessorArchitecture="x64" />
 
   <Properties>
     <DisplayName>EasyKiConverter</DisplayName>

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -4,7 +4,11 @@
 
 ## 架构概览
 
-EasyKiConverter 采用 MVVM (Model-View-ViewModel) 架构模式，提供清晰的职责分离和高效的代码组织。
+EasyKiConverter 采用 MVVM (Model-View-ViewModel) 架构模式，支持 GUI 和 CLI 双模式运行，提供清晰的职责分离和高效的代码组织。
+
+**双模式支持：**
+- **GUI 模式**：QApplication + QML（默认模式）
+- **CLI 模式**：QCoreApplication + CliConverter（纯命令行模式）
 
 ## 架构模式
 
@@ -146,8 +150,8 @@ Service 层负责业务逻辑的处理，提供核心功能。
 
 **主要类：**
 - `ComponentService` - 元件服务
-- `ExportService` - 导出服务（传统）
-- `ParallelExportService` - 流水线并行导出服务
+- `ExportService` - 导出服务
+- `ParallelExportService` - 并行导出服务（两阶段架构）
 - `ConfigService` - 配置服务
 - `PipelineCompletionHandler` - 导出完成处理器
 - `CommandLineParser` - 命令行参数解析器
@@ -185,10 +189,20 @@ CLI 模块位于 `src/utils/cli/` 目录，提供纯命令行模式支持。
 - `CompletionGenerator` - Shell 自动补全生成器
 
 **职责：**
-- 纯命令行模式运行（`--cli` 参数）
-- Shell 自动补全支持
-- BOM 批量导入转换
+- 纯命令行模式运行（`convert` 子命令）
+- Shell 自动补全支持（`--completion bash/zsh/fish`）
+- BOM 批量导入转换（`convert bom <file>`）
+- 单元件转换（`convert component <id>`）
+- 批量转换（`convert batch <ids...>`）
 - 离线批量导出
+
+**CLI 命令示例：**
+```bash
+./easykiconverter convert bom BOM_FILE.xlsx           # BOM 文件转换
+./easykiconverter convert component C12345             # 单个元件转换
+./easykiconverter convert batch C12345 C67890          # 批量转换
+./easykiconverter --completion bash > completion.sh    # 生成 bash 补全脚本
+```
 
 ### Model 层（模型层）
 
@@ -233,194 +247,185 @@ Model 层负责数据的存储和管理。
 - `SvgPathParser` - SVG 路径解析
 - `GzipUtils` - GZIP 压缩解压
 
-### 工作线程（Workers）
+### 网络架构（NetworkClient）
 
-工作线程负责后台任务处理，位于 `src/workers` 目录。
+所有 HTTP 请求都通过 `NetworkClient` 单例处理，采用**专用网络线程 + 按 ResourceType 并发控制**的架构。
 
-- `ExportWorker` - 导出工作线程（基础）
-- `NetworkWorker` - 网络工作线程
-- `FetchWorker` - 抓取工作线程（流水线阶段一）
-- `ProcessWorker` - 处理工作线程（流水线阶段二）
-- `WriteWorker` - 写入工作线程（流水线阶段三）
-
-## 流水线并行架构
-
-### 架构概述
-
-项目实现了**三阶段流水线并行架构**，用于批量导出元件数据，最大化性能。
+#### 架构概述
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                    流水线并行架构                                  │
+│  NetworkClient (Singleton)                                       │
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                  │
-│  ┌─────────────┐    ┌───────────────┐    ┌─────────────┐       │
-│  │  Fetch      │───▶│  Process      │───▶│   Write     │       │
-│  │  Stage      │    │  Stage        │    │   Stage     │       │
-│  │             │    │               │    │             │       │
-│  │ • 组件信息  │    │ • 解析 JSON   │    │ • 写符号    │       │
-│  │ • CAD 数据  │    │ • 转换格式     │    │ • 写封装    │       │
-│  │ • 3D 模型   │    │ • 几何计算     │    │ • 写 3D 模型│       │
-│  └─────────────┘    └───────────────┘    └─────────────┘       │
-│         │                    │                    │               │
-│         ▼                    ▼                    ▼               │
-│   5 threads            N cores             3 threads            │
-│   (I/O 密集型)        (CPU 密集型)        (磁盘 I/O 密集型)     │
-│                                                                  │
-│  ┌──────────────────────────────────────────────────────────┐   │
-│  │         线程安全有界队列（BoundedThreadSafeQueue）        │   │
-│  │  ┌─────────────────────┐    ┌──────────────────────┐     │   │
-│  │  │  FetchProcessQueue  │───▶│  ProcessWriteQueue  │     │   │
-│  │  │   (大小动态调整)      │    │   (大小动态调整)     │     │   │
-│  │  └─────────────────────┘    └──────────────────────┘     │   │
-│  └──────────────────────────────────────────────────────────┘   │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │  专用网络线程 ("EasyKiConverterNetworkThread")               ││
+│  │  - 所有 HTTP 请求都在此线程中执行                            ││
+│  │  - QNetworkAccessManager 在此线程中运行                      ││
+│  └─────────────────────────────────────────────────────────────┘│
+│                              │                                   │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │  请求队列 (m_pendingAsyncRequests)                           ││
+│  │  - 所有请求都入队到同一个队列                                ││
+│  │  - 按 ResourceType 分组进行并发控制                          ││
+│  └─────────────────────────────────────────────────────────────┘│
+│                              │                                   │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │  并发控制 (m_activeAsyncRequestsByType)                      ││
+│  │  - 每种 ResourceType 有独立的 maxConcurrent 限制             ││
+│  │  - pumpAsyncQueue() 按优先级和并发限制调度请求               ││
+│  └─────────────────────────────────────────────────────────────┘│
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### 三阶段详解
+#### 关键实现细节
 
-#### 阶段一：抓取阶段（Fetch Stage）
+1. **单线程处理所有请求**：所有网络请求都在 `m_networkThread` 这一个线程中执行
 
-**职责**：从网络下载所有原始数据
+2. **按 ResourceType 并发控制**：虽然只有一个网络线程，但通过 `m_activeAsyncRequestsByType` 跟踪每种资源类型的活跃请求数，确保不超过 `maxConcurrent` 限制
 
-**线程池配置**：
-- 线程数：5（I/O 密集型）
-- 适合：网络请求并发（避免触发服务器限流）
+3. **同步请求也是异步实现**：`get()`/`post()` 同步方法内部也是调用 `enqueueAsyncRequest()` 入队，然后通过 `BlockingRequestContext::wait()` 阻塞等待结果
 
-**任务**：
-- 获取组件信息（包含 CAD 数据）
-- 下载 3D 模型（OBJ 和 STEP 格式）
-- 处理 GZIP/ZIP 压缩数据
-- 使用 QSharedPointer 避免数据拷贝
+4. **请求调度**：`pumpAsyncQueue()` 方法会：
+   - 清理已完成的请求
+   - 按优先级和 ResourceType 的并发限制选择下一个请求
+   - 通过 `QMetaObject::invokeMethod` 在网络线程中启动请求
 
-**Worker**: `FetchWorker`
+#### ResourceType 并发配置
 
-**特点**：
-- 纯 I/O 密集型
-- 使用同步网络请求（QEventLoop）
-- 支持自动重试（待实现）
+> 注：以下表格与源代码 `src/core/network/INetworkClient.h` 中的定义保持同步。
 
----
+| ResourceType | maxConcurrent | 描述 |
+|--------------|---------------|------|
+| ComponentInfo | 10 | 组件元数据 JSON |
+| CadData | 10 | CAD 数据 JSON（符号/封装） |
+| PreviewImage | 5 | 组件预览图 |
+| ProductSearch | 5 | LCSC 产品搜索 |
+| Datasheet | 3 | PDF 数据手册 |
+| Model3DObj | 3 | 3D 模型 OBJ 文件 |
+| Model3DStep | 3 | 3D 模型 STEP 文件 |
+| UpdateCheck | 2 | GitHub 发布元数据 |
+| WorkerRequest | 5 | 通用工作线程请求 |
 
-#### 阶段二：处理阶段（Process Stage）
+#### 请求者
 
-**职责**：解析和转换数据
+- **EasyedaApi**：组件/CAD/3D 数据（使用 `NetworkClient::get()`）
+- **LcscImageService**：预览图 + 数据手册（使用 `NetworkClient::getAsync()`）
+- **ComponentService**：协调并行获取，通过 `m_maxConcurrentRequests` 控制并发
 
-**线程池配置**：
-- 线程数：等于 CPU 核心数（CPU 密集型）
-- 适合：大量 CPU 计算
+#### 使用模式
 
-**任务**：
-- 解析组件信息 JSON
-- 解析 CAD 数据 JSON
-- 解析 3D 模型数据（OBJ 格式）
-- 生成 KiCad 符号数据
-- 生成 KiCad 封装数据
-- 几何计算和转换
-
-**Worker**: `ProcessWorker`
-
-**特点**：
-- **纯 CPU 密集型**（不包含任何网络 I/O）
-- 使用 EasyedaImporter 进行数据导入
-- 零数据拷贝（使用 QSharedPointer）
-
----
-
-#### 阶段三：写入阶段（Write Stage）
-
-**职责**：将转换后的数据写入文件
-
-**线程池配置**：
-- 线程数：3（磁盘 I/O 密集型）
-- 适合：文件写入并发（避免过度并行导致性能下降）
-
-**任务**：
-- 写入符号库文件（.kicad_sym）
-- 写入封装文件（.kicad_mod）
-- 写入 3D 模型文件（.wrl、.step）
-- 合并符号库（临时文件）
-- 导出调试数据（如果启用）
-
-**Worker**: `WriteWorker`
-
-**特点**：
-- **并行写入**：单个组件的符号、封装、3D 模型同时写入
-- 使用 QThreadPool 实现并行
-- 避免文件写入冲突
-
----
-
-### 阶段间通信
-
-#### 线程安全有界队列
-
-**队列类型**：
 ```cpp
-BoundedThreadSafeQueue<QSharedPointer<ComponentExportStatus>> *m_queue;
+// 同步请求（内部使用异步队列 + 阻塞等待）
+RetryPolicy policy;
+policy.maxRetries = 3;
+policy.baseTimeoutMs = 30000;
+NetworkResult result = NetworkClient::instance().get(url, policy);
+
+// 带 ResourceType 的同步请求（使用预定义的 RequestProfile）
+NetworkResult result = NetworkClient::instance().get(
+    url, ResourceType::ComponentInfo, RetryPolicy::fromProfile(RequestProfiles::componentInfo()));
+
+// 异步请求（返回 AsyncNetworkRequest*，调用方管理生命周期）
+AsyncNetworkRequest* req = NetworkClient::instance().getAsync(url, ResourceType::PreviewImage);
+connect(req, &AsyncNetworkRequest::finished, this, [req](const NetworkResult& r) {
+    if (r.success) { /* ... */ }
+    req->deleteLater();  // 必须在完成后删除
+});
 ```
 
-**特点**：
-- 线程安全（使用 QMutex 和 QWaitCondition）
-- 有界（防止内存溢出）
-- 支持阻塞和非阻塞操作
-- 使用 QSharedPointer 避免数据拷贝
+#### 注意事项
 
-**队列大小**：
-- 动态调整：任务数的 1/4
-- 最小值：100
-- 避免队列满导致的阻塞
+- **不要在 bare std::thread 中使用**：NetworkClient 需要 Qt 事件循环
+- **同步请求会阻塞调用线程**：但网络处理在专用线程中执行
+- **生命周期管理**：异步请求返回的 `AsyncNetworkRequest*` 由调用方负责删除
 
----
+### 工作线程（Workers）
 
-### 进度计算
+工作线程负责后台任务处理，位于 `src/workers` 目录。
 
-**三阶段进度权重**：
-- Fetch 阶段：30%
-- Process 阶段：50%
-- Write 阶段：20%
+- `FetchWorker` - 网络数据获取工作线程
+- `ProcessWorker` - 数据处理工作线程（CPU 密集型）
+- `WriteWorker` - 文件写入工作线程
+- `MediaFetchWorker` - 媒体文件获取工作线程
+- `NetworkWorker` - 网络工作线程
 
-**总进度计算**：
-```cpp
-int overallProgress() {
-    return (fetchProgress() * 30 +
-            processProgress() * 50 +
-            writeProgress() * 20) / 100;
-}
+## 导出架构
+
+### 架构概述
+
+项目实现了**两阶段导出架构**，用于批量导出元件数据，最大化性能。
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    导出架构                                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │  阶段一：预加载 (Preload)                                    ││
+│  │  • ComponentService::fetchMultipleComponentsData()          ││
+│  │  • 并行获取所有组件数据（网络 I/O）                          ││
+│  │  • 并发数：m_maxConcurrentRequests (默认 10)                ││
+│  └─────────────────────────────────────────────────────────────┘│
+│                              ↓                                   │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │  阶段二：导出 (Export)                                       ││
+│  │  • ParallelExportService 协调多个 ExportTypeStage           ││
+│  │  • 每种导出类型独立并行运行                                  ││
+│  │  • 各类型有自己的线程池配置：                                ││
+│  │    - Symbol: maxConcurrent=1 (库级别导出)                    ││
+│  │    - Footprint: maxConcurrent=1 (库级别导出)                 ││
+│  │    - Model3D: maxConcurrent=2 (弱网时降为 1)                 ││
+│  │    - PreviewImages: maxConcurrent=4 (弱网时降为 2)           ││
+│  │    - Datasheet: maxConcurrent=2 (弱网时降为 1)               ││
+│  └─────────────────────────────────────────────────────────────┘│
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
-**进度反馈**：
-- 实时更新各阶段进度
-- 显示当前处理的元件
-- 显示预估剩余时间
+### 阶段一：预加载（Preload）
+
+**职责**：从网络获取所有原始数据
+
+**实现**：
+- 使用 `ComponentService::fetchMultipleComponentsData()` 并行获取
+- 通过 `NetworkClient` 单例发起网络请求
+- 使用专用网络线程 + QNetworkAccessManager
+- 并发数由 `m_maxConcurrentRequests` 控制（默认 10）
+
+**特点**：
+- 数据获取在用户添加组件时就已经完成（验证阶段）
+- 预加载只是从内存缓存中加载已验证的数据
+- 支持重试/退避机制
 
 ---
 
-### 性能优化
+### 阶段二：导出（Export）
 
-#### P0 改进（架构优化）
+**职责**：将数据转换并写入文件
 
-1. **ProcessWorker 移除网络请求**
-   - CPU 利用率提升 50-80%
-   - 充分利用多核 CPU
+**实现**：
+- 使用 `ParallelExportService` 协调多个 `ExportTypeStage`
+- 每种导出类型独立并行运行
+- 每种类型有自己的线程池配置
 
-2. **使用 QSharedPointer 传递数据**
-   - 内存占用减少 50-70%
-   - 性能提升 20-30%
+**导出类型及并发配置**：
 
-3. **调整 ProcessWorker 为纯 CPU 密集型**
-   - CPU 利用率提升 40-60%
+> 注：以下表格与 `ParallelExportService::createExportStages()` 中的线程池配置保持同步。
 
-#### P1 改进（性能优化）
+| 导出类型 | 最大并发数 | 说明 |
+|----------|-----------|------|
+| Symbol | 1 | 库级别导出，单线程 |
+| Footprint | 1 | 库级别导出，单线程 |
+| Model3D | 2 | 弱网时降为 1 |
+| PreviewImages | 4 | 弱网时降为 2 |
+| Datasheet | 2 | 弱网时降为 1 |
 
-1. **动态队列大小**
-   - 避免队列满导致的阻塞
-   - 吞吐量提升 15-25%
-
-2. **并行写入文件**
-   - 写入阶段耗时减少 30-50%
-   - 磁盘 I/O 并发度提升 2-3 倍
+**特点**：
+- 各类型独立并行，互不阻塞
+- 库级别导出（Symbol/Footprint）使用单线程，避免文件写入冲突
+- 支持弱网模式自动降级
 
 ---
 
@@ -429,57 +434,40 @@ int overallProgress() {
 ```
 用户输入元件ID
     ↓
-ParallelExportService.startPreload() + startExport()
+ComponentService::fetchComponentData() 或 fetchMultipleComponentsData()
+    ↓ (并行获取)
+┌─────────────────────────────────────────────┐
+│  网络获取 (NetworkClient)                    │
+│  • EasyedaApi: 组件信息 + CAD 数据           │
+│  • LcscImageService: 预览图 + 数据手册       │
+│  • 3D 模型下载                               │
+└─────────────────────────────────────────────┘
+    ↓ (ComponentData 缓存)
+ParallelExportService::startPreload() + startExport()
     ↓
 ┌─────────────────────────────────────────────┐
-│  Fetch Stage (5 threads)                     │
-│  • 下载组件信息                              │
-│  • 下载 CAD 数据                             │
-│  • 下载 3D 模型                              │
+│  SymbolExportStage (1 thread)                │
+│  • 合并所有符号到单个 .kicad_sym 文件        │
 └─────────────────────────────────────────────┘
-    ↓ (QSharedPointer<ComponentExportStatus>)
 ┌─────────────────────────────────────────────┐
-│  Process Stage (N cores)                     │
-│  • 解析 JSON                                 │
-│  • 转换格式                                  │
-│  • 几何计算                                  │
+│  FootprintExportStage (1 thread)             │
+│  • 合并所有封装到单个 .kicad_mod 目录        │
 └─────────────────────────────────────────────┘
-    ↓ (QSharedPointer<ComponentExportStatus>)
 ┌─────────────────────────────────────────────┐
-│  Write Stage (3 threads)                     │
-│  • 并行写入符号、封装、3D 模型               │
-│  • 合并符号库                                │
+│  Model3DExportStage (2 threads)              │
+│  • 并行写入 3D 模型文件 (.wrl, .step)        │
+└─────────────────────────────────────────────┘
+┌─────────────────────────────────────────────┐
+│  PreviewImagesExportStage (4 threads)        │
+│  • 并行下载和写入预览图文件                  │
+└─────────────────────────────────────────────┘
+┌─────────────────────────────────────────────┐
+│  DatasheetExportStage (2 threads)            │
+│  • 并行下载和写入数据手册文件                │
 └─────────────────────────────────────────────┘
     ↓
 完成导出
 ```
-
----
-
-### 错误处理
-
-**失败诊断**：
-- 精确识别失败阶段（Fetch/Process/Write）
-- 详细的错误消息
-- 调试日志记录
-
-**容错机制**：
-- 3D 模型下载失败不影响整体流程
-- 单个元件失败不影响其他元件
-- 支持部分成功导出
-
----
-
-### 性能指标
-
-**预期性能**（100 个元件）：
-
-| 指标 | 改进前 | 改进后 | 提升 |
-|------|-------|--------|------|
-| 总耗时 | 240 秒 | 110 秒 | 54% |
-| 吞吐量 | 0.42 组件/秒 | 0.91 组件/秒 | 117% |
-| 内存使用 | 400 MB | 200 MB | 50% |
-| CPU 利用率 | 60% | 90% | 50% |
 
 ---
 
@@ -499,15 +487,17 @@ ParallelExportService.startPreload() + startExport()
 
 优化批量转换性能的两阶段策略。
 
-**阶段一：数据收集（并行）**
-- 使用多线程并行收集所有元件数据
-- 充分利用多核 CPU 性能
-- 异步网络请求
+**阶段一：预加载（并行）**
+- 使用 `ComponentService::fetchMultipleComponentsData()` 并行获取所有元件数据
+- 通过 `NetworkClient` 单例发起网络请求
+- 并发数由 `m_maxConcurrentRequests` 控制（默认 10）
+- 数据获取在用户添加组件时就已经完成（验证阶段）
 
-**阶段二：数据导出（串行）**
-- 串行导出所有收集到的数据
-- 避免文件写入冲突
-- 保证数据一致性
+**阶段二：导出（并行）**
+- 使用 `ParallelExportService` 协调多个 `ExportTypeStage`
+- 每种导出类型独立并行运行
+- 库级别导出（Symbol/Footprint）使用单线程
+- 其他类型根据网络状况动态调整并发数
 
 ### 单例模式
 
@@ -702,11 +692,9 @@ EasyKiConverter_QT/
 
 ### 弱网容错（v3.0.4 分析）
 
-项目存在四套网络请求实现，弱网容错能力不一致：
+项目存在多套网络请求实现，弱网容错能力不一致：
 
-- **`FetchWorker`**（流水线批量导出）：支持超时（8-10s）和重试（3次），但超时后不重试
 - **`NetworkClient`**（统一网络层）：支持超时、重试和指数退避，已整合到 ComponentService
-- **`NetworkWorker`**（旧版单件获取）：无超时和重试机制，弱网下可能永久阻塞
 - **`ComponentService`**（LCSC 预览图）：支持超时（15s）+重试，有 Fallback 备用方案
 
 > 注：`NetworkUtils` 源码已移除，其功能已整合到 `NetworkClient` 统一网络层。

--- a/docs/developer/FAQ.md
+++ b/docs/developer/FAQ.md
@@ -250,6 +250,47 @@
 
 ---
 
+### Q: 导出的 3D 模型文件名与封装内记录的 3D 模型路径不一致
+
+**问题描述**：
+导出的 3D 模型文件名为 `C0603.step`，但封装内记录的 3D 模型路径却是 `../lib.3dmodels/C0603_L1.6-W0.8-H0.8.step`，导致 KiCad 无法找到对应的 3D 模型文件。
+
+**根本原因**：
+`Model3DData` 对象中的 `name` 字段在数据流传递过程中被意外丢失，由两个独立的 bug 共同导致：
+
+**Bug 1 - ProcessWorker 重建 Model3DData 丢失属性**：
+`ProcessWorker::parse3DModelData()` 收到 3D 模型 OBJ 数据后，会**重新创建** `Model3DData` 对象来存放原始数据，但旧代码只恢复了 `uuid`，`name`、`translation`、`rotation` 全部丢失。
+
+**Bug 2 - ComponentService 缓存加载覆盖已有 model3DData**：
+`ComponentCacheService::loadComponentData()` 已经从 `metadata.json` 正确加载了包含 `name` 的完整 `model3DData`，但 `ComponentService::loadComponentDataFromCacheAsync()` 会**重新创建一个只有 UUID 的 `model3DData`**，并通过 `setModel3DData()` 覆盖掉已有的完整数据。
+
+**数据流分析**：
+```
+EasyEDA API -> FootprintData.model3D().name() = "C0603_L1.6-W0.8-H0.8"
+                   |
+              【Bug 2】缓存加载 -> model3DData()->name() 被覆盖为空
+                   |
+              3D 模型导出 -> 回退到封装名 -> C0603.step
+              封装导出   -> 使用原始名称 -> C0603_L1.6-W0.8-H0.8.step（路径）
+```
+
+**修复方案**：
+1. `ProcessWorker::parse3DModelData()`：重建 `Model3DData` 前，先保存并恢复 `name`、`translation`、`rotation`
+2. `ComponentService::loadComponentDataFromCacheAsync()`：只在 `cachedData->model3DData()` 不存在或 UUID 缺失时才创建/补充，不再调用 `setModel3DData()` 覆盖已有数据
+
+**回归预防**：
+- 重建对象时必须备份旧对象的所有属性，不要假设新对象只需要部分字段
+- 缓存加载路径不要重复解析/覆盖，补充逻辑应该是"只在缺失时补充"，而不是"无条件重建"
+- 测试缓存场景时，必须同时验证：首次获取（无缓存）和缓存命中，两者的行为应当完全一致
+
+**相关文件**：
+- `src/workers/ProcessWorker.cpp` - 恢复 Model3DData 完整属性
+- `src/services/ComponentService.cpp` - 不再覆盖已有的 model3DData
+
+**状态**：✅ 已修复 (2026-04-29)
+
+---
+
 ## 网络相关
 
 ### Q: 在弱网络环境下导出失败率很高

--- a/docs/developer/KICAD_FIELD_FORMATS.md
+++ b/docs/developer/KICAD_FIELD_FORMATS.md
@@ -1,0 +1,331 @@
+# KiCad 字段格式分析
+
+本文档分析了 KiCad 符号库 (.kicad_sym) 和封装库 (.kicad_mod) 的字段格式，用于指导导出功能的实现。
+
+## 符号库 (.kicad_sym) 格式
+
+### 文件结构
+
+```lisp
+(kicad_symbol_lib (version 20220914) (generator kicad_symbol_editor)
+  (symbol "元件名" (in_bom yes) (on_board yes)
+    ;; 标准属性
+    (property "Reference" "U" (at 3.81 6.35 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Value" "元件名" (at 3.81 -6.35 0)
+      (effects (font (size 1.27 1.27)))
+    )
+    (property "Footprint" "" (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "Datasheet" "https://..." (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    
+    ;; 描述和关键词属性（可选，用于库管理）
+    (property "ki_keywords" "CMOS BUFFER 3State" (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    (property "ki_description" "8-bit D-flip-flop with 3-State outputs" (at 0 0 0)
+      (effects (font (size 1.27 1.27)) hide)
+    )
+    
+    ;; 符号图形定义（unit 0 通常用于电源引脚）
+    (symbol "元件名_0_0"
+      ;; 电源引脚、图形等
+    )
+    
+    ;; 功能单元定义
+    (symbol "元件名_1_1"
+      ;; 引脚定义
+      (pin input line (at -12.7 2.54 0) (length 7.62)
+        (name "引脚名" (effects (font (size 1.27 1.27))))
+        (number "引脚号" (effects (font (size 1.27 1.27))))
+      )
+    )
+  )
+)
+```
+
+### 描述字段说明
+
+| 字段 | 说明 | 示例 |
+|------|------|------|
+| `ki_description` | 元件描述 | `"8-bit D-flip-flop with 3-State outputs"` |
+| `ki_keywords` | 关键词（空格分隔） | `"CMOS BUFFER 3State"` |
+| `Reference` | 参考标识符前缀 | `"U"` (集成电路), `"R"` (电阻), `"C"` (电容) |
+| `Value` | 元件值/型号 | `"40374"` |
+| `Footprint` | 默认封装 | `""` (可为空) |
+| `Datasheet` | 数据手册链接 | `"https://..."` |
+
+### 实际示例
+
+从 `4xxx_IEEE.kicad_sym` 文件中提取的示例：
+
+```lisp
+(symbol "40374" (in_bom yes) (on_board yes)
+  (property "Reference" "U" (at 7.62 8.89 0)
+    (effects (font (size 1.27 1.27)))
+  )
+  (property "Value" "40374" (at 6.35 -15.24 0)
+    (effects (font (size 1.27 1.27)))
+  )
+  (property "Footprint" "" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  (property "Datasheet" "https://www.digchip.com/datasheets/download_datasheet.php?id=369790&part-number=HEF40374BDB" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  (property "ki_keywords" "CMOS BUFFER 3State" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  (property "ki_description" "8-bit D-flip-flop with 3-State outputs" (at 0 0 0)
+    (effects (font (size 1.27 1.27)) hide)
+  )
+  ;; ... 符号定义 ...
+)
+```
+
+---
+
+## 封装库 (.kicad_mod) 格式
+
+### 文件结构
+
+```lisp
+(footprint "封装名" (version 20211014) (generator pcbnew)
+  (layer "F.Cu")
+  (tedit 5A030281)
+  (descr "封装描述文本")
+  (tags "标签1 标签2")
+  (attr through_hole)  ;; 或 smd
+  
+  ;; 参考标识符
+  (fp_text reference "REF**" (at 3.8 -7.2) (layer "F.SilkS")
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  
+  ;; 元件值
+  (fp_text value "封装名" (at 3.8 7.4) (layer "F.Fab")
+    (effects (font (size 1 1) (thickness 0.15)))
+  )
+  
+  ;; 图形元素（丝印、阻焊、装配层等）
+  (fp_line (start x1 y1) (end x2 y2) (layer "F.SilkS") (width 0.12))
+  (fp_circle (center x y) (end x y) (layer "F.SilkS") (width 0.12))
+  
+  ;; 焊盘定义
+  (pad "1" thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad "2" smd rect (at 4 0) (size 2 4.2) (layers "F.Cu" "F.Paste" "F.Mask"))
+  
+  ;; 3D 模型引用
+  (model "${KICAD6_3DMODEL_DIR}/路径/模型.wrl"
+    (offset (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0))
+  )
+)
+```
+
+### 描述字段说明
+
+| 字段 | 说明 | 示例 |
+|------|------|------|
+| `descr` | 封装描述 | `"Generic Buzzer, D12mm height 9.5mm with RM7.6mm"` |
+| `tags` | 标签（空格分隔） | `"buzzer piezo"` |
+| `attr` | 封装属性 | `through_hole` / `smd` |
+
+### 实际示例
+
+#### 通孔封装示例
+
+```lisp
+(footprint "Buzzer_12x9.5RM7.6" (version 20211014) (generator pcbnew)
+  (layer "F.Cu")
+  (tedit 5A030281)
+  (descr "Generic Buzzer, D12mm height 9.5mm with RM7.6mm")
+  (tags "buzzer")
+  (attr through_hole)
+  ;; ...
+  (pad "1" thru_hole rect (at 0 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+  (pad "2" thru_hole circle (at 7.6 0) (size 2 2) (drill 1) (layers *.Cu *.Mask))
+)
+```
+
+#### SMD 封装示例
+
+```lisp
+(footprint "Buzzer_CUI_CPT-9019S-SMT" (version 20211014) (generator pcbnew)
+  (layer "F.Cu")
+  (tedit 5C12D246)
+  (descr "https://www.cui.com/product/resource/cpt-9019s-smt.pdf")
+  (tags "buzzer piezo")
+  (attr smd)
+  ;; ...
+  (pad "1" smd rect (at -4 0) (size 2 4.2) (layers "F.Cu" "F.Paste" "F.Mask"))
+  (pad "2" smd rect (at 4 0) (size 2 4.2) (layers "F.Cu" "F.Paste" "F.Mask"))
+)
+```
+
+---
+
+## 当前代码导出状态（基于 v3.1.7）
+
+### 符号库导出（ExporterSymbol.cpp）
+
+当前代码实际导出的属性：
+
+| 属性名 | 数据来源 | 说明 |
+|--------|----------|------|
+| `Reference` | `symbolData.info().prefix` | 参考标识符前缀（如 "U", "R", "C"） |
+| `Value` | `symbolData.info().name` | 元件名（如 "4001", "RESISTOR"） |
+| `Footprint` | `symbolData.info().package` | 封装名（格式：`libName:packageName`） |
+| `Datasheet` | `symbolData.info().datasheet` | 数据手册链接 |
+| `Manufacturer` | `symbolData.info().manufacturer` | 制造商 |
+| `LCSC Part` | `symbolData.info().lcscId` | LCSC 编号（如 "C12345"） |
+
+**当前未导出的字段（待实现）**：
+- `ki_description` - 符号描述
+- `ki_keywords` - 关键词
+
+### 封装库导出（ExporterFootprint.cpp）
+
+当前代码**未导出**描述和标签字段：
+
+| 字段 | 状态 | 说明 |
+|------|------|------|
+| `descr` | ❌ 未实现 | 封装描述 |
+| `tags` | ❌ 未实现 | 标签 |
+| `attr` | ✅ 已实现 | 根据焊盘类型自动判断 `through_hole` 或 `smd` |
+
+---
+
+## 数据结构字段分析
+
+### SymbolInfo 结构体字段
+
+```cpp
+struct SymbolInfo {
+    QString name;           // 元件名 → Value
+    QString prefix;         // 前缀 → Reference
+    QString package;        // 封装 → Footprint
+    QString manufacturer;   // 制造商 → Manufacturer
+    QString description;    // 描述 → ki_description（待实现）
+    QString datasheet;      // 数据手册 → Datasheet
+    QString lcscId;         // LCSC 编号 → LCSC Part
+    QString jlcId;          // JLC 编号
+    // ... 其他字段
+};
+```
+
+### FootprintInfo 结构体字段
+
+```cpp
+struct FootprintInfo {
+    QString name;           // 封装名
+    QString type;           // 类型
+    QString model3DName;    // 3D 模型名
+    // 注意：没有 description 和 keywords 字段
+    // ... 其他字段
+};
+```
+
+---
+
+## 数据映射表（修正版）
+
+### 符号库映射
+
+| 数据源 | KiCad 属性 | 代码位置 | 状态 |
+|--------|-----------|----------|------|
+| `symbolData.info().prefix` | `Reference` | ExporterSymbol.cpp:510 | ✅ 已实现 |
+| `symbolData.info().name` | `Value` | ExporterSymbol.cpp:524 | ✅ 已实现 |
+| `symbolData.info().package` | `Footprint` | ExporterSymbol.cpp:537 | ✅ 已实现 |
+| `symbolData.info().datasheet` | `Datasheet` | ExporterSymbol.cpp:554 | ✅ 已实现 |
+| `symbolData.info().manufacturer` | `Manufacturer` | ExporterSymbol.cpp:569 | ✅ 已实现 |
+| `symbolData.info().lcscId` | `LCSC Part` | ExporterSymbol.cpp:584 | ✅ 已实现 |
+| `symbolData.info().description` | `ki_description` | - | ❌ 待实现 |
+| 无数据源 | `ki_keywords` | - | ❌ 待实现（需添加字段） |
+
+### 封装库映射
+
+| 数据源 | KiCad 关键字 | 代码位置 | 状态 |
+|--------|-------------|----------|------|
+| 无数据源 | `descr` | - | ❌ 待实现（FootprintInfo 无 description 字段） |
+| 无数据源 | `tags` | - | ❌ 待实现（FootprintInfo 无 keywords 字段） |
+| 焊盘类型判断 | `attr` | ExporterFootprint.cpp:186 | ✅ 已实现 |
+
+---
+
+## 待实现功能
+
+### 1. 符号库添加 ki_description
+
+在 `ExporterSymbol.cpp` 中添加：
+
+```cpp
+// ki_description 属性（从 SymbolInfo.description 获取）
+if (!symbolData.info().description.isEmpty()) {
+    fieldOffset += 2.54;
+    content += QString("    (property\n");
+    content += QString("      \"ki_description\"\n");
+    content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+    content += "      (id 6)\n";
+    content += QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
+    content += QString("      (effects (font (size %1 %2) (thickness 0) ) hide)\n")
+                   .arg(fontSize, 0, 'f', 2)
+                   .arg(fontSize, 0, 'f', 2);
+    content += "    )\n";
+}
+```
+
+**插入位置**：在 LCSC Part 属性之后（约第 593 行）
+
+### 2. 封装库添加 descr
+
+需要先在 `FootprintInfo` 结构体中添加 `description` 字段：
+
+```cpp
+// FootprintData.h 中添加
+struct FootprintInfo {
+    // ... 现有字段
+    QString description;    // 封装描述
+    QString keywords;       // 关键词
+};
+```
+
+然后在 `ExporterFootprint.cpp` 中添加导出逻辑。
+
+### 3. 添加 ki_keywords 字段
+
+需要在 `SymbolInfo` 结构体中添加 `keywords` 字段（如果 EasyEDA API 提供）。
+
+---
+
+## 注意事项
+
+1. **转义字符**：描述文本中的引号需要转义为 `\"`
+
+2. **空值处理**：当前代码已使用 `isEmpty()` 检查，只在有值时才导出
+
+3. **ID 编号**：属性的 `id` 必须连续递增（0-5 已使用，新属性从 6 开始）
+
+4. **编码**：所有文本使用 UTF-8 编码
+
+5. **坐标**：属性的坐标 `(at 0 0 0)` 表示默认位置，hide 表示在原理图中隐藏
+
+---
+
+## 参考文件
+
+- 符号库示例：`/home/dennis/Desktop/4xxx_IEEE.kicad_sym`
+- 封装库示例：`/home/dennis/Desktop/Buzzer_Beeper.pretty/`
+- 符号导出器：`src/core/kicad/ExporterSymbol.cpp`
+- 封装导出器：`src/core/kicad/ExporterFootprint.cpp`
+- 符号数据模型：`src/models/SymbolData.h`
+- 封装数据模型：`src/models/FootprintData.h`
+
+---
+
+*最后更新：2026-05-02*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ not_in_nav: |
 
 # 版本信息（可通过 macros 插件在页面中使用）
 extra:
-  version: 3.1.6
+  version: 3.1.7
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/tangsangsimida/EasyKiConverter

--- a/resources/translations/translations_easykiconverter_en.ts
+++ b/resources/translations/translations_easykiconverter_en.ts
@@ -279,9 +279,44 @@
         <translation>Enter Library Name (e.g., MyLibrary)</translation>
     </message>
     <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="109"/>
+        <source>基础配置</source>
+        <translation>Basic Configuration</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="112"/>
+        <source>库描述</source>
+        <translation>Library Description</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="125"/>
+        <source>符号库描述 (sym-lib-table)</source>
+        <translation>Symbol Library Description (sym-lib-table)</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="140"/>
+        <source>输入符号库描述</source>
+        <translation>Enter Symbol Library Description</translation>
+    </message>
+    <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="141"/>
         <source>符号库</source>
         <translation>Symbols</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="158"/>
+        <source>封装库描述 (fp-lib-table)</source>
+        <translation>Footprint Library Description (fp-lib-table)</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="173"/>
+        <source>输入封装库描述</source>
+        <translation>Enter Footprint Library Description</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="189"/>
+        <source>关键词</source>
+        <translation>Keywords</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="197"/>
@@ -289,8 +324,9 @@
         <translation>Footprints</translation>
     </message>
     <message>
-        <source>调试模式</source>
-        <translation type="vanished">Debug Mode</translation>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="230"/>
+        <source>导出选项</source>
+        <translation>Export Options</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="421"/>
@@ -299,13 +335,27 @@
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="435"/>
+        <source>追加模式</source>
+        <translation>Append Mode</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="484"/>
+        <source>更新模式</source>
+        <translation>Update Mode</translation>
+    </message>
+    <message>
+        <source>调试模式</source>
+        <translation type="vanished">Debug Mode</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="435"/>
         <source>追加</source>
         <translation>Append</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="474"/>
-        <source>保留已存在的元器件</source>
-        <translation>Preserve</translation>
+        <source>保留已经存在的元器件数据，并追加新的元器件</source>
+        <translation>Preserve existing component data and append new components</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="484"/>
@@ -553,11 +603,6 @@
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="374"/>
         <source>导出数据手册文件</source>
         <translation>Export datasheet files</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="444"/>
-        <source>保留已经存在的元器件数据，并追加新的元器件</source>
-        <translation>Preserve existing component data and append new components</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/UpdateBanner.qml" line="45"/>

--- a/resources/translations/translations_easykiconverter_en.ts
+++ b/resources/translations/translations_easykiconverter_en.ts
@@ -315,8 +315,8 @@
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="493"/>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="523"/>
-        <source>覆盖已存在的元器件</source>
-        <translation>Overwrite</translation>
+        <source>覆盖已经存在的元器件数据，并追加新的元器件</source>
+        <translation>Overwrite existing component data and append new components</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportProgressCard.qml" line="10"/>
@@ -556,8 +556,8 @@
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="444"/>
-        <source>保留已存在的元器件，只追加新的元器件</source>
-        <translation>Preserve existing components and only append new ones</translation>
+        <source>保留已经存在的元器件数据，并追加新的元器件</source>
+        <translation>Preserve existing component data and append new components</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/UpdateBanner.qml" line="45"/>

--- a/resources/translations/translations_easykiconverter_zh_CN.ts
+++ b/resources/translations/translations_easykiconverter_zh_CN.ts
@@ -440,8 +440,8 @@
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="444"/>
-        <source>保留已存在的元器件，只追加新的元器件</source>
-        <translation>保留已存在的元器件，只追加新的元器件</translation>
+        <source>保留已经存在的元器件数据，并追加新的元器件</source>
+        <translation>保留已经存在的元器件数据，并追加新的元器件</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="474"/>
@@ -456,8 +456,8 @@
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="493"/>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="523"/>
-        <source>覆盖已存在的元器件</source>
-        <translation>覆盖已存在的元器件</translation>
+        <source>覆盖已经存在的元器件数据，并追加新的元器件</source>
+        <translation>覆盖已经存在的元器件数据，并追加新的元器件</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportProgressCard.qml" line="10"/>

--- a/resources/translations/translations_easykiconverter_zh_CN.ts
+++ b/resources/translations/translations_easykiconverter_zh_CN.ts
@@ -372,6 +372,26 @@
         <translation>输入库名称 (例如: MyLibrary)</translation>
     </message>
     <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="109"/>
+        <source>基础配置</source>
+        <translation>基础配置</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="112"/>
+        <source>库描述</source>
+        <translation>库描述</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="125"/>
+        <source>符号库描述 (sym-lib-table)</source>
+        <translation>符号库描述 (sym-lib-table)</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="140"/>
+        <source>输入符号库描述</source>
+        <translation>输入符号库描述</translation>
+    </message>
+    <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="141"/>
         <source>符号库</source>
         <translation>符号库</translation>
@@ -382,9 +402,44 @@
         <translation>导出符号库文件</translation>
     </message>
     <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="158"/>
+        <source>封装库描述 (fp-lib-table)</source>
+        <translation>封装库描述 (fp-lib-table)</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="173"/>
+        <source>输入封装库描述</source>
+        <translation>输入封装库描述</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="189"/>
+        <source>关键词</source>
+        <translation>关键词</translation>
+    </message>
+    <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="197"/>
         <source>封装库</source>
         <translation>封装库</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="230"/>
+        <source>导出选项</source>
+        <translation>导出选项</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="421"/>
+        <source>导出模式</source>
+        <translation>导出模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="435"/>
+        <source>追加模式</source>
+        <translation>追加模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="484"/>
+        <source>更新模式</source>
+        <translation>更新模式</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="206"/>
@@ -442,11 +497,6 @@
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="444"/>
         <source>保留已经存在的元器件数据，并追加新的元器件</source>
         <translation>保留已经存在的元器件数据，并追加新的元器件</translation>
-    </message>
-    <message>
-        <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="474"/>
-        <source>保留已存在的元器件</source>
-        <translation>保留已存在的元器件</translation>
     </message>
     <message>
         <location filename="../../src/ui/qml/components/ExportSettingsCard.qml" line="484"/>

--- a/src/core/easyeda/EasyedaFootprintImporter.cpp
+++ b/src/core/easyeda/EasyedaFootprintImporter.cpp
@@ -186,6 +186,43 @@ QSharedPointer<FootprintData> EasyedaFootprintImporter::importFootprintData(cons
     return footprintData;
 }
 
+namespace {
+bool isAbsoluteModelOrigin(double originX, double originY, const FootprintBBox& bbox) {
+    if (bbox.width <= 0.0 || bbox.height <= 0.0) {
+        return qAbs(originX) >= 1000.0 || qAbs(originY) >= 1000.0;
+    }
+
+    const double margin = qMax(bbox.width, bbox.height) * 2.0;
+    return originX >= bbox.x - margin && originX <= bbox.x + bbox.width + margin && originY >= bbox.y - margin &&
+           originY <= bbox.y + bbox.height + margin;
+}
+
+bool isRelativeModelOrigin(double originX, double originY, const FootprintBBox& bbox) {
+    const double limit = bbox.width > 0.0 && bbox.height > 0.0 ? qMax(bbox.width, bbox.height) * 2.0 : 1000.0;
+    return qAbs(originX) <= limit && qAbs(originY) <= limit;
+}
+
+Model3DBase normalizeModelOrigin(double originX, double originY, double originZ, const FootprintBBox& bbox) {
+    Model3DBase translation;
+    const double bboxCenterX = bbox.x + bbox.width / 2.0;
+    const double bboxCenterY = bbox.y + bbox.height / 2.0;
+
+    if (isAbsoluteModelOrigin(originX, originY, bbox)) {
+        translation.x = originX;
+        translation.y = originY;
+    } else if (isRelativeModelOrigin(originX, originY, bbox)) {
+        translation.x = bboxCenterX + originX;
+        translation.y = bboxCenterY + originY;
+    } else {
+        translation.x = bboxCenterX;
+        translation.y = bboxCenterY;
+    }
+
+    translation.z = originZ;
+    return translation;
+}
+}  // namespace
+
 FootprintPad EasyedaFootprintImporter::importPadData(const QString& padData) {
     FootprintPad pad;
     QStringList fields = EasyedaUtils::parseDataString(padData);
@@ -373,22 +410,10 @@ void EasyedaFootprintImporter::importSvgNodeData(const QString& svgNodeData,
                 QString c_origin = attrs["c_origin"].toString();
                 QStringList originParts = c_origin.split(",");
                 if (originParts.size() >= 2) {
-                    Model3DBase translation;
-                    double originX = originParts[0].toDouble();
-                    double originY = originParts[1].toDouble();
-
-                    if (qAbs(originX) < 1000 && qAbs(originY) < 1000) {
-                        double bboxCenterX = footprintData->bbox().x + footprintData->bbox().width / 2.0;
-                        double bboxCenterY = footprintData->bbox().y + footprintData->bbox().height / 2.0;
-
-                        translation.x = bboxCenterX;
-                        translation.y = bboxCenterY;
-                    } else {
-                        translation.x = originX;
-                        translation.y = originY;
-                    }
-
-                    translation.z = attrs.contains("z") ? attrs["z"].toDouble() : 0.0;
+                    const double originX = originParts[0].toDouble();
+                    const double originY = originParts[1].toDouble();
+                    const double originZ = attrs.contains("z") ? attrs["z"].toDouble() : 0.0;
+                    const Model3DBase translation = normalizeModelOrigin(originX, originY, originZ, footprintData->bbox());
                     model3D.setTranslation(translation);
                 }
             }
@@ -443,10 +468,10 @@ void EasyedaFootprintImporter::importSvgNodeData(const QString& svgNodeData,
             QString c_origin = attrs["c_origin"].toString();
             QStringList originParts = c_origin.split(",");
             if (originParts.size() >= 2) {
-                Model3DBase translation;
-                translation.x = originParts[0].toDouble();
-                translation.y = originParts[1].toDouble();
-                translation.z = attrs.contains("z") ? attrs["z"].toDouble() : 0.0;
+                const double originX = originParts[0].toDouble();
+                const double originY = originParts[1].toDouble();
+                const double originZ = attrs.contains("z") ? attrs["z"].toDouble() : 0.0;
+                const Model3DBase translation = normalizeModelOrigin(originX, originY, originZ, footprintData->bbox());
                 model3D.setTranslation(translation);
             }
         }

--- a/src/core/easyeda/EasyedaFootprintImporter.cpp
+++ b/src/core/easyeda/EasyedaFootprintImporter.cpp
@@ -413,7 +413,8 @@ void EasyedaFootprintImporter::importSvgNodeData(const QString& svgNodeData,
                     const double originX = originParts[0].toDouble();
                     const double originY = originParts[1].toDouble();
                     const double originZ = attrs.contains("z") ? attrs["z"].toDouble() : 0.0;
-                    const Model3DBase translation = normalizeModelOrigin(originX, originY, originZ, footprintData->bbox());
+                    const Model3DBase translation =
+                        normalizeModelOrigin(originX, originY, originZ, footprintData->bbox());
                     model3D.setTranslation(translation);
                 }
             }

--- a/src/core/kicad/CMakeLists.txt
+++ b/src/core/kicad/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(EasyKiConverterKicad STATIC
     ExporterFootprint.cpp
     FootprintGraphicsGenerator.cpp
     Exporter3DModel.cpp
+    KiCadLibTable.cpp
 )
 
 target_include_directories(EasyKiConverterKicad

--- a/src/core/kicad/Exporter3DModel.cpp
+++ b/src/core/kicad/Exporter3DModel.cpp
@@ -7,6 +7,9 @@
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QTextStream>
+#include <QVector>
+
+#include <limits>
 
 namespace EasyKiConverter {
 
@@ -430,8 +433,13 @@ QJsonObject Exporter3DModel::parseObjData(const QByteArray& objData) {
 
     // qDebug() << "Found" << materials.size() << "materials";
 
-    // 第二遍：提取顶点数据（存储为字符串，用于 WRL 输出
-    QStringList vertexStrings;  // 存储顶点坐标字符
+    // 第二遍：提取顶点数据
+    QVector<Model3DBase> convertedVertices;
+    double minX = std::numeric_limits<double>::max();
+    double maxX = std::numeric_limits<double>::lowest();
+    double minY = std::numeric_limits<double>::max();
+    double maxY = std::numeric_limits<double>::lowest();
+    double minZ = std::numeric_limits<double>::max();
     for (const QString& line : lines) {
         QString trimmedLine = line.trimmed();
         if (trimmedLine.isEmpty() || trimmedLine.startsWith('#')) {
@@ -449,18 +457,38 @@ QJsonObject Exporter3DModel::parseObjData(const QByteArray& objData) {
                 double x = parts[1].toDouble() / 2.54;
                 double y = parts[2].toDouble() / 2.54;
                 double z = parts[3].toDouble() / 2.54;
-                // 保留 4 位小数，与 Python 版本保持一致
-                QString vertexStr = QString("%1 %2 %3").arg(x, 0, 'f', 4).arg(y, 0, 'f', 4).arg(z, 0, 'f', 4);
-                vertexStrings.append(vertexStr);
-
-                // 同时保存JSON 数组，用于后续处
-                QJsonArray vertex;
-                vertex.append(x);
-                vertex.append(y);
-                vertex.append(z);
-                vertices.append(vertex);
+                convertedVertices.append(Model3DBase(x, y, z));
+                minX = qMin(minX, x);
+                maxX = qMax(maxX, x);
+                minY = qMin(minY, y);
+                maxY = qMax(maxY, y);
+                minZ = qMin(minZ, z);
             }
         }
+    }
+
+    const bool hasVertices = !convertedVertices.isEmpty();
+    const double normalizeX = hasVertices ? (minX + maxX) / 2.0 : 0.0;
+    const double normalizeY = hasVertices ? (minY + maxY) / 2.0 : 0.0;
+    const double normalizeZ = hasVertices && minZ > 0.0 ? minZ : 0.0;
+
+    QStringList vertexStrings;
+    for (Model3DBase vertexData : convertedVertices) {
+        vertexData.x -= normalizeX;
+        vertexData.y -= normalizeY;
+        vertexData.z -= normalizeZ;
+
+        // 保留 4 位小数，与 Python 版本保持一致
+        QString vertexStr =
+            QString("%1 %2 %3").arg(vertexData.x, 0, 'f', 4).arg(vertexData.y, 0, 'f', 4).arg(vertexData.z, 0, 'f', 4);
+        vertexStrings.append(vertexStr);
+
+        // 同时保存JSON 数组，用于后续处理
+        QJsonArray vertex;
+        vertex.append(vertexData.x);
+        vertex.append(vertexData.y);
+        vertex.append(vertexData.z);
+        vertices.append(vertex);
     }
 
     // qDebug() << "Found" << vertices.size() << "vertices";

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -189,9 +189,10 @@ void ExporterFootprint::generateFootprintBaseContent(const FootprintData& footpr
     content += QString("(footprint easykiconverter:%1\n").arg(footprintData.info().name);
     content += "  (version 20221018)\n";
 
-    // 导出封装描述 (descr) - 用户输入
-    if (!libraryDescription.isEmpty()) {
-        content += QString("  (descr \"%1\")\n").arg(libraryDescription);
+    // 导出封装描述 (descr) - 单个元器件描述；库描述写入 fp-lib-table
+    const QString footprintDescription = footprintData.info().description.trimmed();
+    if (!footprintDescription.isEmpty()) {
+        content += QString("  (descr \"%1\")\n").arg(footprintDescription);
     }
 
     // 导出封装标签 (tags) - 用户输入

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -1,5 +1,6 @@
 #include "ExporterFootprint.h"
 
+#include "KiCadLibTable.h"
 #include "core/utils/GeometryUtils.h"
 #include "utils/PathSecurity.h"
 
@@ -161,6 +162,13 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
     qDebug() << "Footprint library exported to:" << filePath;
 
     return true;
+}
+
+bool ExporterFootprint::generateFpLibTable(const QString& libName,
+                                           const QString& libDirPath,
+                                           const QString& outputDir,
+                                           const QString& libraryDescription) {
+    return generateKiCadLibTable("fp_lib_table", "fp-lib-table", libName, libDirPath, outputDir, libraryDescription);
 }
 
 QString ExporterFootprint::generateHeader(const QString& libName) const {

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -64,11 +64,15 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
                                                const QString& libName,
                                                const QString& filePath,
                                                bool preferWrl,
-                                               bool exportStep) {
+                                               bool exportStep,
+                                               const QString& libraryDescription,
+                                               const QString& libraryKeywords) {
     qDebug() << "=== Export Footprint Library ===";
     qDebug() << "Library name:" << libName;
     qDebug() << "Output path:" << filePath;
     qDebug() << "Footprint count:" << footprints.count();
+    qDebug() << "Library description:" << libraryDescription;
+    qDebug() << "Library keywords:" << libraryKeywords;
 
     QDir libDir(filePath);
 
@@ -125,18 +129,18 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
             if (useWrl && useStep) {
                 QString wrlPath = QStringLiteral("../%1.3dmodels/%2.wrl").arg(safeLibName, modelName);
                 QString stepPath = QStringLiteral("../%1.3dmodels/%2.step").arg(safeLibName, modelName);
-                content = generateFootprintContent(footprint, wrlPath, stepPath);
+                content = generateFootprintContent(footprint, wrlPath, stepPath, libraryDescription, libraryKeywords);
             } else if (useWrl) {
                 QString wrlPath = QStringLiteral("../%1.3dmodels/%2.wrl").arg(safeLibName, modelName);
-                content = generateFootprintContent(footprint, wrlPath);
+                content = generateFootprintContent(footprint, wrlPath, libraryDescription, libraryKeywords);
             } else if (useStep) {
                 QString stepPath = QStringLiteral("../%1.3dmodels/%2.step").arg(safeLibName, modelName);
-                content = generateFootprintContent(footprint, stepPath);
+                content = generateFootprintContent(footprint, stepPath, libraryDescription, libraryKeywords);
             } else {
-                content = generateFootprintContent(footprint);
+                content = generateFootprintContent(footprint, QString(), libraryDescription, libraryKeywords);
             }
         } else {
-            content = generateFootprintContent(footprint);
+            content = generateFootprintContent(footprint, QString(), libraryDescription, libraryKeywords);
         }
 
         QFile file(fullPath);
@@ -171,9 +175,21 @@ QString ExporterFootprint::generateHeader(const QString& libName) const {
 void ExporterFootprint::generateFootprintBaseContent(const FootprintData& footprintData,
                                                      QString& content,
                                                      double& outBboxX,
-                                                     double& outBboxY) const {
+                                                     double& outBboxY,
+                                                     const QString& libraryDescription,
+                                                     const QString& libraryKeywords) const {
     content += QString("(footprint easykiconverter:%1\n").arg(footprintData.info().name);
     content += "  (version 20221018)\n";
+
+    // 导出封装描述 (descr) - 用户输入
+    if (!libraryDescription.isEmpty()) {
+        content += QString("  (descr \"%1\")\n").arg(libraryDescription);
+    }
+
+    // 导出封装标签 (tags) - 用户输入
+    if (!libraryKeywords.isEmpty()) {
+        content += QString("  (tags \"%1\")\n").arg(libraryKeywords);
+    }
 
     bool isThroughHole = false;
     for (const FootprintPad& pad : footprintData.pads()) {
@@ -272,9 +288,24 @@ void ExporterFootprint::generateFootprintBaseContent(const FootprintData& footpr
 
 QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
                                                     const QString& model3DPath) const {
+    // 委托给带 libraryDescription/libraryKeywords 参数的版本
+    return generateFootprintContent(footprintData, model3DPath, QString(), QString());
+}
+
+QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
+                                                    const QString& model3DWrlPath,
+                                                    const QString& model3DStepPath) const {
+    // 委托给带 libraryDescription/libraryKeywords 参数的版本
+    return generateFootprintContent(footprintData, model3DWrlPath, model3DStepPath, QString(), QString());
+}
+
+QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
+                                                    const QString& model3DPath,
+                                                    const QString& libraryDescription,
+                                                    const QString& libraryKeywords) const {
     QString content;
     double bboxX = 0, bboxY = 0;
-    generateFootprintBaseContent(footprintData, content, bboxX, bboxY);
+    generateFootprintBaseContent(footprintData, content, bboxX, bboxY, libraryDescription, libraryKeywords);
 
     if (!footprintData.model3D().name().isEmpty() || !model3DPath.isEmpty()) {
         content += m_graphicsGenerator.generateModel3D(
@@ -287,10 +318,12 @@ QString ExporterFootprint::generateFootprintContent(const FootprintData& footpri
 
 QString ExporterFootprint::generateFootprintContent(const FootprintData& footprintData,
                                                     const QString& model3DWrlPath,
-                                                    const QString& model3DStepPath) const {
+                                                    const QString& model3DStepPath,
+                                                    const QString& libraryDescription,
+                                                    const QString& libraryKeywords) const {
     QString content;
     double bboxX = 0, bboxY = 0;
-    generateFootprintBaseContent(footprintData, content, bboxX, bboxY);
+    generateFootprintBaseContent(footprintData, content, bboxX, bboxY, libraryDescription, libraryKeywords);
 
     if (!footprintData.model3D().name().isEmpty() || !model3DWrlPath.isEmpty() || !model3DStepPath.isEmpty()) {
         if (!model3DWrlPath.isEmpty()) {

--- a/src/core/kicad/ExporterFootprint.h
+++ b/src/core/kicad/ExporterFootprint.h
@@ -64,14 +64,30 @@ public:
                                 const QString& libName,
                                 const QString& filePath,
                                 bool preferWrl = true,
-                                bool exportStep = false);
+                                bool exportStep = false,
+                                const QString& libraryDescription = QString(),
+                                const QString& libraryKeywords = QString());
 
 private:
     QString generateHeader(const QString& libName) const;
     void generateFootprintBaseContent(const FootprintData& footprintData,
                                       QString& content,
                                       double& outBboxX,
-                                      double& outBboxY) const;
+                                      double& outBboxY,
+                                      const QString& libraryDescription = QString(),
+                                      const QString& libraryKeywords = QString()) const;
+    // 基础版本：支持描述和关键词，内部委托到双路径重载
+    QString generateFootprintContent(const FootprintData& footprintData,
+                                     const QString& model3DPath,
+                                     const QString& libraryDescription,
+                                     const QString& libraryKeywords) const;
+    // 双3D模型路径版本：支持描述和关键词
+    QString generateFootprintContent(const FootprintData& footprintData,
+                                     const QString& model3DWrlPath,
+                                     const QString& model3DStepPath,
+                                     const QString& libraryDescription,
+                                     const QString& libraryKeywords) const;
+    // 兼容旧调用：无描述/关键词，内部委托到基础版本
     QString generateFootprintContent(const FootprintData& footprintData, const QString& model3DPath = QString()) const;
     QString generateFootprintContent(const FootprintData& footprintData,
                                      const QString& model3DWrlPath,

--- a/src/core/kicad/ExporterFootprint.h
+++ b/src/core/kicad/ExporterFootprint.h
@@ -68,6 +68,20 @@ public:
                                 const QString& libraryDescription = QString(),
                                 const QString& libraryKeywords = QString());
 
+    /**
+     * @brief 生成 fp-lib-table 文件
+     *
+     * @param libName 库名称
+     * @param libDirPath 封装库目录路径（.pretty 目录）
+     * @param outputDir 输出目录
+     * @param libraryDescription 库描述
+     * @return bool 是否成功
+     */
+    bool generateFpLibTable(const QString& libName,
+                            const QString& libDirPath,
+                            const QString& outputDir,
+                            const QString& libraryDescription = QString());
+
 private:
     QString generateHeader(const QString& libName) const;
     void generateFootprintBaseContent(const FootprintData& footprintData,

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -76,7 +76,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName);
+            out << generateSymbolContent(symbol, libName, libraryDescription);
         }
 
         // 生成尾部
@@ -356,7 +356,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName);
+        out << generateSymbolContent(symbol, libName, libraryDescription);
     }
 
     // 生成尾部
@@ -384,7 +384,9 @@ QString ExporterSymbol::generateHeader(const QString& libName, const QString& li
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
+                                              const QString& libName,
+                                              const QString& libraryDescription) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -600,11 +602,13 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, cons
     }
 
     // ki_description 属性（符号库描述）
-    if (!symbolData.info().description.isEmpty()) {
+    // 优先使用元器件自身的描述，如果为空则使用库描述
+    QString kiDescription = symbolData.info().description.isEmpty() ? libraryDescription : symbolData.info().description;
+    if (!kiDescription.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");
         content += QString("      \"ki_description\"\n");
-        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(kiDescription));
         content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -41,7 +41,8 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
                                          const QString& libName,
                                          const QString& filePath,
                                          bool appendMode,
-                                         bool updateMode) {
+                                         bool updateMode,
+                                         const QString& libraryDescription) {
     qDebug() << "=== Export Symbol Library ===";
     qDebug() << "Library name:" << libName;
     qDebug() << "Output path:" << filePath;
@@ -49,6 +50,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     qDebug() << "KiCad version: V6";
     qDebug() << "Append mode:" << appendMode;
     qDebug() << "Update mode:" << updateMode;
+    qDebug() << "Library description:" << libraryDescription;
 
     // 重置检测到的版本，避免影响后续调用
     m_detectedVersion.clear();
@@ -181,8 +183,6 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     qDebug() << "Existing symbols count:" << existingSymbols.count();
     qDebug() << "Sub-symbol names:" << subSymbolNames;
 
-    qDebug() << "Existing symbols count:" << existingSymbols.count();
-
     // 确定要导出的符号
     QList<SymbolData> symbolsToExport;
     int overwriteCount = 0;
@@ -230,7 +230,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     out.setEncoding(QStringConverter::Utf8);
 
     // 生成头部
-    out << generateHeader(libName);
+    out << generateHeader(libName, libraryDescription);
 
     // 生成所有符号（包括未覆盖的现有符号和新导出的符号）
     int index = 0;
@@ -367,14 +367,21 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     return true;
 }
 
-QString ExporterSymbol::generateHeader(const QString& libName) const {
-    Q_UNUSED(libName);
+QString ExporterSymbol::generateHeader(const QString& libName, const QString& libraryDescription) const {
+    Q_UNUSED(libName);  // 库名在符号内容中使用，不在头部使用
     QString version = m_detectedVersion.isEmpty() ? "20211014" : m_detectedVersion;
-    return QString(
-               "(kicad_symbol_lib\n"
-               "  (version %1)\n"
-               "  (generator https://github.com/tangsangsimida/EasyKiConverter)\n")
-        .arg(version);
+    QString header = QString(
+                         "(kicad_symbol_lib\n"
+                         "  (version %1)\n"
+                         "  (generator https://github.com/tangsangsimida/EasyKiConverter)\n")
+                         .arg(version);
+
+    // 添加库描述（如果提供）
+    if (!libraryDescription.isEmpty()) {
+        header += QString("  (description \"%1\")\n").arg(libraryDescription);
+    }
+
+    return header;
 }
 
 QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
@@ -584,6 +591,21 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, cons
         content += QString("      \"LCSC Part\"\n");
         content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().lcscId));
         content += "      (id 5)\n";
+        content +=
+            QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
+        content += QString("      (effects (font (size %1 %2) (thickness 0) ) hide)\n")
+                       .arg(fontSize, 0, 'f', 2)
+                       .arg(fontSize, 0, 'f', 2);
+        content += "    )\n";
+    }
+
+    // ki_description 属性（符号库描述）
+    if (!symbolData.info().description.isEmpty()) {
+        fieldOffset += 2.54;
+        content += QString("    (property\n");
+        content += QString("      \"ki_description\"\n");
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+        content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
         content += QString("      (effects (font (size %1 %2) (thickness 0) ) hide)\n")

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -1,10 +1,12 @@
 #include "ExporterSymbol.h"
 
+#include "KiCadLibTable.h"
 #include "core/utils/GeometryUtils.h"
 #include "core/utils/SvgPathParser.h"
 
 #include <QDebug>
 #include <QFile>
+#include <QFileInfo>
 #include <QRegularExpression>
 #include <QTextStream>
 
@@ -76,7 +78,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName, libraryDescription);
+            out << generateSymbolContent(symbol, libName);
         }
 
         // 生成尾部
@@ -230,7 +232,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     out.setEncoding(QStringConverter::Utf8);
 
     // 生成头部
-    out << generateHeader(libName, libraryDescription);
+    out << generateHeader(libName);
 
     // 生成所有符号（包括未覆盖的现有符号和新导出的符号）
     int index = 0;
@@ -356,7 +358,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName, libraryDescription);
+        out << generateSymbolContent(symbol, libName);
     }
 
     // 生成尾部
@@ -367,7 +369,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     return true;
 }
 
-QString ExporterSymbol::generateHeader(const QString& libName, const QString& libraryDescription) const {
+QString ExporterSymbol::generateHeader(const QString& libName) const {
     Q_UNUSED(libName);  // 库名在符号内容中使用，不在头部使用
     QString version = m_detectedVersion.isEmpty() ? "20211014" : m_detectedVersion;
     QString header = QString(
@@ -376,17 +378,10 @@ QString ExporterSymbol::generateHeader(const QString& libName, const QString& li
                          "  (generator https://github.com/tangsangsimida/EasyKiConverter)\n")
                          .arg(version);
 
-    // 添加库描述（如果提供）
-    if (!libraryDescription.isEmpty()) {
-        header += QString("  (description \"%1\")\n").arg(libraryDescription);
-    }
-
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
-                                              const QString& libName,
-                                              const QString& libraryDescription) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -601,14 +596,12 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
         content += "    )\n";
     }
 
-    // ki_description 属性（符号库描述）
-    // 优先使用元器件自身的描述，如果为空则使用库描述
-    QString kiDescription = symbolData.info().description.isEmpty() ? libraryDescription : symbolData.info().description;
-    if (!kiDescription.isEmpty()) {
+    // ki_description 属性（仅使用元器件自身描述，库描述写入 sym-lib-table）
+    if (!symbolData.info().description.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");
         content += QString("      \"ki_description\"\n");
-        content += QString("      \"%1\"\n").arg(escapePropertyValue(kiDescription));
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
         content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);
@@ -687,6 +680,13 @@ QString ExporterSymbol::generateSubSymbol(const SymbolData& symbolData,
     content += "    )\n";  // 结束子符号
 
     return content;
+}
+
+bool ExporterSymbol::generateSymLibTable(const QString& libName,
+                                         const QString& libFilePath,
+                                         const QString& outputDir,
+                                         const QString& libraryDescription) {
+    return generateKiCadLibTable("sym_lib_table", "sym-lib-table", libName, libFilePath, outputDir, libraryDescription);
 }
 
 }  // namespace EasyKiConverter

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -78,7 +78,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName, libraryDescription);
+            out << generateSymbolContent(symbol, libName);
         }
 
         // 生成尾部
@@ -358,7 +358,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName, libraryDescription);
+        out << generateSymbolContent(symbol, libName);
     }
 
     // 生成尾部
@@ -381,9 +381,7 @@ QString ExporterSymbol::generateHeader(const QString& libName) const {
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
-                                              const QString& libName,
-                                              const QString& libraryDescription) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -598,8 +596,8 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
         content += "    )\n";
     }
 
-    // ki_description 属性 - 用户输入；留空时不写入
-    const QString symbolDescription = libraryDescription.trimmed();
+    // ki_description 属性 - 单个元器件描述；库描述写入 sym-lib-table
+    const QString symbolDescription = symbolData.info().description.trimmed();
     if (!symbolDescription.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");

--- a/src/core/kicad/ExporterSymbol.cpp
+++ b/src/core/kicad/ExporterSymbol.cpp
@@ -78,7 +78,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
         int index = 0;
         for (const SymbolData& symbol : symbols) {
             qDebug() << "Exporting symbol" << (++index) << "of" << symbols.count() << ":" << symbol.info().name;
-            out << generateSymbolContent(symbol, libName);
+            out << generateSymbolContent(symbol, libName, libraryDescription);
         }
 
         // 生成尾部
@@ -358,7 +358,7 @@ bool ExporterSymbol::exportSymbolLibrary(const QList<SymbolData>& symbols,
     // 再导出新符号和被覆盖的符号
     for (const SymbolData& symbol : symbolsToExport) {
         qDebug() << "Exporting symbol" << (++index) << "of" << symbolsToExport.count() << ":" << symbol.info().name;
-        out << generateSymbolContent(symbol, libName);
+        out << generateSymbolContent(symbol, libName, libraryDescription);
     }
 
     // 生成尾部
@@ -381,7 +381,9 @@ QString ExporterSymbol::generateHeader(const QString& libName) const {
     return header;
 }
 
-QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, const QString& libName) const {
+QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData,
+                                              const QString& libName,
+                                              const QString& libraryDescription) const {
     QString content;
 
     // V6 格式 - 主符号定义（包含属性）
@@ -596,12 +598,13 @@ QString ExporterSymbol::generateSymbolContent(const SymbolData& symbolData, cons
         content += "    )\n";
     }
 
-    // ki_description 属性（仅使用元器件自身描述，库描述写入 sym-lib-table）
-    if (!symbolData.info().description.isEmpty()) {
+    // ki_description 属性 - 用户输入；留空时不写入
+    const QString symbolDescription = libraryDescription.trimmed();
+    if (!symbolDescription.isEmpty()) {
         fieldOffset += 2.54;
         content += QString("    (property\n");
         content += QString("      \"ki_description\"\n");
-        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolData.info().description));
+        content += QString("      \"%1\"\n").arg(escapePropertyValue(symbolDescription));
         content += "      (id 6)\n";
         content +=
             QString("      (at %1 %2 0)\n").arg(graphCenterOffsetX, 0, 'f', 2).arg(yLow - fieldOffset, 0, 'f', 2);

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -81,9 +81,7 @@ private:
      * @param libName 库名称（用于 Footprint 前缀
      * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData,
-                                  const QString& libName,
-                                  const QString& libraryDescription = QString()) const;
+    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -81,7 +81,9 @@ private:
      * @param libName 库名称（用于 Footprint 前缀
      * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
+    QString generateSymbolContent(const SymbolData& symbolData,
+                                  const QString& libName,
+                                  const QString& libraryDescription = QString()) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -51,6 +51,20 @@ public:
                              bool updateMode = false,
                              const QString& libraryDescription = QString());
 
+    /**
+     * @brief 生成 sym-lib-table 文件
+     *
+     * @param libName 库名称
+     * @param libFilePath 符号库文件路径
+     * @param outputDir 输出目录
+     * @param libraryDescription 库描述
+     * @return bool 是否成功
+     */
+    bool generateSymLibTable(const QString& libName,
+                             const QString& libFilePath,
+                             const QString& outputDir,
+                             const QString& libraryDescription = QString());
+
 private:
     /**
      * @brief 生成 KiCad 符号
@@ -58,19 +72,16 @@ private:
      * @param libName 库名称
          * @return QString 头部文本
      */
-    QString generateHeader(const QString& libName, const QString& libraryDescription = QString()) const;
+    QString generateHeader(const QString& libName) const;
 
     /**
      * @brief 生成 KiCad 符号内容
      *
      * @param symbolData 符号数据
      * @param libName 库名称（用于 Footprint 前缀
-     * @param libraryDescription 库描述（用于 ki_description 字段）
-         * @return QString 符号内容
+     * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData,
-                                  const QString& libName,
-                                  const QString& libraryDescription = QString()) const;
+    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -65,9 +65,12 @@ private:
      *
      * @param symbolData 符号数据
      * @param libName 库名称（用于 Footprint 前缀
+     * @param libraryDescription 库描述（用于 ki_description 字段）
          * @return QString 符号内容
      */
-    QString generateSymbolContent(const SymbolData& symbolData, const QString& libName) const;
+    QString generateSymbolContent(const SymbolData& symbolData,
+                                  const QString& libName,
+                                  const QString& libraryDescription = QString()) const;
 
     /**
      * @brief 生成 KiCad 子符号（用于多部分符号）

--- a/src/core/kicad/ExporterSymbol.h
+++ b/src/core/kicad/ExporterSymbol.h
@@ -48,7 +48,8 @@ public:
                              const QString& libName,
                              const QString& filePath,
                              bool appendMode = true,
-                             bool updateMode = false);
+                             bool updateMode = false,
+                             const QString& libraryDescription = QString());
 
 private:
     /**
@@ -57,7 +58,7 @@ private:
      * @param libName 库名称
          * @return QString 头部文本
      */
-    QString generateHeader(const QString& libName) const;
+    QString generateHeader(const QString& libName, const QString& libraryDescription = QString()) const;
 
     /**
      * @brief 生成 KiCad 符号内容

--- a/src/core/kicad/FootprintGraphicsGenerator.cpp
+++ b/src/core/kicad/FootprintGraphicsGenerator.cpp
@@ -517,23 +517,15 @@ QString FootprintGraphicsGenerator::generateModel3D(const Model3DData& model3D,
         rotZ += 360.0;
     }
 
-    // 计算 3D 模型的偏移
-    // 需要区分相对偏移（像素单位）和绝对偏移（毫米单位）两种情况
-    double finalOffsetX, finalOffsetY;
-
-    // 判断是否为绝对偏移（毫米单位）：值很小说明已经转换为毫米
-    if (qAbs(model3D.translation().x) < 100 && qAbs(model3D.translation().y) < 100) {
-        // 绝对偏移：translation 已经是毫米单位
-        // 符号已居中对齐，直接使用绝对偏移值
-        finalOffsetX = model3D.translation().x;
-        finalOffsetY = -model3D.translation().y;  // Y 轴取反
-    } else {
-        // 相对偏移：translation 是像素单位，需要转换为毫米
-        // 计算相对于 bbox 的偏移
-        double offsetX = model3D.translation().x - bboxX;
-        double offsetY = model3D.translation().y - bboxY;
-        finalOffsetX = pxToMmRounded(offsetX);
-        finalOffsetY = -pxToMmRounded(offsetY);  // Y 轴取反
+    // translation 在解析阶段已经统一为 EasyEDA 绝对坐标。
+    const double offsetX = model3D.translation().x - bboxX;
+    const double offsetY = model3D.translation().y - bboxY;
+    double finalOffsetX = pxToMmRounded(offsetX);
+    double finalOffsetY = -pxToMmRounded(offsetY);
+    constexpr double MAX_REASONABLE_MODEL_OFFSET_MM = 50.0;
+    if (qAbs(finalOffsetX) > MAX_REASONABLE_MODEL_OFFSET_MM || qAbs(finalOffsetY) > MAX_REASONABLE_MODEL_OFFSET_MM) {
+        finalOffsetX = 0.0;
+        finalOffsetY = 0.0;
     }
 
     content += QString("  (model \"%1\"\n").arg(finalPath);

--- a/src/core/kicad/KiCadLibTable.cpp
+++ b/src/core/kicad/KiCadLibTable.cpp
@@ -1,0 +1,49 @@
+#include "KiCadLibTable.h"
+
+#include "core/utils/KiCadTableUtils.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+#include <QTextStream>
+
+namespace EasyKiConverter {
+
+bool generateKiCadLibTable(const QString& tableType,
+                           const QString& fileName,
+                           const QString& libName,
+                           const QString& libPath,
+                           const QString& outputDir,
+                           const QString& libraryDescription) {
+    QString filePath = QDir(outputDir).filePath(fileName);
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "Failed to create" << fileName << ":" << filePath;
+        return false;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+
+    QFileInfo libInfo(libPath);
+    QString relativePath = libInfo.fileName();
+
+    out << "(" << tableType << "\n";
+    out << "  (version 7)\n";
+    out << QString("  (lib (name \"%1\")(type \"KiCad\")(uri \"%2\")(options \"\")")
+               .arg(KiCadTableUtils::escapeTableValue(libName), KiCadTableUtils::escapeTableValue(relativePath));
+    if (!libraryDescription.isEmpty()) {
+        out << QString("(descr \"%1\")").arg(KiCadTableUtils::escapeTableValue(libraryDescription));
+    }
+    out << ")\n";
+    out << ")\n";
+
+    file.close();
+    qDebug() << "Generated" << fileName << ":" << filePath;
+    return true;
+}
+
+}  // namespace EasyKiConverter

--- a/src/core/kicad/KiCadLibTable.h
+++ b/src/core/kicad/KiCadLibTable.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QString>
+
+namespace EasyKiConverter {
+
+/**
+ * @brief 生成 KiCad 库表文件（sym-lib-table / fp-lib-table）
+ *
+ * @param tableType 表类型名（"sym_lib_table" 或 "fp_lib_table"）
+ * @param fileName 输出文件名（"sym-lib-table" 或 "fp-lib-table"）
+ * @param libName 库名称
+ * @param libPath 库文件/目录路径
+ * @param outputDir 输出目录
+ * @param libraryDescription 库描述（可选）
+ * @return bool 是否成功
+ */
+bool generateKiCadLibTable(const QString& tableType,
+                           const QString& fileName,
+                           const QString& libName,
+                           const QString& libPath,
+                           const QString& outputDir,
+                           const QString& libraryDescription);
+
+}  // namespace EasyKiConverter

--- a/src/core/network/AsyncNetworkRequest.cpp
+++ b/src/core/network/AsyncNetworkRequest.cpp
@@ -78,6 +78,11 @@ AsyncNetworkRequest::~AsyncNetworkRequest() {
 }
 
 void AsyncNetworkRequest::cancel() {
+    if (thread() != QThread::currentThread()) {
+        QMetaObject::invokeMethod(this, &AsyncNetworkRequest::cancel, Qt::QueuedConnection);
+        return;
+    }
+
     if (!m_cancelled.testAndSetRelaxed(0, 1)) {
         return;
     }
@@ -88,19 +93,14 @@ void AsyncNetworkRequest::cancel() {
         m_timeoutTimer->stop();
     }
 
-    bool shouldCompleteImmediately = false;
     {
         QMutexLocker locker(&m_repliesMutex);
         if (m_currentReply && !m_currentReply->isFinished()) {
             m_currentReply->abort();
-        } else {
-            shouldCompleteImmediately = true;
         }
     }
 
-    if (shouldCompleteImmediately) {
-        completeWithResult(cancelledResult());
-    }
+    completeWithResult(cancelledResult());
 }
 
 bool AsyncNetworkRequest::isCancelled() const {

--- a/src/core/network/NetworkClient.cpp
+++ b/src/core/network/NetworkClient.cpp
@@ -58,22 +58,7 @@ NetworkClient::NetworkClient() {
 }
 
 NetworkClient::~NetworkClient() {
-    QList<QPointer<AsyncNetworkRequest>> pendingRequests;
-    {
-        QMutexLocker locker(&m_asyncQueueMutex);
-        for (const PendingAsyncRequest& pending : std::as_const(m_pendingAsyncRequests)) {
-            pendingRequests.append(pending.request);
-        }
-        m_pendingAsyncRequests.clear();
-    }
-
-    for (const QPointer<AsyncNetworkRequest>& request : pendingRequests) {
-        if (!request) {
-            continue;
-        }
-        request->cancel();
-        QMetaObject::invokeMethod(request, &QObject::deleteLater, Qt::QueuedConnection);
-    }
+    cancelAllRequests();
 
     if (m_asyncNetworkManager) {
         QMetaObject::invokeMethod(m_asyncNetworkManager, &QObject::deleteLater, Qt::QueuedConnection);
@@ -256,6 +241,7 @@ AsyncNetworkRequest* NetworkClient::enqueueAsyncRequest(const QUrl& url,
         pending.sequence = m_asyncSequence++;
         pending.enqueuedAtMs = QDateTime::currentMSecsSinceEpoch();
         m_pendingAsyncRequests.append(pending);
+        m_liveAsyncRequests.append(request);
         updateStatsForEnqueuedRequest(resourceType);
     }
 
@@ -263,8 +249,12 @@ AsyncNetworkRequest* NetworkClient::enqueueAsyncRequest(const QUrl& url,
         request,
         &AsyncNetworkRequest::finished,
         this,
-        [this, resourceType](const NetworkResult& result) {
+        [this, request, resourceType](const NetworkResult& result) {
             updateStatsForCompletedRequest(resourceType, result);
+            {
+                QMutexLocker locker(&m_asyncQueueMutex);
+                m_liveAsyncRequests.removeAll(request);
+            }
             onAsyncRequestFinished(resourceType);
         },
         Qt::QueuedConnection);
@@ -354,6 +344,32 @@ void NetworkClient::pumpAsyncQueue() {
                 }
             },
             Qt::QueuedConnection);
+    }
+}
+
+void NetworkClient::cancelAllRequests() {
+    QList<QPointer<AsyncNetworkRequest>> requestsToCancel;
+    {
+        QMutexLocker locker(&m_asyncQueueMutex);
+        requestsToCancel = m_liveAsyncRequests;
+        m_pendingAsyncRequests.clear();
+        m_asyncPumpScheduled = false;
+    }
+
+    for (const QPointer<AsyncNetworkRequest>& request : std::as_const(requestsToCancel)) {
+        if (!request || request->isFinished()) {
+            continue;
+        }
+
+        if (request->thread() == QThread::currentThread()) {
+            request->cancel();
+        } else if (QThread::currentThread() == &m_networkThread) {
+            request->cancel();
+        } else {
+            const Qt::ConnectionType connectionType =
+                m_networkThread.isRunning() ? Qt::BlockingQueuedConnection : Qt::QueuedConnection;
+            QMetaObject::invokeMethod(request, &AsyncNetworkRequest::cancel, connectionType);
+        }
     }
 }
 

--- a/src/core/network/NetworkClient.h
+++ b/src/core/network/NetworkClient.h
@@ -106,6 +106,14 @@ public:
     QString formatRuntimeStats() const override;
 
     /**
+     * @brief Cancel all queued and active async requests managed by this client.
+     *
+     * This is used during export/application cancellation to unblock synchronous
+     * callers that are waiting on NetworkClient::get()/post().
+     */
+    void cancelAllRequests();
+
+    /**
      * @brief 检查数据是否为 gzip 压缩格式
      */
     static bool isGzipCompressed(const QByteArray& data);
@@ -163,6 +171,7 @@ private:
     QNetworkAccessManager* m_asyncNetworkManager = nullptr;
     mutable QMutex m_asyncQueueMutex;
     QList<PendingAsyncRequest> m_pendingAsyncRequests;
+    QList<QPointer<AsyncNetworkRequest>> m_liveAsyncRequests;
     QHash<int, int> m_activeAsyncRequestsByType;
     QHash<int, MutableResourceStats> m_resourceStats;
     quint64 m_asyncSequence = 0;

--- a/src/core/utils/CMakeLists.txt
+++ b/src/core/utils/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(EasyKiConverterUtils STATIC
     SvgPathParser.cpp
     AtomicFileWriter.cpp
     GzipUtils.cpp
+    KiCadTableUtils.cpp
     UrlUtils.cpp
 )
 

--- a/src/core/utils/KiCadTableUtils.cpp
+++ b/src/core/utils/KiCadTableUtils.cpp
@@ -1,0 +1,14 @@
+#include "KiCadTableUtils.h"
+
+namespace EasyKiConverter {
+namespace KiCadTableUtils {
+
+QString escapeTableValue(const QString& value) {
+    QString escaped = value;
+    escaped.replace("\\", "\\\\");
+    escaped.replace("\"", "\\\"");
+    return escaped;
+}
+
+}  // namespace KiCadTableUtils
+}  // namespace EasyKiConverter

--- a/src/core/utils/KiCadTableUtils.h
+++ b/src/core/utils/KiCadTableUtils.h
@@ -1,0 +1,14 @@
+#ifndef KICADTABLEUTILS_H
+#define KICADTABLEUTILS_H
+
+#include <QString>
+
+namespace EasyKiConverter {
+namespace KiCadTableUtils {
+
+QString escapeTableValue(const QString& value);
+
+}  // namespace KiCadTableUtils
+}  // namespace EasyKiConverter
+
+#endif  // KICADTABLEUTILS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -274,7 +274,7 @@ int main(int argc, char* argv[]) {
         // 纯 CLI 模式：使用 QCoreApplication
         QCoreApplication app(argc, argv);
         app.setApplicationName("EasyKiConverter");
-        app.setApplicationVersion("3.1.6");
+        app.setApplicationVersion("3.1.7");
         app.setOrganizationName("EasyKiConverter");
         app.setOrganizationDomain("easykiconverter.com");
 
@@ -433,7 +433,7 @@ int main(int argc, char* argv[]) {
 
     // 设置应用程序信息
     app.setApplicationName("EasyKiConverter");
-    app.setApplicationVersion("3.1.6");
+    app.setApplicationVersion("3.1.7");
     app.setOrganizationName("EasyKiConverter");
     app.setOrganizationDomain("easykiconverter.com");
 

--- a/src/models/ComponentListItemData.cpp
+++ b/src/models/ComponentListItemData.cpp
@@ -29,6 +29,17 @@ void ComponentListItemData::setPackage(const QString& package) {
     }
 }
 
+void ComponentListItemData::setDescription(const QString& description) {
+    m_descriptionEdited = true;
+    if (m_description != description) {
+        m_description = description;
+        applyDescriptionToComponentData();
+        emit dataChanged();
+        return;
+    }
+    applyDescriptionToComponentData();
+}
+
 void ComponentListItemData::setNameSilent(const QString& name) {
     m_name = name;
 }
@@ -44,8 +55,29 @@ void ComponentListItemData::setComponentData(const QSharedPointer<ComponentData>
             setName(data->name());
         if (!data->package().isEmpty())
             setPackage(data->package());
+        if (!m_descriptionEdited) {
+            m_description = data->name();
+        }
+        applyDescriptionToComponentData();
     }
     emit dataChanged();
+}
+
+void ComponentListItemData::applyDescriptionToComponentData() {
+    if (!m_componentData) {
+        return;
+    }
+
+    if (m_componentData->symbolData()) {
+        SymbolInfo info = m_componentData->symbolData()->info();
+        info.description = m_description;
+        m_componentData->symbolData()->setInfo(info);
+    }
+    if (m_componentData->footprintData()) {
+        FootprintInfo info = m_componentData->footprintData()->info();
+        info.description = m_description;
+        m_componentData->footprintData()->setInfo(info);
+    }
 }
 
 void ComponentListItemData::setValid(bool valid) {

--- a/src/models/ComponentListItemData.h
+++ b/src/models/ComponentListItemData.h
@@ -21,6 +21,7 @@ class ComponentListItemData : public QObject {
     Q_PROPERTY(QString componentId READ componentId CONSTANT)
     Q_PROPERTY(QString name READ name NOTIFY dataChanged)
     Q_PROPERTY(QString package READ package NOTIFY dataChanged)
+    Q_PROPERTY(QString description READ description NOTIFY dataChanged)
     Q_PROPERTY(QVariantList previewImages READ previewImages NOTIFY previewImagesChanged)
     Q_PROPERTY(int previewImageCount READ previewImageCount NOTIFY previewImagesChanged)
     Q_PROPERTY(bool isValid READ isValid NOTIFY validationStatusChanged)
@@ -52,6 +53,10 @@ public:
 
     QString package() const {
         return m_package;
+    }
+
+    QString description() const {
+        return m_description;
     }
 
     QVariantList previewImages() const;
@@ -95,6 +100,7 @@ public:
     // Setter 方法
     void setName(const QString& name);
     void setPackage(const QString& package);
+    void setDescription(const QString& description);
     void setNameSilent(const QString& name);
     void setPackageSilent(const QString& package);
     void addPreviewImage(const QImage& image);
@@ -134,10 +140,13 @@ signals:
 
 private:
     void updatePreviewImagesCache() const;
+    void applyDescriptionToComponentData();
 
     QString m_componentId;
     QString m_name;
     QString m_package;
+    QString m_description;
+    bool m_descriptionEdited = false;
     QList<QImage> m_previewImages;
     mutable QVariantList m_previewImagesCache;
     bool m_isValid;

--- a/src/models/FootprintData.h
+++ b/src/models/FootprintData.h
@@ -17,6 +17,7 @@ struct FootprintInfo {
     QString name;
     QString type;
     QString model3DName;
+    QString description;
 
     // EasyEDA API 原始字段
     QString uuid;

--- a/src/models/FootprintDataSerializer.cpp
+++ b/src/models/FootprintDataSerializer.cpp
@@ -12,6 +12,7 @@ QJsonObject FootprintDataSerializer::toJson(const FootprintInfo& info) {
     json["name"] = info.name;
     json["type"] = info.type;
     json["model_3d_name"] = info.model3DName;
+    json["description"] = info.description;
 
     // EasyEDA API 原始字段
     json["uuid"] = info.uuid;
@@ -51,6 +52,7 @@ bool FootprintDataSerializer::fromJson(FootprintInfo& info, const QJsonObject& j
     info.name = json["name"].toString();
     info.type = json["type"].toString();
     info.model3DName = json["model_3d_name"].toString();
+    info.description = json["description"].toString();
 
     // EasyEDA API 原始字段
     info.uuid = json["uuid"].toString();

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -243,7 +243,7 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
         }
 
         if (!result.success) {
-            emit fetchError(result.componentId, result.errorMessage);
+            emitFetchErrorAndClearState(result.componentId, result.errorMessage);
             return;
         }
 
@@ -317,6 +317,13 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
             }
         }
 
+        if (!result.symbolData || !result.footprintData) {
+            qWarning() << "Cache load incomplete for" << normalizedId << "- symbol:" << (result.symbolData != nullptr)
+                       << "footprint:" << (result.footprintData != nullptr);
+            result.success = false;
+            return result;
+        }
+
         result.cachedData = cachedData;
         result.success = true;
 
@@ -369,7 +376,7 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
                 }
 
                 if (!result.success) {
-                    emit fetchError(result.componentId, result.errorMessage);
+                    emitFetchErrorAndClearState(result.componentId, result.errorMessage);
                     return;
                 }
 
@@ -777,7 +784,7 @@ void ComponentService::handleCadDataFetched(const QString& componentId, const QJ
         watcher->deleteLater();
 
         if (!parsed.success) {
-            emit fetchError(parsed.componentId, parsed.errorMessage);
+            emitFetchErrorAndClearState(parsed.componentId, parsed.errorMessage);
             return;
         }
 
@@ -806,15 +813,7 @@ void ComponentService::handleCadDataFetched(const QString& componentId, const QJ
 }
 
 void ComponentService::handleFetchError(const QString& errorMessage) {
-    qDebug() << "Fetch error:" << errorMessage;
-
-    // 如果在并行模式下，处理并行错误
-    if (m_parallelContext != nullptr) {
-        handleParallelFetchError(m_currentComponentId, errorMessage);
-    }
-
-    // 最后发送信号，防止信号连接的槽函数删除了本对象导致后续访问成员变量崩溃
-    emit fetchError(m_currentComponentId, errorMessage);
+    emitFetchErrorAndClearState(m_currentComponentId, errorMessage);
 }
 
 void ComponentService::handleFetchErrorWithId(const QString& idOrUuid, const QString& error) {
@@ -833,14 +832,7 @@ void ComponentService::handleFetchErrorWithId(const QString& idOrUuid, const QSt
         }
     }
 
-    qDebug() << "Fetch error for component:" << componentId << "Error:" << error;
-
-    // 如果在并行模式下，处理并行错误
-    if (m_parallelContext != nullptr) {
-        handleParallelFetchError(componentId, error);
-    }
-
-    emit fetchError(componentId, error);
+    emitFetchErrorAndClearState(componentId, error);
 }
 
 void ComponentService::setOutputPath(const QString& path) {
@@ -1020,11 +1012,24 @@ void ComponentService::cancelRequestForComponent(const QString& componentId) {
     qDebug() << "ComponentService: Request cancelled for component" << normalizedId;
 }
 
-void ComponentService::handleFetchErrorForComponent(const QString& componentId, const QString& error) {
+void ComponentService::emitFetchErrorAndClearState(const QString& componentId, const QString& error) {
     qWarning() << "Fetch error for component" << componentId << ":" << error;
-    if (m_parallelContext != nullptr) {
-        handleParallelFetchError(componentId, error);
+
+    {
+        QMutexLocker locker(&m_fetchingComponentsMutex);
+        m_fetchingComponents.remove(componentId);
     }
+    {
+        QMutexLocker locker(&m_componentCacheMutex);
+        const auto it = m_componentCache.find(componentId);
+        if (it != m_componentCache.end() && !it.value().isValid()) {
+            m_componentCache.erase(it);
+        }
+    }
+
+    handleParallelFetchError(componentId, error);
+
+    // fetchError 必须最后发送，因为连接的槽函数可能会删除本对象
     emit fetchError(componentId, error);
 }
 

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -954,6 +954,24 @@ void ComponentService::updateComponentCache(const QString& componentId, const Co
     qDebug() << "ComponentService: Updated cache for" << componentId;
 }
 
+void ComponentService::updateComponentDescription(const QString& componentId, const QString& description) {
+    QMutexLocker locker(&m_componentCacheMutex);
+    auto it = m_componentCache.find(componentId);
+    if (it == m_componentCache.end()) {
+        return;
+    }
+    if (it->symbolData()) {
+        SymbolInfo info = it->symbolData()->info();
+        info.description = description;
+        it->symbolData()->setInfo(info);
+    }
+    if (it->footprintData()) {
+        FootprintInfo info = it->footprintData()->info();
+        info.description = description;
+        it->footprintData()->setInfo(info);
+    }
+}
+
 void ComponentService::clearCache() {
     m_componentCache.clear();
 

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -405,6 +405,15 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
         }
         if (result.footprintData) {
             result.cachedData->setFootprintData(result.footprintData);
+            const Model3DData parsedModel3D = result.footprintData->model3D();
+            if (!parsedModel3D.uuid().isEmpty()) {
+                auto model3DData = QSharedPointer<Model3DData>::create();
+                model3DData->setUuid(parsedModel3D.uuid());
+                model3DData->setName(parsedModel3D.name());
+                model3DData->setTranslation(parsedModel3D.translation());
+                model3DData->setRotation(parsedModel3D.rotation());
+                result.cachedData->setModel3DData(model3DData);
+            }
         }
 
         // 更新 m_fetchingComponents
@@ -976,6 +985,8 @@ void ComponentService::cancelAllPreviewImageFetches() {
 
 void ComponentService::cancelAllPendingRequests() {
     qDebug() << "ComponentService: Cancelling all pending component data requests";
+
+    NetworkClient::instance().cancelAllRequests();
 
     // 清空正在获取的组件记录，防止响应到达时更新已清除的数据
     {

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -301,11 +301,20 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
         }
 
         // 从 metadata.json 恢复 model3DData
+        // 注意：loadComponentData 已经加载了 model3DData（包含 name、translation、rotation）
+        // 这里只在没有 model3DData 或 UUID 缺失时进行补充，不要覆盖已有数据
         QJsonObject metadata = cache->loadMetadata(normalizedId);
         if (metadata.contains("model3duuid")) {
-            auto model3DData = QSharedPointer<Model3DData>::create();
-            model3DData->setUuid(metadata.value("model3duuid").toString());
-            cachedData->setModel3DData(model3DData);
+            const QString uuid = metadata.value("model3duuid").toString();
+            if (!uuid.isEmpty()) {
+                if (!cachedData->model3DData()) {
+                    auto model3DData = QSharedPointer<Model3DData>::create();
+                    model3DData->setUuid(uuid);
+                    cachedData->setModel3DData(model3DData);
+                } else if (cachedData->model3DData()->uuid().isEmpty()) {
+                    cachedData->model3DData()->setUuid(uuid);
+                }
+            }
         }
 
         result.cachedData = cachedData;

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -130,6 +130,13 @@ public:
     void updateComponentCache(const QString& componentId, const ComponentData& data);
 
     /**
+     * @brief 更新元件的符号/封装描述
+     * @param componentId 元件ID
+     * @param description 用户编辑后的描述
+     */
+    void updateComponentDescription(const QString& componentId, const QString& description);
+
+    /**
      * @brief 取消所有正在进行的预览图获取操作
      *
      * 当用户点击开始导出时调用，以确保取消所有未完成的预览图获取工作

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -339,7 +339,7 @@ private:
      * @param componentId 元件ID
      * @param error 错误信息
      */
-    void handleFetchErrorForComponent(const QString& componentId, const QString& error);
+    void emitFetchErrorAndClearState(const QString& componentId, const QString& error);
 
     /**
      * @brief 处理并行数据收集完成

--- a/src/services/ConfigService.cpp
+++ b/src/services/ConfigService.cpp
@@ -279,6 +279,10 @@ void ConfigService::setDarkMode(bool enabled) {
     QMutexLocker locker(&m_configMutex);
     m_config["darkMode"] = enabled;
     emit configChanged();
+
+    // 释放锁后保存
+    locker.unlock();
+    saveConfig();
 }
 
 bool ConfigService::getDebugMode() const {

--- a/src/services/export/CMakeLists.txt
+++ b/src/services/export/CMakeLists.txt
@@ -19,6 +19,7 @@ set(EXPORT_HEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/ComponentDataCache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/TempFileManager.h
     ${CMAKE_CURRENT_SOURCE_DIR}/DebugExportHelper.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/KiCadLibraryTableManager.h
     PARENT_SCOPE
 )
 
@@ -40,5 +41,6 @@ set(EXPORT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ExportWorkerHelpers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TempFileManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/DebugExportHelper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/KiCadLibraryTableManager.cpp
     PARENT_SCOPE
 )

--- a/src/services/export/ExportProgress.h
+++ b/src/services/export/ExportProgress.h
@@ -47,6 +47,11 @@ struct ExportOptions {
     bool weakNetworkSupport = false;  ///< 是否启用客户端弱网络适配
     bool updateMode = false;  ///< 更新模式：仅导出缺失或已更改的文件
     bool debugMode = false;  ///< 调试模式：输出详细调试信息
+    bool exportSymbolDescription = true;  ///< 是否导出符号库描述 (ki_description)
+    bool exportFootprintDescription = true;  ///< 是否导出封装库描述 (descr)
+    QString symbolLibraryDescription;  ///< 用户输入的符号库描述文本
+    QString footprintLibraryDescription;  ///< 用户输入的封装库描述文本
+    QString footprintLibraryKeywords;  ///< 用户输入的封装库关键词文本
 };
 
 /**

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -154,6 +154,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
 
     if (m_cancelled.load()) {
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
@@ -161,6 +162,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (footprintList.isEmpty()) {
         qWarning() << "FootprintExportStage: No valid footprints to export";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
@@ -179,6 +181,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (!dir.mkpath(outputDir)) {
         qCritical() << "FootprintExportStage: Failed to create output directory:" << outputDir;
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -188,6 +191,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (tempDirPath.isEmpty()) {
         qCritical() << "FootprintExportStage: Failed to create temp dir path";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -196,14 +200,13 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 5. 执行封装库导出
     bool exportSuccess = false;
-    QString libraryDescription =
-        m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
+    QString libraryDescription = m_options.footprintLibraryDescription;
     {
         ExporterFootprint exporter;
         // 传入3D模型格式标志：WRL和STEP可以同时导出，生成两个 (model ...) 块
         const bool preferWrl = m_options.needsModel3DWrl();
         const bool exportStep = m_options.needsModel3DStep();
-        QString libraryKeywords = m_options.exportFootprintDescription ? m_options.footprintLibraryKeywords : QString();
+        QString libraryKeywords = m_options.footprintLibraryKeywords;
         exportSuccess = exporter.exportFootprintLibrary(
             footprintList, libName, tempDirPath, preferWrl, exportStep, libraryDescription, libraryKeywords);
     }
@@ -211,6 +214,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
     if (m_cancelled.load()) {
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -219,6 +223,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         qCritical() << "FootprintExportStage: Failed to export footprint library";
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }
@@ -230,6 +235,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         qCritical() << "FootprintExportStage: Failed to commit temp dir";
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
     }

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -200,7 +200,11 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         // 传入3D模型格式标志：WRL和STEP可以同时导出，生成两个 (model ...) 块
         const bool preferWrl = m_options.needsModel3DWrl();
         const bool exportStep = m_options.needsModel3DStep();
-        exportSuccess = exporter.exportFootprintLibrary(footprintList, libName, tempDirPath, preferWrl, exportStep);
+        QString libraryDescription =
+            m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
+        QString libraryKeywords = m_options.exportFootprintDescription ? m_options.footprintLibraryKeywords : QString();
+        exportSuccess = exporter.exportFootprintLibrary(
+            footprintList, libName, tempDirPath, preferWrl, exportStep, libraryDescription, libraryKeywords);
     }
 
     if (m_cancelled.load()) {

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -1,5 +1,6 @@
 #include "FootprintExportStage.h"
 
+#include "KiCadLibraryTableManager.h"
 #include "core/kicad/ExporterFootprint.h"
 #include "models/ComponentData.h"
 
@@ -195,13 +196,13 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 5. 执行封装库导出
     bool exportSuccess = false;
+    QString libraryDescription =
+        m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
     {
         ExporterFootprint exporter;
         // 传入3D模型格式标志：WRL和STEP可以同时导出，生成两个 (model ...) 块
         const bool preferWrl = m_options.needsModel3DWrl();
         const bool exportStep = m_options.needsModel3DStep();
-        QString libraryDescription =
-            m_options.exportFootprintDescription ? m_options.footprintLibraryDescription : QString();
         QString libraryKeywords = m_options.exportFootprintDescription ? m_options.footprintLibraryKeywords : QString();
         exportSuccess = exporter.exportFootprintLibrary(
             footprintList, libName, tempDirPath, preferWrl, exportStep, libraryDescription, libraryKeywords);
@@ -231,6 +232,13 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         m_isExporting.store(false);
         emit completed(0, footprintList.size(), 0);
         return;
+    }
+
+    // 6.1 生成 fp-lib-table 文件（如果提供了库描述）
+    if (!libraryDescription.isEmpty()) {
+        ExporterFootprint fpTableExporter;
+        fpTableExporter.generateFpLibTable(libName, finalDir, outputDir, libraryDescription);
+        KiCadLibraryTableManager::registerFootprintLibrary(outputDir, libName, finalDir, libraryDescription);
     }
 
     // 7. 清理临时目录

--- a/src/services/export/FootprintExportWorker.cpp
+++ b/src/services/export/FootprintExportWorker.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
-#include <QtConcurrent>
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 
@@ -81,9 +81,10 @@ void FootprintExportWorker::run() {
             qDebug() << "FootprintExportWorker: Successfully exported" << filePath;
 
             if (m_options.debugMode) {
-                QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
-                    DebugExportHelper::exportDebugData(componentId, data, outputPath);
-                });
+                QThreadPool::globalInstance()->start(
+                    [componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+                        DebugExportHelper::exportDebugData(componentId, data, outputPath);
+                    });
             }
 
             emit completed(m_componentId, true, QString());

--- a/src/services/export/KiCadLibraryTableManager.cpp
+++ b/src/services/export/KiCadLibraryTableManager.cpp
@@ -1,0 +1,217 @@
+#include "KiCadLibraryTableManager.h"
+
+#include "core/utils/KiCadTableUtils.h"
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QTextStream>
+
+namespace EasyKiConverter {
+
+KiCadLibraryTableManager::RegistrationResult KiCadLibraryTableManager::registerSymbolLibrary(
+    const QString& outputDir,
+    const QString& libName,
+    const QString& libFilePath,
+    const QString& libraryDescription) {
+    const QString projectRoot = findKiCadProjectRoot(outputDir);
+    if (projectRoot.isEmpty()) {
+        return writeImportGuide(outputDir) ? RegistrationResult::ImportGuideWritten : RegistrationResult::Failed;
+    }
+
+    const QString uri = makeProjectUri(projectRoot, libFilePath);
+    return updateProjectLibraryTable(projectRoot,
+                                     QStringLiteral("sym-lib-table"),
+                                     QStringLiteral("sym_lib_table"),
+                                     libName,
+                                     uri,
+                                     libraryDescription)
+               ? RegistrationResult::Registered
+               : RegistrationResult::Failed;
+}
+
+KiCadLibraryTableManager::RegistrationResult KiCadLibraryTableManager::registerFootprintLibrary(
+    const QString& outputDir,
+    const QString& libName,
+    const QString& libDirPath,
+    const QString& libraryDescription) {
+    const QString projectRoot = findKiCadProjectRoot(outputDir);
+    if (projectRoot.isEmpty()) {
+        return writeImportGuide(outputDir) ? RegistrationResult::ImportGuideWritten : RegistrationResult::Failed;
+    }
+
+    const QString uri = makeProjectUri(projectRoot, libDirPath);
+    return updateProjectLibraryTable(projectRoot,
+                                     QStringLiteral("fp-lib-table"),
+                                     QStringLiteral("fp_lib_table"),
+                                     libName,
+                                     uri,
+                                     libraryDescription)
+               ? RegistrationResult::Registered
+               : RegistrationResult::Failed;
+}
+
+bool KiCadLibraryTableManager::writeImportGuide(const QString& outputDir) {
+    QDir dir(outputDir);
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        qWarning() << "KiCadLibraryTableManager: Failed to create output directory for import guide:" << outputDir;
+        return false;
+    }
+
+    const QString guidePath = dir.filePath(QStringLiteral("KiCad_IMPORT.md"));
+    QSaveFile file(guidePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "KiCadLibraryTableManager: Failed to open import guide:" << guidePath;
+        return false;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+
+    out << "# KiCad Library Import\n\n";
+    out << "EasyKiConverter did not find a KiCad project (`*.kicad_pro`) in this output path or its parent "
+           "directories, so it did not modify any project library table.\n\n";
+    out << "To show library descriptions in KiCad, add the exported libraries to the target project's library "
+           "tables or to KiCad's global library tables.\n\n";
+
+    const QString symTablePath = dir.filePath(QStringLiteral("sym-lib-table"));
+    if (QFileInfo::exists(symTablePath)) {
+        out << "## Symbol Library Entry\n\n";
+        out << "Use the entry from:\n\n";
+        out << "```text\n" << symTablePath << "\n```\n\n";
+    }
+
+    const QString fpTablePath = dir.filePath(QStringLiteral("fp-lib-table"));
+    if (QFileInfo::exists(fpTablePath)) {
+        out << "## Footprint Library Entry\n\n";
+        out << "Use the entry from:\n\n";
+        out << "```text\n" << fpTablePath << "\n```\n\n";
+    }
+
+    out << "Project-specific KiCad library tables are named `sym-lib-table` and `fp-lib-table` and live next to the "
+           "project's `.kicad_pro` file.\n";
+
+    if (!file.commit()) {
+        qWarning() << "KiCadLibraryTableManager: Failed to commit import guide:" << guidePath;
+        return false;
+    }
+
+    return true;
+}
+
+QString KiCadLibraryTableManager::findKiCadProjectRoot(const QString& outputDir) {
+    QDir dir(QFileInfo(outputDir).absoluteFilePath());
+    if (!dir.exists()) {
+        return QString();
+    }
+
+    while (true) {
+        const QStringList projectFiles = dir.entryList(QStringList(QStringLiteral("*.kicad_pro")), QDir::Files);
+        if (!projectFiles.isEmpty()) {
+            return dir.absolutePath();
+        }
+
+        if (!dir.cdUp()) {
+            break;
+        }
+    }
+
+    return QString();
+}
+
+bool KiCadLibraryTableManager::updateProjectLibraryTable(const QString& projectRoot,
+                                                         const QString& tableFileName,
+                                                         const QString& tableRootName,
+                                                         const QString& libName,
+                                                         const QString& uri,
+                                                         const QString& libraryDescription) {
+    QDir projectDir(projectRoot);
+    const QString tablePath = projectDir.filePath(tableFileName);
+
+    QString content;
+    QFile existingFile(tablePath);
+    if (existingFile.exists()) {
+        if (!existingFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            qWarning() << "KiCadLibraryTableManager: Failed to read library table:" << tablePath;
+            return false;
+        }
+        QTextStream in(&existingFile);
+        in.setEncoding(QStringConverter::Utf8);
+        content = in.readAll();
+    }
+
+    if (content.trimmed().isEmpty()) {
+        content = QStringLiteral("(%1\n  (version 7)\n)\n").arg(tableRootName);
+    }
+
+    QStringList lines = content.split('\n');
+    const QRegularExpression entryRegex(
+        QStringLiteral(R"(^\s*\(lib\s+\(name\s+"?%1"?\))").arg(QRegularExpression::escape(libName)));
+
+    QStringList filteredLines;
+    filteredLines.reserve(lines.size() + 1);
+    for (const QString& line : lines) {
+        if (!entryRegex.match(line).hasMatch()) {
+            filteredLines.append(line);
+        }
+    }
+
+    int insertIndex = filteredLines.size();
+    while (insertIndex > 0 && filteredLines.at(insertIndex - 1).trimmed().isEmpty()) {
+        --insertIndex;
+    }
+    if (insertIndex > 0 && filteredLines.at(insertIndex - 1).trimmed() == QStringLiteral(")")) {
+        --insertIndex;
+    }
+
+    filteredLines.insert(insertIndex, makeLibraryEntry(libName, uri, libraryDescription));
+    QString updatedContent = filteredLines.join('\n');
+    if (!updatedContent.endsWith('\n')) {
+        updatedContent += '\n';
+    }
+
+    QSaveFile file(tablePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "KiCadLibraryTableManager: Failed to write library table:" << tablePath;
+        return false;
+    }
+
+    QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
+    out << updatedContent;
+    if (!file.commit()) {
+        qWarning() << "KiCadLibraryTableManager: Failed to commit library table:" << tablePath;
+        return false;
+    }
+
+    qDebug() << "KiCadLibraryTableManager: Updated project library table:" << tablePath;
+    return true;
+}
+
+QString KiCadLibraryTableManager::makeLibraryEntry(const QString& libName,
+                                                   const QString& uri,
+                                                   const QString& libraryDescription) {
+    QString entry = QStringLiteral("  (lib (name \"%1\")(type \"KiCad\")(uri \"%2\")(options \"\")")
+                        .arg(KiCadTableUtils::escapeTableValue(libName), KiCadTableUtils::escapeTableValue(uri));
+    if (!libraryDescription.isEmpty()) {
+        entry += QStringLiteral("(descr \"%1\")").arg(KiCadTableUtils::escapeTableValue(libraryDescription));
+    } else {
+        entry += QStringLiteral("(descr \"\")");
+    }
+    entry += QStringLiteral(")");
+    return entry;
+}
+
+QString KiCadLibraryTableManager::makeProjectUri(const QString& projectRoot, const QString& libraryPath) {
+    QString relativePath = QDir(projectRoot).relativeFilePath(QFileInfo(libraryPath).absoluteFilePath());
+    relativePath.replace(QDir::separator(), QLatin1Char('/'));
+    if (relativePath == QStringLiteral(".")) {
+        return QStringLiteral("${KIPRJMOD}");
+    }
+    return QStringLiteral("${KIPRJMOD}/%1").arg(relativePath);
+}
+
+}  // namespace EasyKiConverter

--- a/src/services/export/KiCadLibraryTableManager.h
+++ b/src/services/export/KiCadLibraryTableManager.h
@@ -1,0 +1,43 @@
+#ifndef KICADLIBRARYTABLEMANAGER_H
+#define KICADLIBRARYTABLEMANAGER_H
+
+#include <QString>
+
+namespace EasyKiConverter {
+
+class KiCadLibraryTableManager {
+public:
+    enum class RegistrationResult {
+        Registered,
+        ImportGuideWritten,
+        Failed,
+    };
+
+    static RegistrationResult registerSymbolLibrary(const QString& outputDir,
+                                                    const QString& libName,
+                                                    const QString& libFilePath,
+                                                    const QString& libraryDescription);
+
+    static RegistrationResult registerFootprintLibrary(const QString& outputDir,
+                                                       const QString& libName,
+                                                       const QString& libDirPath,
+                                                       const QString& libraryDescription);
+
+private:
+    static bool writeImportGuide(const QString& outputDir);
+    static QString findKiCadProjectRoot(const QString& outputDir);
+
+    static bool updateProjectLibraryTable(const QString& projectRoot,
+                                          const QString& tableFileName,
+                                          const QString& tableRootName,
+                                          const QString& libName,
+                                          const QString& uri,
+                                          const QString& libraryDescription);
+
+    static QString makeLibraryEntry(const QString& libName, const QString& uri, const QString& libraryDescription);
+    static QString makeProjectUri(const QString& projectRoot, const QString& libraryPath);
+};
+
+}  // namespace EasyKiConverter
+
+#endif  // KICADLIBRARYTABLEMANAGER_H

--- a/src/services/export/Model3DExportWorker.cpp
+++ b/src/services/export/Model3DExportWorker.cpp
@@ -160,7 +160,7 @@ void Model3DExportWorker::run() {
     if ((!needWrl || wrlFromCache) && (!needStep || stepFromCache)) {
         qDebug() << "Model3DExportWorker: Both WRL and STEP loaded from cache for" << m_componentId;
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+            (void)QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }
@@ -229,7 +229,7 @@ void Model3DExportWorker::run() {
                  << "for" << m_componentId;
 
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+            (void)QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }

--- a/src/services/export/PreviewImagesExportWorker.cpp
+++ b/src/services/export/PreviewImagesExportWorker.cpp
@@ -171,7 +171,7 @@ void PreviewImagesExportWorker::run() {
         qDebug() << "PreviewImagesExportWorker: Successfully exported all previews for" << m_componentId;
 
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+            (void)QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -1,6 +1,7 @@
 #include "SymbolExportStage.h"
 
 #include "DebugExportHelper.h"
+#include "KiCadLibraryTableManager.h"
 #include "core/kicad/ExporterSymbol.h"
 #include "models/ComponentData.h"
 
@@ -10,7 +11,7 @@
 #include <QFile>
 #include <QMutexLocker>
 #include <QThread>
-#include <QtConcurrent>
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 
@@ -151,7 +152,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         emit itemStatusChanged(componentId, status);
 
         if (m_options.debugMode) {
-            QtConcurrent::run([componentId, data, outputPath = m_options.outputPath]() {
+            QThreadPool::globalInstance()->start([componentId, data, outputPath = m_options.outputPath]() {
                 DebugExportHelper::exportDebugData(componentId, data, outputPath);
             });
         }
@@ -218,11 +219,10 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 6. 执行符号库导出
     bool exportSuccess = false;
+    QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
     {
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
-        QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
-        qDebug() << "SymbolExportStage: libraryDescription=" << libraryDescription;
         exportSuccess = exporter.exportSymbolLibrary(
             symbolList, libName, tempPath, appendMode, m_options.updateMode, libraryDescription);
     }
@@ -251,6 +251,13 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         m_isExporting.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
+    }
+
+    // 7.1 生成 sym-lib-table 文件（如果提供了库描述）
+    if (!libraryDescription.isEmpty()) {
+        ExporterSymbol symTableExporter;
+        symTableExporter.generateSymLibTable(libName, finalPath, outputDir, libraryDescription);
+        KiCadLibraryTableManager::registerSymbolLibrary(outputDir, libName, finalPath, libraryDescription);
     }
 
     // 8. 清理临时目录

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -9,6 +9,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QMutexLocker>
 #include <QThread>
 #include <QThreadPool>
@@ -121,7 +122,6 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         if (it == cachedData.end() || !it.value()) {
             qWarning() << "SymbolExportStage: No data for component:" << componentId;
             failedIds.append(componentId);
-            // 发射 itemStatusChanged 信号通知 ViewModel
             ExportItemStatus status;
             status.status = ExportItemStatus::Status::Failed;
             status.errorMessage = "No component data";
@@ -131,11 +131,9 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
         QSharedPointer<ComponentData> data = it.value();
 
-        // 检查符号数据
         if (!data->symbolData()) {
             qWarning() << "SymbolExportStage: No symbol data for component:" << componentId;
             failedIds.append(componentId);
-            // 发射 itemStatusChanged 信号通知 ViewModel
             ExportItemStatus status;
             status.status = ExportItemStatus::Status::Failed;
             status.errorMessage = "No symbol data";
@@ -143,12 +141,10 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
             continue;
         }
 
-        // 添加到符号列表
         symbolList.append(*data->symbolData());
         collectedIds.append(componentId);
         successCount++;
 
-        // 发射 itemStatusChanged 信号通知 ViewModel
         ExportItemStatus status;
         status.status = ExportItemStatus::Status::Success;
         emit itemStatusChanged(componentId, status);
@@ -189,6 +185,15 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         successCount = 0;
     };
 
+    const auto abortExport = [&](const QString& errorMessage) {
+        qCritical() << "SymbolExportStage:" << errorMessage;
+        failCollectedSymbols(errorMessage);
+        m_tempManager.rollbackAll();
+        m_isExporting.store(false);
+        m_isRunning.store(false);
+        emit completed(0, failedIds.size(), 0);
+    };
+
     // 2. 构建输出路径
     QString libName = m_options.libName.isEmpty() ? QStringLiteral("EasyKiConverter") : m_options.libName;
     QString fileName = libName + QStringLiteral(".kicad_sym");
@@ -201,10 +206,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     // 3. 确保输出目录存在
     QDir dir;
     if (!dir.mkpath(outputDir)) {
-        qCritical() << "SymbolExportStage: Failed to create output directory:" << outputDir;
-        m_isExporting.store(false);
-        m_isRunning.store(false);
-        emit completed(0, symbolList.size(), 0);
+        abortExport(QStringLiteral("Failed to create output directory: %1").arg(outputDir));
         return;
     }
 
@@ -213,44 +215,64 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     // 4. 创建临时文件并导出
     QString tempPath = m_tempManager.createSymbolTempPath(libName, QStringLiteral(".kicad_sym"));
     if (tempPath.isEmpty()) {
-        qCritical() << "SymbolExportStage: Failed to create temp file path";
-        m_isExporting.store(false);
-        m_isRunning.store(false);
-        emit completed(0, symbolList.size(), 0);
+        abortExport(QStringLiteral("Failed to create temp file path"));
         return;
     }
 
     // 追加/更新到现有符号库时，先把最终文件复制到临时文件，再在临时文件上执行 merge。
     if (finalFileExists && (!m_options.overwriteExistingFiles || m_options.updateMode)) {
+        const QString tempDirPath = QFileInfo(tempPath).absolutePath();
+        if (!QDir().mkpath(tempDirPath)) {
+            abortExport(QStringLiteral("Failed to create temp symbol library directory: %1").arg(tempDirPath));
+            return;
+        }
+
         QFile tempFile(tempPath);
         if (tempFile.exists() && !tempFile.remove()) {
-            const QString errorMessage = QStringLiteral("Failed to remove stale temp symbol library: %1").arg(tempPath);
-            qCritical() << "SymbolExportStage:" << errorMessage << "error:" << tempFile.errorString();
-            failCollectedSymbols(errorMessage);
-            m_tempManager.rollbackAll();
-            m_isExporting.store(false);
-            m_isRunning.store(false);
-            emit completed(0, failedIds.size(), 0);
+            abortExport(QStringLiteral("Failed to remove stale temp symbol library: %1").arg(tempPath));
             return;
         }
 
         QFile sourceFile(finalPath);
-        if (!sourceFile.copy(tempPath)) {
-            const QString errorMessage =
-                QStringLiteral("Failed to copy existing symbol library to temp: %1 -> %2").arg(finalPath, tempPath);
-            qCritical() << "SymbolExportStage:" << errorMessage << "error:" << sourceFile.errorString();
-            failCollectedSymbols(errorMessage);
-            m_tempManager.rollbackAll();
-            m_isExporting.store(false);
-            m_isRunning.store(false);
-            emit completed(0, failedIds.size(), 0);
+        if (!sourceFile.open(QIODevice::ReadOnly)) {
+            if (!QFileInfo::exists(finalPath)) {
+                qWarning()
+                    << "SymbolExportStage: Existing symbol library disappeared before copy, creating new library:"
+                    << finalPath;
+            } else {
+                abortExport(QStringLiteral("Failed to open existing symbol library for copy: %1").arg(finalPath));
+                return;
+            }
+        } else if (!tempFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            abortExport(QStringLiteral("Failed to create temp symbol library for copy: %1").arg(tempPath));
             return;
+        } else {
+            constexpr qint64 kChunkSize = 65536;
+            char buf[kChunkSize];
+            bool copyError = false;
+            while (!sourceFile.atEnd()) {
+                qint64 bytesRead = sourceFile.read(buf, kChunkSize);
+                if (bytesRead < 0) {
+                    abortExport(QStringLiteral("Failed to read existing symbol library: %1").arg(finalPath));
+                    copyError = true;
+                    break;
+                }
+                if (tempFile.write(buf, bytesRead) != bytesRead) {
+                    abortExport(QStringLiteral("Failed to write temp symbol library copy: %1").arg(tempPath));
+                    copyError = true;
+                    break;
+                }
+            }
+            if (copyError) {
+                return;
+            }
+            tempFile.close();
         }
     }
 
     qDebug() << "SymbolExportStage: Exporting" << symbolList.size() << "symbols to temp:" << tempPath;
 
-    // 6. 执行符号库导出
+    // 5. 执行符号库导出
     bool exportSuccess = false;
     QString libraryDescription = m_options.symbolLibraryDescription;
     {
@@ -269,31 +291,18 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     }
 
     if (!exportSuccess) {
-        const QString errorMessage = QStringLiteral("Failed to export symbol library");
-        qCritical() << "SymbolExportStage:" << errorMessage;
-        failCollectedSymbols(errorMessage);
-        m_tempManager.rollbackAll();
-        m_isExporting.store(false);
-        m_isRunning.store(false);
-        emit completed(0, failedIds.size(), 0);
+        abortExport(QStringLiteral("Failed to export symbol library"));
         return;
     }
 
-    // 7. 提交临时文件（重命名为最终路径）
-    if (m_tempManager.commit(finalPath)) {
-        qDebug() << "SymbolExportStage: Successfully exported to:" << finalPath;
-    } else {
-        const QString errorMessage = QStringLiteral("Failed to commit temp file");
-        qCritical() << "SymbolExportStage:" << errorMessage;
-        failCollectedSymbols(errorMessage);
-        m_tempManager.rollbackAll();
-        m_isExporting.store(false);
-        m_isRunning.store(false);
-        emit completed(0, failedIds.size(), 0);
+    // 6. 提交临时文件（重命名为最终路径）
+    if (!m_tempManager.commit(finalPath)) {
+        abortExport(QStringLiteral("Failed to commit temp file"));
         return;
     }
+    qDebug() << "SymbolExportStage: Successfully exported to:" << finalPath;
 
-    // 7.1 生成 sym-lib-table 文件（如果提供了库描述）
+    // 7. 生成 sym-lib-table 文件（如果提供了库描述）
     if (!libraryDescription.isEmpty()) {
         ExporterSymbol symTableExporter;
         symTableExporter.generateSymLibTable(libName, finalPath, outputDir, libraryDescription);

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -106,6 +106,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 1. 收集所有有效的符号数据
     QList<SymbolData> symbolList;
+    QStringList collectedIds;
     QStringList failedIds;
     int successCount = 0;
     int skippedCount = 0;
@@ -144,6 +145,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
         // 添加到符号列表
         symbolList.append(*data->symbolData());
+        collectedIds.append(componentId);
         successCount++;
 
         // 发射 itemStatusChanged 信号通知 ViewModel
@@ -162,6 +164,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     if (m_cancelled.load()) {
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
@@ -169,9 +172,22 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (symbolList.isEmpty()) {
         qWarning() << "SymbolExportStage: No valid symbols to export";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, componentIds.size(), 0);
         return;
     }
+
+    const auto failCollectedSymbols = [this, &collectedIds, &failedIds, &successCount](const QString& errorMessage) {
+        for (const QString& componentId : collectedIds) {
+            failedIds.append(componentId);
+            ExportItemStatus status;
+            status.status = ExportItemStatus::Status::Failed;
+            status.errorMessage = errorMessage;
+            status.endTime = QDateTime::currentDateTime();
+            emit itemStatusChanged(componentId, status);
+        }
+        successCount = 0;
+    };
 
     // 2. 构建输出路径
     QString libName = m_options.libName.isEmpty() ? QStringLiteral("EasyKiConverter") : m_options.libName;
@@ -187,6 +203,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (!dir.mkpath(outputDir)) {
         qCritical() << "SymbolExportStage: Failed to create output directory:" << outputDir;
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
     }
@@ -198,19 +215,35 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (tempPath.isEmpty()) {
         qCritical() << "SymbolExportStage: Failed to create temp file path";
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
     }
 
     // 追加/更新到现有符号库时，先把最终文件复制到临时文件，再在临时文件上执行 merge。
     if (finalFileExists && (!m_options.overwriteExistingFiles || m_options.updateMode)) {
-        QFile::remove(tempPath);
-        if (!QFile::copy(finalPath, tempPath)) {
-            qCritical() << "SymbolExportStage: Failed to copy existing symbol library to temp:" << finalPath << "->"
-                        << tempPath;
+        QFile tempFile(tempPath);
+        if (tempFile.exists() && !tempFile.remove()) {
+            const QString errorMessage = QStringLiteral("Failed to remove stale temp symbol library: %1").arg(tempPath);
+            qCritical() << "SymbolExportStage:" << errorMessage << "error:" << tempFile.errorString();
+            failCollectedSymbols(errorMessage);
             m_tempManager.rollbackAll();
             m_isExporting.store(false);
-            emit completed(0, symbolList.size(), 0);
+            m_isRunning.store(false);
+            emit completed(0, failedIds.size(), 0);
+            return;
+        }
+
+        QFile sourceFile(finalPath);
+        if (!sourceFile.copy(tempPath)) {
+            const QString errorMessage =
+                QStringLiteral("Failed to copy existing symbol library to temp: %1 -> %2").arg(finalPath, tempPath);
+            qCritical() << "SymbolExportStage:" << errorMessage << "error:" << sourceFile.errorString();
+            failCollectedSymbols(errorMessage);
+            m_tempManager.rollbackAll();
+            m_isExporting.store(false);
+            m_isRunning.store(false);
+            emit completed(0, failedIds.size(), 0);
             return;
         }
     }
@@ -219,7 +252,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
 
     // 6. 执行符号库导出
     bool exportSuccess = false;
-    QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
+    QString libraryDescription = m_options.symbolLibraryDescription;
     {
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
@@ -230,15 +263,19 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (m_cancelled.load()) {
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
+        m_isRunning.store(false);
         emit completed(0, symbolList.size(), 0);
         return;
     }
 
     if (!exportSuccess) {
-        qCritical() << "SymbolExportStage: Failed to export symbol library";
+        const QString errorMessage = QStringLiteral("Failed to export symbol library");
+        qCritical() << "SymbolExportStage:" << errorMessage;
+        failCollectedSymbols(errorMessage);
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
-        emit completed(0, symbolList.size(), 0);
+        m_isRunning.store(false);
+        emit completed(0, failedIds.size(), 0);
         return;
     }
 
@@ -246,10 +283,13 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     if (m_tempManager.commit(finalPath)) {
         qDebug() << "SymbolExportStage: Successfully exported to:" << finalPath;
     } else {
-        qCritical() << "SymbolExportStage: Failed to commit temp file";
+        const QString errorMessage = QStringLiteral("Failed to commit temp file");
+        qCritical() << "SymbolExportStage:" << errorMessage;
+        failCollectedSymbols(errorMessage);
         m_tempManager.rollbackAll();
         m_isExporting.store(false);
-        emit completed(0, symbolList.size(), 0);
+        m_isRunning.store(false);
+        emit completed(0, failedIds.size(), 0);
         return;
     }
 

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -221,7 +221,9 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
     {
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
-        exportSuccess = exporter.exportSymbolLibrary(symbolList, libName, tempPath, appendMode, m_options.updateMode);
+        QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
+        exportSuccess = exporter.exportSymbolLibrary(
+            symbolList, libName, tempPath, appendMode, m_options.updateMode, libraryDescription);
     }
 
     if (m_cancelled.load()) {

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -222,6 +222,7 @@ void SymbolExportStage::doLibraryExport(const QStringList& componentIds,
         ExporterSymbol exporter;
         bool appendMode = !m_options.overwriteExistingFiles;
         QString libraryDescription = m_options.exportSymbolDescription ? m_options.symbolLibraryDescription : QString();
+        qDebug() << "SymbolExportStage: libraryDescription=" << libraryDescription;
         exportSuccess = exporter.exportSymbolLibrary(
             symbolList, libName, tempPath, appendMode, m_options.updateMode, libraryDescription);
     }

--- a/src/services/export/SymbolExportWorker.cpp
+++ b/src/services/export/SymbolExportWorker.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
-#include <QtConcurrent>
+#include <QThreadPool>
 
 namespace EasyKiConverter {
 
@@ -80,9 +80,10 @@ void SymbolExportWorker::run() {
             qDebug() << "SymbolExportWorker: Successfully exported" << filePath;
 
             if (m_options.debugMode) {
-                QtConcurrent::run([componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
-                    DebugExportHelper::exportDebugData(componentId, data, outputPath);
-                });
+                QThreadPool::globalInstance()->start(
+                    [componentId = m_componentId, data = m_data, outputPath = m_options.outputPath]() {
+                        DebugExportHelper::exportDebugData(componentId, data, outputPath);
+                    });
             }
 
             emit completed(m_componentId, true, QString());

--- a/src/services/export/TempFileManager.cpp
+++ b/src/services/export/TempFileManager.cpp
@@ -75,7 +75,8 @@ QString TempFileManager::createSymbolTempPath(const QString& libName, const QStr
 
     // 符号库临时文件：libName.suffix
     QString tempName = libName + suffix;
-    QString tempPath = tempDirectory() + QDir::separator() + tempName;
+    const QString tempDir = tempDirectory();
+    QString tempPath = tempDir + QDir::separator() + tempName;
 
     m_tempFiles.insert(tempPath);
     qDebug() << "TempFileManager: Created symbol temp path:" << tempPath;
@@ -320,12 +321,11 @@ bool TempFileManager::ensureTempDirectory() const {
         return false;
     }
 
-    QDir dir(tempDir);
-    if (dir.exists()) {
+    if (QDir(tempDir).exists()) {
         return true;
     }
 
-    return dir.mkpath(tempDir);
+    return QDir().mkpath(tempDir);
 }
 
 bool TempFileManager::deleteFile(const QString& path) const {

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -362,6 +362,7 @@ Item {
                     // 导出设置卡片
                     ExportSettingsCard {
                         Layout.fillWidth: true
+                        Layout.fillHeight: true
                         exportSettingsController: window.exportSettingsController
                         onOpenOutputFolderDialog: outputFolderDialog.open()
                     }

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -247,16 +247,13 @@ Item {
             onPaint: {
                 const ctx = getContext("2d");
                 ctx.reset();
-
                 const r = windowRadius;
                 ctx.beginPath();
                 ctx.roundedRect(0, 0, width, height, r, r);
                 ctx.closePath();
                 ctx.clip();
-
                 ctx.fillStyle = AppStyle.colors.background;
                 ctx.fill();
-
                 if (bgSource.status === Image.Ready) {
                     const sw = bgSource.sourceSize.width;
                     const sh = bgSource.sourceSize.height;

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -13,6 +13,7 @@ Card {
     readonly property bool showValidationHint: componentListController ? componentListController.validationReadyHint : false
     readonly property bool showPreviewHint: componentListController ? componentListController.previewReadyHint : false
     readonly property color hintColor: showPreviewHint ? "#31c36b" : (showValidationHint ? "#2f7ef8" : "transparent")
+    property string editingDescriptionComponentId: ""
     title: qsTranslate("MainWindow", "元器件列表")
     // 默认折叠，只有在有元器件时才展开
     isCollapsed: componentListController ? componentListController.componentCount === 0 : true
@@ -112,6 +113,11 @@ Card {
                         componentListCard.componentListController.refreshComponentInfo(index);
                     }
                 }
+                onDescriptionEditRequested: function (componentId, description) {
+                    componentListCard.editingDescriptionComponentId = componentId;
+                    descriptionDialog.descriptionText = description;
+                    descriptionDialog.open();
+                }
             }
 
             // 过滤函数
@@ -150,6 +156,17 @@ Card {
                     item.inDisplay = passFilter && passSearch;
                 }
             }
+        },
+        DescriptionEditDialog {
+            id: descriptionDialog
+            parent: componentListCard.Window.window ? componentListCard.Window.window.contentItem : componentListCard
+            onAccepted: function (description) {
+                if (componentListCard.componentListController && componentListCard.editingDescriptionComponentId !== "") {
+                    componentListCard.componentListController.updateComponentDescription(componentListCard.editingDescriptionComponentId, description);
+                }
+                componentListCard.editingDescriptionComponentId = "";
+            }
+            onRejected: componentListCard.editingDescriptionComponentId = ""
         }
     ]
     overlayContent: [

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -13,6 +13,7 @@ Rectangle {
     signal deleteClicked
     signal copyClicked
     signal retryClicked
+    signal descriptionEditRequested(string componentId, string description)
     height: 64 // 增加高度以容纳缩略图和更多信息
     // 悬停效果
     color: itemMouseArea.containsMouse ? AppStyle.colors.background : AppStyle.colors.surface
@@ -553,18 +554,44 @@ Rectangle {
                     if (phase === "failed")
                         return itemData.errorMessage || "验证失败";
                     if (phase === "completed" || itemData.isValid) {
-                        var info = [];
-                        if (itemData.name)
-                            info.push(itemData.name);
-                        if (itemData.package)
-                            info.push(itemData.package);
-                        return info.join(" | ");
+                        return itemData.description || itemData.name || "";
                     }
                     return "";
                 }
                 font.pixelSize: AppStyle.fontSizes.sm
                 color: (itemData && itemData.validationPhase === "failed") ? AppStyle.colors.danger : AppStyle.colors.textSecondary
                 elide: Text.ElideRight
+            }
+        }
+        // 重试按钮（仅对验证失败的元器件显示）
+        Button {
+            Layout.preferredWidth: 28
+            Layout.preferredHeight: 28
+            Layout.alignment: Qt.AlignVCenter
+            visible: itemData && itemData.isValid
+            background: Rectangle {
+                color: parent.pressed ? AppStyle.colors.primaryPressed : parent.hovered ? "#dbeafe" : "transparent"
+                radius: AppStyle.radius.sm
+                Behavior on color {
+                    ColorAnimation {
+                        duration: AppStyle.durations.fast
+                    }
+                }
+            }
+            contentItem: Text {
+                text: "✎"
+                font.pixelSize: AppStyle.fontSizes.lg
+                font.bold: true
+                color: parent.hovered ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+            ToolTip.visible: hovered
+            ToolTip.text: qsTr("编辑元器件描述")
+            onClicked: {
+                if (itemData) {
+                    rootItem.descriptionEditRequested(itemData.componentId, itemData.description || "");
+                }
             }
         }
         // 重试按钮（仅对验证失败的元器件显示）

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -222,9 +222,18 @@ Rectangle {
                             fillColor: "transparent"
                             capStyle: ShapePath.RoundCap
                             joinStyle: ShapePath.RoundJoin
-                            PathMove { x: checkShape.width / 2 - 6; y: checkShape.height / 2 }
-                            PathLine { x: checkShape.width / 2 - 2; y: checkShape.height / 2 + 3 }
-                            PathLine { x: checkShape.width / 2 + 6; y: checkShape.height / 2 - 3 }
+                            PathMove {
+                                x: checkShape.width / 2 - 6
+                                y: checkShape.height / 2
+                            }
+                            PathLine {
+                                x: checkShape.width / 2 - 2
+                                y: checkShape.height / 2 + 3
+                            }
+                            PathLine {
+                                x: checkShape.width / 2 + 6
+                                y: checkShape.height / 2 - 3
+                            }
                         }
                     }
                 }
@@ -247,16 +256,28 @@ Rectangle {
                             strokeWidth: 2
                             fillColor: "transparent"
                             capStyle: ShapePath.RoundCap
-                            PathMove { x: crossShape.width / 2 - 6; y: crossShape.height / 2 - 6 }
-                            PathLine { x: crossShape.width / 2 + 6; y: crossShape.height / 2 + 6 }
+                            PathMove {
+                                x: crossShape.width / 2 - 6
+                                y: crossShape.height / 2 - 6
+                            }
+                            PathLine {
+                                x: crossShape.width / 2 + 6
+                                y: crossShape.height / 2 + 6
+                            }
                         }
                         ShapePath {
                             strokeColor: AppStyle.colors.danger
                             strokeWidth: 2
                             fillColor: "transparent"
                             capStyle: ShapePath.RoundCap
-                            PathMove { x: crossShape.width / 2 + 6; y: crossShape.height / 2 - 6 }
-                            PathLine { x: crossShape.width / 2 - 6; y: crossShape.height / 2 + 6 }
+                            PathMove {
+                                x: crossShape.width / 2 + 6
+                                y: crossShape.height / 2 - 6
+                            }
+                            PathLine {
+                                x: crossShape.width / 2 - 6
+                                y: crossShape.height / 2 + 6
+                            }
                         }
                     }
                 }

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -186,7 +186,10 @@ Rectangle {
                             return "";
                         if (!itemData.previewImages || itemData.previewImages.length === 0)
                             return "";
-                        return "data:image/jpeg;base64," + itemData.previewImages[0];
+                        var imageData = itemData.previewImages[0];
+                        if (!imageData || imageData === "")
+                            return "";
+                        return "data:image/jpeg;base64," + imageData;
                     }
                     fillMode: Image.PreserveAspectFit
                     cache: true

--- a/src/ui/qml/components/ConfirmDialog.qml
+++ b/src/ui/qml/components/ConfirmDialog.qml
@@ -68,7 +68,7 @@ SliderDialogBase {
         visible = true;
         root.dialogBox.y = 0;
         root.dialogBoxTranslate.y = 0;
-        showAnim.start();
+        root.showAnimation.start();
         root.forceActiveFocus();
         // 默认聚焦在取消按钮（第一个非分隔线项）
         var childIndex = 0;

--- a/src/ui/qml/components/DescriptionEditDialog.qml
+++ b/src/ui/qml/components/DescriptionEditDialog.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "../styles"
+
+/**
+ * @brief 元器件描述编辑对话框
+ *
+ * 使用与退出确认对话框一致的滑块按钮和遮罩样式。
+ */
+SliderDialogBase {
+    id: root
+    hasOverlay: true
+    title: qsTr("元器件描述")
+    message: qsTr("编辑当前元器件导出到符号和封装中的描述。")
+
+    property string descriptionText: ""
+
+    signal accepted(string description)
+    signal rejected
+
+    mainContentSource: ColumnLayout {
+        spacing: AppStyle.spacing.sm
+
+        TextArea {
+            id: descriptionInput
+            Layout.fillWidth: true
+            Layout.preferredHeight: 128
+            text: root.descriptionText
+            wrapMode: TextEdit.Wrap
+            selectByMouse: true
+            font.pixelSize: AppStyle.fontSizes.sm
+            color: AppStyle.colors.textPrimary
+            placeholderText: qsTr("留空则不导出描述")
+            onTextChanged: root.descriptionText = text
+            Component.onCompleted: Qt.callLater(forceActiveFocus)
+
+            background: Rectangle {
+                color: AppStyle.colors.surface
+                border.color: descriptionInput.activeFocus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                border.width: descriptionInput.activeFocus ? 2 : 1
+                radius: AppStyle.radius.md
+            }
+        }
+    }
+
+    buttonSpecs: [
+        {
+            text: qsTr("取消"),
+            color: AppStyle.colors.textSecondary,
+            action: function () {
+                root.rejected();
+                root.closeWithAnimation();
+            }
+        },
+        {
+            isSeparator: true
+        },
+        {
+            text: qsTr("保存"),
+            color: AppStyle.colors.primary,
+            action: function () {
+                root.accepted(root.descriptionText);
+                root.close();
+            }
+        }
+    ]
+
+    Keys.onEscapePressed: {
+        root.rejected();
+        root.closeWithAnimation();
+    }
+
+    function open() {
+        visible = true;
+        root.dialogBox.y = 0;
+        root.dialogBoxTranslate.y = 0;
+        root.showAnimation.start();
+        root.forceActiveFocus();
+
+        var childIndex = 0;
+        for (var i = 0; i < buttonSpecs.length; i++) {
+            if (buttonSpecs[i].isSeparator) {
+                continue;
+            }
+            var loader = buttonColLayout.children[childIndex];
+            if (loader && loader.actualButton) {
+                root.updateSlider(loader.actualButton, AppStyle.colors.textSecondary);
+                break;
+            }
+            childIndex++;
+        }
+    }
+}

--- a/src/ui/qml/components/DescriptionEditDialog.qml
+++ b/src/ui/qml/components/DescriptionEditDialog.qml
@@ -13,15 +13,11 @@ SliderDialogBase {
     hasOverlay: true
     title: qsTr("元器件描述")
     message: qsTr("编辑当前元器件导出到符号和封装中的描述。")
-
     property string descriptionText: ""
-
     signal accepted(string description)
     signal rejected
-
     mainContentSource: ColumnLayout {
         spacing: AppStyle.spacing.sm
-
         TextArea {
             id: descriptionInput
             Layout.fillWidth: true
@@ -34,7 +30,6 @@ SliderDialogBase {
             placeholderText: qsTr("留空则不导出描述")
             onTextChanged: root.descriptionText = text
             Component.onCompleted: Qt.callLater(forceActiveFocus)
-
             background: Rectangle {
                 color: AppStyle.colors.surface
                 border.color: descriptionInput.activeFocus ? AppStyle.colors.borderFocus : AppStyle.colors.border
@@ -65,7 +60,6 @@ SliderDialogBase {
             }
         }
     ]
-
     Keys.onEscapePressed: {
         root.rejected();
         root.closeWithAnimation();
@@ -77,7 +71,6 @@ SliderDialogBase {
         root.dialogBoxTranslate.y = 0;
         root.showAnimation.start();
         root.forceActiveFocus();
-
         var childIndex = 0;
         for (var i = 0; i < buttonSpecs.length; i++) {
             if (buttonSpecs[i].isSeparator) {

--- a/src/ui/qml/components/ExportButtonsSection.qml
+++ b/src/ui/qml/components/ExportButtonsSection.qml
@@ -123,7 +123,7 @@ ColumnLayout {
                     var idList = exportButtonsSection.componentListController ? exportButtonsSection.componentListController.getAllComponentIds() : [];
                     var settingsController = exportButtonsSection.exportSettingsController;
                     if (progressController && settingsController) {
-                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false);
+                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false, settingsController.symbolLibraryDescription || "");
                     }
                 }
             }

--- a/src/ui/qml/components/ExportButtonsSection.qml
+++ b/src/ui/qml/components/ExportButtonsSection.qml
@@ -123,7 +123,7 @@ ColumnLayout {
                     var idList = exportButtonsSection.componentListController ? exportButtonsSection.componentListController.getAllComponentIds() : [];
                     var settingsController = exportButtonsSection.exportSettingsController;
                     if (progressController && settingsController) {
-                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false, settingsController.symbolLibraryDescription || "");
+                        progressController.startExport(idList, settingsController.outputPath || "", settingsController.libName || "", settingsController.exportSymbol || false, settingsController.exportFootprint || false, settingsController.exportModel3D || false, settingsController.exportModel3DFormat || 3, settingsController.exportPreviewImages || false, settingsController.exportDatasheet || false, settingsController.overwriteExistingFiles || false, (settingsController.exportMode || 0) === 1, settingsController.debugMode || false, settingsController.symbolLibraryDescription || "", settingsController.footprintLibraryDescription || "", settingsController.footprintLibraryKeywords || "");
                     }
                 }
             }

--- a/src/ui/qml/components/ExportResultsCard.qml
+++ b/src/ui/qml/components/ExportResultsCard.qml
@@ -10,26 +10,26 @@ Loader {
     property var exportProgressController
     active: resultsLoader.exportProgressController ? (resultsLoader.exportProgressController.isExporting || resultsLoader.exportProgressController.resultsList.length > 0) : false
     visible: active  // 确保 Loader 在没有结果时不占用空间
-    resources: [
-        // 防抖定时器，避免频繁调用 updateFilter()
-        Timer {
-            id: filterUpdateTimer
-            interval: 50
-            onTriggered: visualModel.updateFilter()
-        },
-        // 监听筛选模式变化，更新过滤
-        Connections {
-            target: resultsLoader.exportProgressController
-            function onFilterModeChanged() {
-                filterUpdateTimer.restart();
-            }
-            function onResultsListChanged() {
-                filterUpdateTimer.restart();
-            }
-        }
-    ]
     sourceComponent: Card {
         title: qsTranslate("MainWindow", "转换结果")
+        resources: [
+            // 防抖定时器，避免频繁调用 updateFilter()
+            Timer {
+                id: filterUpdateTimer
+                interval: 50
+                onTriggered: visualModel.updateFilter()
+            },
+            // 监听筛选模式变化，更新过滤
+            Connections {
+                target: resultsLoader.exportProgressController
+                function onFilterModeChanged() {
+                    filterUpdateTimer.restart();
+                }
+                function onResultsListChanged() {
+                    filterUpdateTimer.restart();
+                }
+            }
+        ]
         ColumnLayout {
             id: resultsContent
             width: parent.width

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -106,109 +106,80 @@ Card {
             }
         }
 
-        // ==================== 库元数据区块 ====================
+        // ==================== 库描述区块 ====================
         SectionHeader {
-            id: metadataHeader
-            sectionTitle: qsTranslate("MainWindow", "库元数据")
+            id: libraryDescriptionHeader
+            sectionTitle: qsTranslate("MainWindow", "库描述")
         }
 
         GridLayout {
             Layout.fillWidth: true
-            columns: 3
-            columnSpacing: AppStyle.spacing.md
-            rowSpacing: AppStyle.spacing.sm
-            // 符号库描述
+            columns: 2
+            columnSpacing: AppStyle.spacing.xl
+            rowSpacing: AppStyle.spacing.md
+
+            // 符号库描述：写入 sym-lib-table，不是单个符号描述
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.xs
                 Text {
-                    text: qsTranslate("MainWindow", "符号库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textSecondary
+                    text: qsTranslate("MainWindow", "符号库描述 (sym-lib-table)")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
                 }
                 TextField {
-                    id: symbolDescInput
+                    id: symbolLibraryDescriptionInput
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 32
+                    Layout.preferredHeight: 36
                     text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
                     onTextChanged: {
                         if (exportSettingsCard.exportSettingsController) {
                             exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
                         }
                     }
-                    placeholderText: qsTranslate("MainWindow", "符号库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
+                    placeholderText: qsTranslate("MainWindow", "输入符号库描述")
+                    font.pixelSize: AppStyle.fontSizes.sm
                     color: AppStyle.colors.textPrimary
                     placeholderTextColor: AppStyle.colors.textSecondary
                     background: Rectangle {
                         color: AppStyle.colors.surface
-                        border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: symbolDescInput.focus ? 2 : 1
-                        radius: AppStyle.radius.sm
+                        border.color: symbolLibraryDescriptionInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: symbolLibraryDescriptionInput.focus ? 2 : 1
+                        radius: AppStyle.radius.md
                     }
                 }
             }
 
-            // 封装库描述
+            // 封装库描述：写入 fp-lib-table，不是单个封装描述
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.xs
                 Text {
-                    text: qsTranslate("MainWindow", "封装库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textSecondary
+                    text: qsTranslate("MainWindow", "封装库描述 (fp-lib-table)")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
                 }
                 TextField {
-                    id: footprintDescInput
+                    id: footprintLibraryDescriptionInput
                     Layout.fillWidth: true
-                    Layout.preferredHeight: 32
+                    Layout.preferredHeight: 36
                     text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
                     onTextChanged: {
                         if (exportSettingsCard.exportSettingsController) {
                             exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
                         }
                     }
-                    placeholderText: qsTranslate("MainWindow", "封装库描述")
-                    font.pixelSize: AppStyle.fontSizes.xs
+                    placeholderText: qsTranslate("MainWindow", "输入封装库描述")
+                    font.pixelSize: AppStyle.fontSizes.sm
                     color: AppStyle.colors.textPrimary
                     placeholderTextColor: AppStyle.colors.textSecondary
                     background: Rectangle {
                         color: AppStyle.colors.surface
-                        border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: footprintDescInput.focus ? 2 : 1
-                        radius: AppStyle.radius.sm
-                    }
-                }
-            }
-
-            // 封装库关键词
-            ColumnLayout {
-                Layout.fillWidth: true
-                spacing: AppStyle.spacing.xs
-                Text {
-                    text: qsTranslate("MainWindow", "关键词")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textSecondary
-                }
-                TextField {
-                    id: footprintKeywordsInput
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 32
-                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
-                    onTextChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
-                        }
-                    }
-                    placeholderText: qsTranslate("MainWindow", "关键词")
-                    font.pixelSize: AppStyle.fontSizes.xs
-                    color: AppStyle.colors.textPrimary
-                    placeholderTextColor: AppStyle.colors.textSecondary
-                    background: Rectangle {
-                        color: AppStyle.colors.surface
-                        border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: footprintKeywordsInput.focus ? 2 : 1
-                        radius: AppStyle.radius.sm
+                        border.color: footprintLibraryDescriptionInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: footprintLibraryDescriptionInput.focus ? 2 : 1
+                        radius: AppStyle.radius.md
                     }
                 }
             }

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -511,7 +511,7 @@ Card {
                 }
                 font.pixelSize: AppStyle.fontSizes.sm
                 ToolTip.visible: hovered
-                ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
+                ToolTip.text: qsTranslate("MainWindow", "保留已经存在的元器件数据，并追加新的元器件")
                 indicator: Rectangle {
                     implicitWidth: AppStyle.sizes.radioButton
                     implicitHeight: AppStyle.sizes.radioButton
@@ -558,7 +558,7 @@ Card {
                 }
                 font.pixelSize: AppStyle.fontSizes.sm
                 ToolTip.visible: hovered
-                ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                ToolTip.text: qsTranslate("MainWindow", "覆盖已经存在的元器件数据，并追加新的元器件")
                 indicator: Rectangle {
                     implicitWidth: AppStyle.sizes.radioButton
                     implicitHeight: AppStyle.sizes.radioButton

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -510,7 +510,7 @@ Card {
             }
 
             Text {
-                text: qsTranslate("MainWindow", "保留已存在的元器件")
+                text: qsTranslate("MainWindow", "保留已经存在的元器件数据，并追加新的元器件")
                 font.pixelSize: AppStyle.fontSizes.sm
                 color: AppStyle.colors.textSecondary
                 verticalAlignment: Text.AlignVCenter
@@ -557,7 +557,7 @@ Card {
             }
 
             Text {
-                text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                text: qsTranslate("MainWindow", "覆盖已经存在的元器件数据，并追加新的元器件")
                 font.pixelSize: AppStyle.fontSizes.sm
                 color: AppStyle.colors.textSecondary
                 verticalAlignment: Text.AlignVCenter

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -117,7 +117,6 @@ Card {
             columns: 2
             columnSpacing: AppStyle.spacing.xl
             rowSpacing: AppStyle.spacing.md
-
             // 符号库描述：写入 sym-lib-table，不是单个符号描述
             ColumnLayout {
                 Layout.fillWidth: true

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -5,139 +5,258 @@ import EasyKiconverter_Cpp_Version.src.ui.qml.styles 1.0
 
 Card {
     id: exportSettingsCard
-    // 外部依赖
     property var exportSettingsController
-    // 信号：请求打开输出目录对话框
     signal openOutputFolderDialog
     title: qsTranslate("MainWindow", "导出设置")
-    GridLayout {
+
+    ScrollView {
+        id: scrollView
         width: parent.width
-        columns: 2
-        columnSpacing: ResponsiveHelper.spacing.xl
-        rowSpacing: ResponsiveHelper.spacing.md
-        // 输出路径
+        height: parent.height
+        clip: true
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        ScrollBar.vertical.policy: ScrollBar.AsNeeded
+
         ColumnLayout {
-            Layout.fillWidth: true
-            spacing: ResponsiveHelper.spacing.sm
-            Text {
-                text: qsTranslate("MainWindow", "输出路径")
-                font.pixelSize: ResponsiveHelper.fontSizes.sm
-                font.bold: true
-                color: AppStyle.colors.textPrimary
-                horizontalAlignment: Text.AlignHCenter
-            }
-            RowLayout {
+            id: rootLayout
+            width: scrollView.availableWidth > 0 ? scrollView.availableWidth : parent.width
+            spacing: AppStyle.spacing.md
+
+            // ==================== SectionHeader 组件 ====================
+            component SectionHeader: RowLayout {
                 Layout.fillWidth: true
-                spacing: ResponsiveHelper.spacing.md
-                TextField {
-                    id: outputPathInput
-                    Layout.fillWidth: true
-                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
-                    onTextChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setOutputPath(text);
-                        }
-                    }
-                    placeholderText: qsTranslate("MainWindow", "选择输出目录")
-                    font.pixelSize: ResponsiveHelper.fontSizes.sm
-                    color: AppStyle.colors.textPrimary
-                    placeholderTextColor: AppStyle.colors.textSecondary
-                    background: Rectangle {
-                        color: AppStyle.colors.surface
-                        border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                        border.width: outputPathInput.focus ? 2 : 1
-                        radius: AppStyle.radius.md
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: AppStyle.durations.fast
-                            }
-                        }
-                        Behavior on border.width {
-                            NumberAnimation {
-                                duration: AppStyle.durations.fast
-                            }
-                        }
-                    }
-                }
-                ModernButton {
-                    text: qsTranslate("MainWindow", "浏览")
-                    iconName: "folder"
+                spacing: AppStyle.spacing.sm
+                property string sectionTitle: ""
+                Text {
+                    text: sectionTitle
                     font.pixelSize: AppStyle.fontSizes.sm
-                    backgroundColor: AppStyle.colors.textSecondary
-                    hoverColor: AppStyle.colors.textPrimary
-                    pressedColor: AppStyle.colors.textPrimary
-                    onClicked: {
-                        exportSettingsCard.openOutputFolderDialog();
-                    }
+                    font.bold: true
+                    color: AppStyle.colors.textSecondary
+                }
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 1
+                    color: AppStyle.colors.border
+                    opacity: 0.5
                 }
             }
-        }
-        // 库名称
-        ColumnLayout {
-            Layout.fillWidth: true
-            spacing: ResponsiveHelper.spacing.sm
-            Text {
-                text: qsTranslate("MainWindow", "库名称")
-                font.pixelSize: ResponsiveHelper.fontSizes.sm
-                font.bold: true
-                color: AppStyle.colors.textPrimary
-                horizontalAlignment: Text.AlignHCenter
+
+            // ==================== 基础配置区块 ====================
+            SectionHeader {
+                id: basicConfigHeader
+                sectionTitle: qsTranslate("MainWindow", "基础配置")
             }
-            TextField {
-                id: libNameInput
+
+            GridLayout {
                 Layout.fillWidth: true
-                text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
-                onTextChanged: {
-                    if (exportSettingsCard.exportSettingsController) {
-                        exportSettingsCard.exportSettingsController.setLibName(text);
+                columns: 2
+                columnSpacing: AppStyle.spacing.xl
+                rowSpacing: AppStyle.spacing.md
+
+                // 输出路径
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "输出路径")
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        font.bold: true
+                        color: AppStyle.colors.textPrimary
+                        horizontalAlignment: Text.AlignHCenter
                     }
-                }
-                placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
-                font.pixelSize: ResponsiveHelper.fontSizes.sm
-                color: AppStyle.colors.textPrimary
-                placeholderTextColor: AppStyle.colors.textSecondary
-                background: Rectangle {
-                    color: AppStyle.colors.surface
-                    border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                    border.width: libNameInput.focus ? 2 : 1
-                    radius: AppStyle.radius.md
-                    Behavior on border.color {
-                        ColorAnimation {
-                            duration: AppStyle.durations.fast
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: AppStyle.spacing.md
+                        TextField {
+                            id: outputPathInput
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 36
+                            text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
+                            onTextChanged: {
+                                if (exportSettingsCard.exportSettingsController) {
+                                    exportSettingsCard.exportSettingsController.setOutputPath(text);
+                                }
+                            }
+                            placeholderText: qsTranslate("MainWindow", "选择输出目录")
+                            font.pixelSize: AppStyle.fontSizes.sm
+                            color: AppStyle.colors.textPrimary
+                            placeholderTextColor: AppStyle.colors.textSecondary
+                            background: Rectangle {
+                                color: AppStyle.colors.surface
+                                border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                                border.width: outputPathInput.focus ? 2 : 1
+                                radius: AppStyle.radius.md
+                            }
+                        }
+                        ModernButton {
+                            text: qsTranslate("MainWindow", "浏览")
+                            iconName: "folder"
+                            font.pixelSize: AppStyle.fontSizes.sm
+                            backgroundColor: AppStyle.colors.textSecondary
+                            hoverColor: AppStyle.colors.textPrimary
+                            pressedColor: AppStyle.colors.textPrimary
+                            onClicked: exportSettingsCard.openOutputFolderDialog()
                         }
                     }
-                    Behavior on border.width {
-                        NumberAnimation {
-                            duration: AppStyle.durations.fast
+                }
+
+                // 库名称
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "库名称")
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        font.bold: true
+                        color: AppStyle.colors.textPrimary
+                        horizontalAlignment: Text.AlignHCenter
+                    }
+                    TextField {
+                        id: libNameInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 36
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setLibName(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: libNameInput.focus ? 2 : 1
+                            radius: AppStyle.radius.md
                         }
                     }
                 }
             }
-        }
-    }
 
-    // 分隔
-    Item {
-        Layout.preferredHeight: 10
-        Layout.fillWidth: true
-    }
+            // ==================== 库元数据区块 ====================
+            SectionHeader {
+                id: metadataHeader
+                sectionTitle: qsTranslate("MainWindow", "库元数据")
+            }
 
-    // 原导出选项内容
-    Item {
-        Layout.fillWidth: true
-        Layout.columnSpan: 10  // 跨越10列
-        Layout.preferredHeight: exportOptionsLayout.implicitHeight
-        RowLayout {
-            id: exportOptionsLayout
-            anchors.fill: parent
-            spacing: 1
-            // 符号库选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+            GridLayout {
+                Layout.fillWidth: true
+                columns: 3
+                columnSpacing: AppStyle.spacing.md
+                rowSpacing: AppStyle.spacing.sm
+
+                // 符号库描述
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "符号库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textSecondary
+                    }
+                    TextField {
+                        id: symbolDescInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 32
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "符号库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: symbolDescInput.focus ? 2 : 1
+                            radius: AppStyle.radius.sm
+                        }
+                    }
+                }
+
+                // 封装库描述
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "封装库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textSecondary
+                    }
+                    TextField {
+                        id: footprintDescInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 32
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "封装库描述")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: footprintDescInput.focus ? 2 : 1
+                            radius: AppStyle.radius.sm
+                        }
+                    }
+                }
+
+                // 封装库关键词
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.xs
+                    Text {
+                        text: qsTranslate("MainWindow", "关键词")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textSecondary
+                    }
+                    TextField {
+                        id: footprintKeywordsInput
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 32
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
+                        onTextChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
+                            }
+                        }
+                        placeholderText: qsTranslate("MainWindow", "关键词")
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: AppStyle.colors.textPrimary
+                        placeholderTextColor: AppStyle.colors.textSecondary
+                        background: Rectangle {
+                            color: AppStyle.colors.surface
+                            border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: footprintKeywordsInput.focus ? 2 : 1
+                            radius: AppStyle.radius.sm
+                        }
+                    }
+                }
+            }
+
+            // ==================== 导出选项区块 ====================
+            SectionHeader {
+                id: exportOptionsHeader
+                sectionTitle: qsTranslate("MainWindow", "导出选项")
+            }
+
+            Flow {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.lg
+
+                // 符号库选项
                 CheckBox {
                     id: symbolCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "符号库")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportSymbol : false
                     onCheckedChanged: {
@@ -145,10 +264,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportSymbol(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出符号库文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -158,17 +276,6 @@ Card {
                         color: symbolCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: symbolCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -177,23 +284,18 @@ Card {
                             visible: symbolCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: symbolCheckbox.text
+                        font: symbolCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: symbolCheckbox.indicator.width + symbolCheckbox.spacing
                     }
                 }
-            }
-            // 封装库选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+
+                // 封装库选项
                 CheckBox {
                     id: footprintCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "封装库")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportFootprint : false
                     onCheckedChanged: {
@@ -201,10 +303,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportFootprint(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出封装库文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -214,17 +315,6 @@ Card {
                         color: footprintCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: footprintCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -233,159 +323,128 @@ Card {
                             visible: footprintCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: footprintCheckbox.text
+                        font: footprintCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: footprintCheckbox.indicator.width + footprintCheckbox.spacing
                     }
                 }
-            }
-            // 3D模型选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
-                CheckBox {
-                    id: model3dCheckbox
-                    Layout.fillWidth: true
-                    text: qsTranslate("MainWindow", "3D模型")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportModel3D(checked);
-                        }
-                    }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
-                    ToolTip.delay: 500
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: model3dCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
 
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: model3dCheckbox.checked
-                        }
-                    }
-
-                    contentItem: Text {
-                        text: parent.text
-                        font: parent.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
-                    }
-                }
-                // 3D模型格式按钮组 - 仅在3D模型启用时显示，独立切换
-                // 当两个格式都取消勾选时，自动取消3D模型主复选框
+                // 3D模型选项
                 RowLayout {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignHCenter
-                    spacing: ResponsiveHelper.spacing.xs
-                    visible: model3dCheckbox.checked
-                    // WRL 按钮 - 点击切换
-                    Rectangle {
-                        Layout.preferredWidth: 46
-                        Layout.preferredHeight: 26
-                        radius: AppStyle.radius.xs
-                        property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
-                        color: wrlActive ? AppStyle.colors.primary : "transparent"
-                        border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        MouseArea {
-                            id: wrlBtn
-                            anchors.fill: parent
-                            onClicked: {
-                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                if ((current & 1) !== 0) {
-                                    // WRL已选中，取消选中WRL
-                                    var newFormat = current & ~1;
-                                    if (newFormat === 0) {
-                                        // 两个都取消了，取消主复选框
-                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
-                                    } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
-                                    }
-                                } else {
-                                    // WRL未选中，勾选WRL
-                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
-                                }
+                    spacing: AppStyle.spacing.sm
+                    CheckBox {
+                        id: model3dCheckbox
+                        text: qsTranslate("MainWindow", "3D模型")
+                        checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
+                        onCheckedChanged: {
+                            if (exportSettingsCard.exportSettingsController) {
+                                exportSettingsCard.exportSettingsController.setExportModel3D(checked);
                             }
                         }
-                        Text {
-                            anchors.centerIn: parent
-                            text: "WRL"
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        ToolTip.visible: hovered
+                        ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
+                        indicator: Rectangle {
+                            implicitWidth: AppStyle.sizes.checkbox
+                            implicitHeight: AppStyle.sizes.checkbox
+                            x: model3dCheckbox.leftPadding
+                            y: parent.height / 2 - height / 2
+                            radius: AppStyle.radius.xs
+                            color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                            border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                            border.width: AppStyle.borderWidths.normal
+                            Text {
+                                anchors.centerIn: parent
+                                text: "✓"
+                                font.pixelSize: AppStyle.fontSizes.sm
+                                color: AppStyle.colors.textOnPrimary
+                                visible: model3dCheckbox.checked
+                            }
+                        }
+                        contentItem: Text {
+                            text: model3dCheckbox.text
+                            font: model3dCheckbox.font
+                            color: AppStyle.colors.textPrimary
+                            verticalAlignment: Text.AlignVCenter
+                            leftPadding: model3dCheckbox.indicator.width + model3dCheckbox.spacing
                         }
                     }
-                    // STEP 按钮 - 点击切换
-                    Rectangle {
-                        Layout.preferredWidth: 50
-                        Layout.preferredHeight: 26
-                        radius: AppStyle.radius.xs
-                        property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
-                        color: stepActive ? AppStyle.colors.primary : "transparent"
-                        border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        MouseArea {
-                            id: stepBtn
-                            anchors.fill: parent
-                            onClicked: {
-                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                if ((current & 2) !== 0) {
-                                    // STEP已选中，取消选中STEP
-                                    var newFormat = current & ~2;
-                                    if (newFormat === 0) {
-                                        // 两个都取消了，取消主复选框
-                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
+
+                    // 3D模型格式按钮组
+                    RowLayout {
+                        visible: model3dCheckbox.checked
+                        spacing: AppStyle.spacing.xs
+                        Rectangle {
+                            Layout.preferredWidth: 46
+                            Layout.preferredHeight: 26
+                            radius: AppStyle.radius.xs
+                            property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
+                            color: wrlActive ? AppStyle.colors.primary : "transparent"
+                            border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                            border.width: AppStyle.borderWidths.normal
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                    if ((current & 1) !== 0) {
+                                        var newFormat = current & ~1;
+                                        if (newFormat === 0) {
+                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                        } else {
+                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                        }
                                     } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
                                     }
-                                } else {
-                                    // STEP未选中，勾选STEP
-                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
                                 }
                             }
+                            Text {
+                                anchors.centerIn: parent
+                                text: "WRL"
+                                font.pixelSize: AppStyle.fontSizes.xs
+                                color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
+                            }
                         }
-                        Text {
-                            anchors.centerIn: parent
-                            text: "STEP"
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        Rectangle {
+                            Layout.preferredWidth: 50
+                            Layout.preferredHeight: 26
+                            radius: AppStyle.radius.xs
+                            property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
+                            color: stepActive ? AppStyle.colors.primary : "transparent"
+                            border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                            border.width: AppStyle.borderWidths.normal
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                    if ((current & 2) !== 0) {
+                                        var newFormat = current & ~2;
+                                        if (newFormat === 0) {
+                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                        } else {
+                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                        }
+                                    } else {
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
+                                    }
+                                }
+                            }
+                            Text {
+                                anchors.centerIn: parent
+                                text: "STEP"
+                                font.pixelSize: AppStyle.fontSizes.xs
+                                color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
+                            }
                         }
                     }
                 }
-            }
-            // 预览图选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+
+                // 预览图选项
                 CheckBox {
                     id: previewImagesCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "预览图")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportPreviewImages : false
                     onCheckedChanged: {
@@ -393,10 +452,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportPreviewImages(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出预览图文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -406,17 +464,6 @@ Card {
                         color: previewImagesCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: previewImagesCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -425,23 +472,18 @@ Card {
                             visible: previewImagesCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: previewImagesCheckbox.text
+                        font: previewImagesCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: previewImagesCheckbox.indicator.width + previewImagesCheckbox.spacing
                     }
                 }
-            }
-            // 手册选项
-            ColumnLayout {
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
+
+                // 手册选项
                 CheckBox {
                     id: datasheetCheckbox
-                    Layout.fillWidth: true
                     text: qsTranslate("MainWindow", "手册")
                     checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportDatasheet : false
                     onCheckedChanged: {
@@ -449,10 +491,9 @@ Card {
                             exportSettingsCard.exportSettingsController.setExportDatasheet(checked);
                         }
                     }
-                    font.pixelSize: ResponsiveHelper.fontSizes.md
+                    font.pixelSize: AppStyle.fontSizes.sm
                     ToolTip.visible: hovered
                     ToolTip.text: qsTranslate("MainWindow", "导出数据手册文件")
-                    ToolTip.delay: 500
                     indicator: Rectangle {
                         implicitWidth: AppStyle.sizes.checkbox
                         implicitHeight: AppStyle.sizes.checkbox
@@ -462,17 +503,6 @@ Card {
                         color: datasheetCheckbox.checked ? AppStyle.colors.primary : "transparent"
                         border.color: datasheetCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                         border.width: AppStyle.borderWidths.normal
-                        Behavior on color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-                        Behavior on border.color {
-                            ColorAnimation {
-                                duration: 150
-                            }
-                        }
-
                         Text {
                             anchors.centerIn: parent
                             text: "✓"
@@ -481,130 +511,118 @@ Card {
                             visible: datasheetCheckbox.checked
                         }
                     }
-
                     contentItem: Text {
-                        text: parent.text
-                        font: parent.font
+                        text: datasheetCheckbox.text
+                        font: datasheetCheckbox.font
                         color: AppStyle.colors.textPrimary
                         verticalAlignment: Text.AlignVCenter
-                        leftPadding: parent.indicator.width + parent.spacing
+                        leftPadding: datasheetCheckbox.indicator.width + datasheetCheckbox.spacing
                     }
                 }
             }
-            // 导出模式选项
-            ColumnLayout {
-                Layout.columnSpan: 2  // 跨越两列，分配更多空间
-                Layout.fillWidth: false  // 不填充宽度
-                spacing: ResponsiveHelper.spacing.sm
-                Text {
-                    Layout.fillWidth: true
-                    text: qsTranslate("MainWindow", "导出模式")
-                    font.pixelSize: ResponsiveHelper.fontSizes.sm
-                    font.bold: true
-                    color: AppStyle.colors.textPrimary
-                    horizontalAlignment: Text.AlignLeft
+
+            // ==================== 导出模式区块 ====================
+            SectionHeader {
+                id: exportModeHeader
+                sectionTitle: qsTranslate("MainWindow", "导出模式")
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xl
+
+                // 追加模式
+                RadioButton {
+                    id: appendModeRadio
+                    text: qsTranslate("MainWindow", "追加模式")
+                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
+                    onCheckedChanged: {
+                        if (checked && exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setExportMode(0);
+                        }
+                    }
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
+                    indicator: Rectangle {
+                        implicitWidth: AppStyle.sizes.radioButton
+                        implicitHeight: AppStyle.sizes.radioButton
+                        x: appendModeRadio.leftPadding
+                        y: parent.height / 2 - height / 2
+                        radius: width / 2
+                        color: "transparent"
+                        border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: AppStyle.sizes.radioButtonIndicator
+                            height: AppStyle.sizes.radioButtonIndicator
+                            radius: width / 2
+                            color: AppStyle.colors.primary
+                            visible: appendModeRadio.checked
+                        }
+                    }
+                    contentItem: Text {
+                        text: appendModeRadio.text
+                        font: appendModeRadio.font
+                        color: AppStyle.colors.textPrimary
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: appendModeRadio.indicator.width + appendModeRadio.spacing
+                    }
                 }
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: ResponsiveHelper.spacing.xs
-                    // 追加模式
-                    RowLayout {
-                        spacing: ResponsiveHelper.spacing.sm
-                        RadioButton {
-                            id: appendModeRadio
-                            text: qsTranslate("MainWindow", "追加")
-                            checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
-                            onCheckedChanged: {
-                                if (checked && exportSettingsCard.exportSettingsController) {
-                                    exportSettingsCard.exportSettingsController.setExportMode(0);
-                                }
-                            }
-                            font.pixelSize: ResponsiveHelper.fontSizes.sm
-                            ToolTip.visible: hovered
-                            ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
-                            ToolTip.delay: 500
-                            indicator: Rectangle {
-                                implicitWidth: AppStyle.sizes.radioButton
-                                implicitHeight: AppStyle.sizes.radioButton
-                                x: appendModeRadio.leftPadding
-                                y: parent.height / 2 - height / 2
-                                radius: width / 2  // 声明式圆角
-                                color: "transparent"
-                                border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                                border.width: AppStyle.borderWidths.normal
-                                Rectangle {
-                                    anchors.centerIn: parent
-                                    width: AppStyle.sizes.radioButtonIndicator
-                                    height: AppStyle.sizes.radioButtonIndicator
-                                    radius: width / 2  // 声明式圆角
-                                    color: AppStyle.colors.primary
-                                    visible: appendModeRadio.checked
-                                }
-                            }
 
-                            contentItem: Text {
-                                text: parent.text
-                                font: parent.font
-                                color: AppStyle.colors.textPrimary
-                                verticalAlignment: Text.AlignVCenter
-                                leftPadding: parent.indicator.width + parent.spacing
-                            }
-                        }
-                        Text {
-                            text: qsTranslate("MainWindow", "保留已存在的元器件")
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: AppStyle.colors.textSecondary
+                Text {
+                    text: qsTranslate("MainWindow", "保留已存在的元器件")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    color: AppStyle.colors.textSecondary
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                // 更新模式
+                RadioButton {
+                    id: updateModeRadio
+                    text: qsTranslate("MainWindow", "更新模式")
+                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
+                    onCheckedChanged: {
+                        if (checked && exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setExportMode(1);
                         }
                     }
-                    // 更新模式
-                    RowLayout {
-                        spacing: ResponsiveHelper.spacing.sm
-                        RadioButton {
-                            id: updateModeRadio
-                            text: qsTranslate("MainWindow", "更新")
-                            checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
-                            onCheckedChanged: {
-                                if (checked && exportSettingsCard.exportSettingsController) {
-                                    exportSettingsCard.exportSettingsController.setExportMode(1);
-                                }
-                            }
-                            font.pixelSize: ResponsiveHelper.fontSizes.sm
-                            ToolTip.visible: hovered
-                            ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                            ToolTip.delay: 500
-                            indicator: Rectangle {
-                                implicitWidth: AppStyle.sizes.radioButton
-                                implicitHeight: AppStyle.sizes.radioButton
-                                x: updateModeRadio.leftPadding
-                                y: parent.height / 2 - height / 2
-                                radius: width / 2  // 声明式圆角
-                                color: "transparent"
-                                border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                                border.width: AppStyle.borderWidths.normal
-                                Rectangle {
-                                    anchors.centerIn: parent
-                                    width: AppStyle.sizes.radioButtonIndicator
-                                    height: AppStyle.sizes.radioButtonIndicator
-                                    radius: width / 2  // 声明式圆角
-                                    color: AppStyle.colors.primary
-                                    visible: updateModeRadio.checked
-                                }
-                            }
-
-                            contentItem: Text {
-                                text: parent.text
-                                font: parent.font
-                                color: AppStyle.colors.textPrimary
-                                verticalAlignment: Text.AlignVCenter
-                                leftPadding: parent.indicator.width + parent.spacing
-                            }
-                        }
-                        Text {
-                            text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                            font.pixelSize: ResponsiveHelper.fontSizes.xs
-                            color: AppStyle.colors.textSecondary
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                    indicator: Rectangle {
+                        implicitWidth: AppStyle.sizes.radioButton
+                        implicitHeight: AppStyle.sizes.radioButton
+                        x: updateModeRadio.leftPadding
+                        y: parent.height / 2 - height / 2
+                        radius: width / 2
+                        color: "transparent"
+                        border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: AppStyle.sizes.radioButtonIndicator
+                            height: AppStyle.sizes.radioButtonIndicator
+                            radius: width / 2
+                            color: AppStyle.colors.primary
+                            visible: updateModeRadio.checked
                         }
                     }
+                    contentItem: Text {
+                        text: updateModeRadio.text
+                        font: updateModeRadio.font
+                        color: AppStyle.colors.textPrimary
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: updateModeRadio.indicator.width + updateModeRadio.spacing
+                    }
+                }
+
+                Text {
+                    text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    color: AppStyle.colors.textSecondary
+                    verticalAlignment: Text.AlignVCenter
                 }
             }
         }

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -8,38 +8,29 @@ Card {
     property var exportSettingsController
     signal openOutputFolderDialog
     title: qsTranslate("MainWindow", "导出设置")
-
-    ScrollView {
-        id: scrollView
+    ColumnLayout {
+        id: rootLayout
         width: parent.width
-        height: parent.height
-        clip: true
-        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-        ScrollBar.vertical.policy: ScrollBar.AsNeeded
-
-        ColumnLayout {
-            id: rootLayout
-            width: scrollView.availableWidth > 0 ? scrollView.availableWidth : parent.width
-            spacing: AppStyle.spacing.md
-
-            // ==================== SectionHeader 组件 ====================
-            component SectionHeader: RowLayout {
-                Layout.fillWidth: true
-                spacing: AppStyle.spacing.sm
-                property string sectionTitle: ""
-                Text {
-                    text: sectionTitle
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    font.bold: true
-                    color: AppStyle.colors.textSecondary
-                }
-                Rectangle {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 1
-                    color: AppStyle.colors.border
-                    opacity: 0.5
-                }
+        spacing: AppStyle.spacing.lg
+        anchors.margins: AppStyle.spacing.md
+        // ==================== SectionHeader 组件 ====================
+        component SectionHeader: RowLayout {
+            Layout.fillWidth: true
+            spacing: AppStyle.spacing.sm
+            property string sectionTitle: ""
+            Text {
+                text: sectionTitle
+                font.pixelSize: AppStyle.fontSizes.sm
+                font.bold: true
+                color: AppStyle.colors.textSecondary
             }
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 1
+                color: AppStyle.colors.border
+                opacity: 0.5
+            }
+        }
 
             // ==================== 基础配置区块 ====================
             SectionHeader {
@@ -52,7 +43,6 @@ Card {
                 columns: 2
                 columnSpacing: AppStyle.spacing.xl
                 rowSpacing: AppStyle.spacing.md
-
                 // 输出路径
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -81,7 +71,7 @@ Card {
                             font.pixelSize: AppStyle.fontSizes.sm
                             color: AppStyle.colors.textPrimary
                             placeholderTextColor: AppStyle.colors.textSecondary
-                            background: Rectangle {
+                                background: Rectangle {
                                 color: AppStyle.colors.surface
                                 border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
                                 border.width: outputPathInput.focus ? 2 : 1
@@ -146,7 +136,6 @@ Card {
                 columns: 3
                 columnSpacing: AppStyle.spacing.md
                 rowSpacing: AppStyle.spacing.sm
-
                 // 符号库描述
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -253,7 +242,6 @@ Card {
             Flow {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.lg
-
                 // 符号库选项
                 CheckBox {
                     id: symbolCheckbox
@@ -530,7 +518,6 @@ Card {
             RowLayout {
                 Layout.fillWidth: true
                 spacing: AppStyle.spacing.xl
-
                 // 追加模式
                 RadioButton {
                     id: appendModeRadio
@@ -627,4 +614,3 @@ Card {
             }
         }
     }
-}

--- a/src/ui/qml/components/ExportSettingsCard.qml
+++ b/src/ui/qml/components/ExportSettingsCard.qml
@@ -13,604 +13,603 @@ Card {
         width: parent.width
         spacing: AppStyle.spacing.lg
         anchors.margins: AppStyle.spacing.md
-        // ==================== SectionHeader 组件 ====================
-        component SectionHeader: RowLayout {
-            Layout.fillWidth: true
-            spacing: AppStyle.spacing.sm
-            property string sectionTitle: ""
-            Text {
-                text: sectionTitle
-                font.pixelSize: AppStyle.fontSizes.sm
-                font.bold: true
-                color: AppStyle.colors.textSecondary
-            }
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 1
-                color: AppStyle.colors.border
-                opacity: 0.5
-            }
+        // ==================== 基础配置区块 ====================
+        SectionHeader {
+            id: basicConfigHeader
+            sectionTitle: qsTranslate("MainWindow", "基础配置")
         }
 
-            // ==================== 基础配置区块 ====================
-            SectionHeader {
-                id: basicConfigHeader
-                sectionTitle: qsTranslate("MainWindow", "基础配置")
-            }
-
-            GridLayout {
+        GridLayout {
+            Layout.fillWidth: true
+            columns: 2
+            columnSpacing: AppStyle.spacing.xl
+            rowSpacing: AppStyle.spacing.md
+            // 输出路径
+            ColumnLayout {
                 Layout.fillWidth: true
-                columns: 2
-                columnSpacing: AppStyle.spacing.xl
-                rowSpacing: AppStyle.spacing.md
-                // 输出路径
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "输出路径")
-                        font.pixelSize: AppStyle.fontSizes.sm
-                        font.bold: true
-                        color: AppStyle.colors.textPrimary
-                        horizontalAlignment: Text.AlignHCenter
-                    }
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: AppStyle.spacing.md
-                        TextField {
-                            id: outputPathInput
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: 36
-                            text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
-                            onTextChanged: {
-                                if (exportSettingsCard.exportSettingsController) {
-                                    exportSettingsCard.exportSettingsController.setOutputPath(text);
-                                }
-                            }
-                            placeholderText: qsTranslate("MainWindow", "选择输出目录")
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textPrimary
-                            placeholderTextColor: AppStyle.colors.textSecondary
-                                background: Rectangle {
-                                color: AppStyle.colors.surface
-                                border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                                border.width: outputPathInput.focus ? 2 : 1
-                                radius: AppStyle.radius.md
-                            }
-                        }
-                        ModernButton {
-                            text: qsTranslate("MainWindow", "浏览")
-                            iconName: "folder"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            backgroundColor: AppStyle.colors.textSecondary
-                            hoverColor: AppStyle.colors.textPrimary
-                            pressedColor: AppStyle.colors.textPrimary
-                            onClicked: exportSettingsCard.openOutputFolderDialog()
-                        }
-                    }
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "输出路径")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
+                    horizontalAlignment: Text.AlignHCenter
                 }
-
-                // 库名称
-                ColumnLayout {
+                RowLayout {
                     Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "库名称")
-                        font.pixelSize: AppStyle.fontSizes.sm
-                        font.bold: true
-                        color: AppStyle.colors.textPrimary
-                        horizontalAlignment: Text.AlignHCenter
-                    }
+                    spacing: AppStyle.spacing.md
                     TextField {
-                        id: libNameInput
+                        id: outputPathInput
                         Layout.fillWidth: true
                         Layout.preferredHeight: 36
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
+                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.outputPath : ""
                         onTextChanged: {
                             if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setLibName(text);
+                                exportSettingsCard.exportSettingsController.setOutputPath(text);
                             }
                         }
-                        placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
+                        placeholderText: qsTranslate("MainWindow", "选择输出目录")
                         font.pixelSize: AppStyle.fontSizes.sm
                         color: AppStyle.colors.textPrimary
                         placeholderTextColor: AppStyle.colors.textSecondary
                         background: Rectangle {
                             color: AppStyle.colors.surface
-                            border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: libNameInput.focus ? 2 : 1
+                            border.color: outputPathInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                            border.width: outputPathInput.focus ? 2 : 1
                             radius: AppStyle.radius.md
                         }
                     }
-                }
-            }
-
-            // ==================== 库元数据区块 ====================
-            SectionHeader {
-                id: metadataHeader
-                sectionTitle: qsTranslate("MainWindow", "库元数据")
-            }
-
-            GridLayout {
-                Layout.fillWidth: true
-                columns: 3
-                columnSpacing: AppStyle.spacing.md
-                rowSpacing: AppStyle.spacing.sm
-                // 符号库描述
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "符号库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textSecondary
-                    }
-                    TextField {
-                        id: symbolDescInput
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 32
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
-                        onTextChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
-                            }
-                        }
-                        placeholderText: qsTranslate("MainWindow", "符号库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textPrimary
-                        placeholderTextColor: AppStyle.colors.textSecondary
-                        background: Rectangle {
-                            color: AppStyle.colors.surface
-                            border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: symbolDescInput.focus ? 2 : 1
-                            radius: AppStyle.radius.sm
-                        }
-                    }
-                }
-
-                // 封装库描述
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "封装库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textSecondary
-                    }
-                    TextField {
-                        id: footprintDescInput
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 32
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
-                        onTextChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
-                            }
-                        }
-                        placeholderText: qsTranslate("MainWindow", "封装库描述")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textPrimary
-                        placeholderTextColor: AppStyle.colors.textSecondary
-                        background: Rectangle {
-                            color: AppStyle.colors.surface
-                            border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: footprintDescInput.focus ? 2 : 1
-                            radius: AppStyle.radius.sm
-                        }
-                    }
-                }
-
-                // 封装库关键词
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    spacing: AppStyle.spacing.xs
-                    Text {
-                        text: qsTranslate("MainWindow", "关键词")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textSecondary
-                    }
-                    TextField {
-                        id: footprintKeywordsInput
-                        Layout.fillWidth: true
-                        Layout.preferredHeight: 32
-                        text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
-                        onTextChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
-                            }
-                        }
-                        placeholderText: qsTranslate("MainWindow", "关键词")
-                        font.pixelSize: AppStyle.fontSizes.xs
-                        color: AppStyle.colors.textPrimary
-                        placeholderTextColor: AppStyle.colors.textSecondary
-                        background: Rectangle {
-                            color: AppStyle.colors.surface
-                            border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
-                            border.width: footprintKeywordsInput.focus ? 2 : 1
-                            radius: AppStyle.radius.sm
-                        }
-                    }
-                }
-            }
-
-            // ==================== 导出选项区块 ====================
-            SectionHeader {
-                id: exportOptionsHeader
-                sectionTitle: qsTranslate("MainWindow", "导出选项")
-            }
-
-            Flow {
-                Layout.fillWidth: true
-                spacing: AppStyle.spacing.lg
-                // 符号库选项
-                CheckBox {
-                    id: symbolCheckbox
-                    text: qsTranslate("MainWindow", "符号库")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportSymbol : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportSymbol(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出符号库文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: symbolCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: symbolCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: symbolCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: symbolCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: symbolCheckbox.text
-                        font: symbolCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: symbolCheckbox.indicator.width + symbolCheckbox.spacing
-                    }
-                }
-
-                // 封装库选项
-                CheckBox {
-                    id: footprintCheckbox
-                    text: qsTranslate("MainWindow", "封装库")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportFootprint : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportFootprint(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出封装库文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: footprintCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: footprintCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: footprintCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: footprintCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: footprintCheckbox.text
-                        font: footprintCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: footprintCheckbox.indicator.width + footprintCheckbox.spacing
-                    }
-                }
-
-                // 3D模型选项
-                RowLayout {
-                    spacing: AppStyle.spacing.sm
-                    CheckBox {
-                        id: model3dCheckbox
-                        text: qsTranslate("MainWindow", "3D模型")
-                        checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
-                        onCheckedChanged: {
-                            if (exportSettingsCard.exportSettingsController) {
-                                exportSettingsCard.exportSettingsController.setExportModel3D(checked);
-                            }
-                        }
+                    ModernButton {
+                        text: qsTranslate("MainWindow", "浏览")
+                        iconName: "folder"
                         font.pixelSize: AppStyle.fontSizes.sm
-                        ToolTip.visible: hovered
-                        ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
-                        indicator: Rectangle {
-                            implicitWidth: AppStyle.sizes.checkbox
-                            implicitHeight: AppStyle.sizes.checkbox
-                            x: model3dCheckbox.leftPadding
-                            y: parent.height / 2 - height / 2
-                            radius: AppStyle.radius.xs
-                            color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                            border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                            border.width: AppStyle.borderWidths.normal
-                            Text {
-                                anchors.centerIn: parent
-                                text: "✓"
-                                font.pixelSize: AppStyle.fontSizes.sm
-                                color: AppStyle.colors.textOnPrimary
-                                visible: model3dCheckbox.checked
-                            }
-                        }
-                        contentItem: Text {
-                            text: model3dCheckbox.text
-                            font: model3dCheckbox.font
-                            color: AppStyle.colors.textPrimary
-                            verticalAlignment: Text.AlignVCenter
-                            leftPadding: model3dCheckbox.indicator.width + model3dCheckbox.spacing
-                        }
-                    }
-
-                    // 3D模型格式按钮组
-                    RowLayout {
-                        visible: model3dCheckbox.checked
-                        spacing: AppStyle.spacing.xs
-                        Rectangle {
-                            Layout.preferredWidth: 46
-                            Layout.preferredHeight: 26
-                            radius: AppStyle.radius.xs
-                            property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
-                            color: wrlActive ? AppStyle.colors.primary : "transparent"
-                            border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                            border.width: AppStyle.borderWidths.normal
-                            MouseArea {
-                                anchors.fill: parent
-                                onClicked: {
-                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                    if ((current & 1) !== 0) {
-                                        var newFormat = current & ~1;
-                                        if (newFormat === 0) {
-                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
-                                        } else {
-                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
-                                        }
-                                    } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
-                                    }
-                                }
-                            }
-                            Text {
-                                anchors.centerIn: parent
-                                text: "WRL"
-                                font.pixelSize: AppStyle.fontSizes.xs
-                                color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
-                            }
-                        }
-                        Rectangle {
-                            Layout.preferredWidth: 50
-                            Layout.preferredHeight: 26
-                            radius: AppStyle.radius.xs
-                            property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
-                            color: stepActive ? AppStyle.colors.primary : "transparent"
-                            border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                            border.width: AppStyle.borderWidths.normal
-                            MouseArea {
-                                anchors.fill: parent
-                                onClicked: {
-                                    var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
-                                    if ((current & 2) !== 0) {
-                                        var newFormat = current & ~2;
-                                        if (newFormat === 0) {
-                                            exportSettingsCard.exportSettingsController.setExportModel3D(false);
-                                        } else {
-                                            exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
-                                        }
-                                    } else {
-                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
-                                    }
-                                }
-                            }
-                            Text {
-                                anchors.centerIn: parent
-                                text: "STEP"
-                                font.pixelSize: AppStyle.fontSizes.xs
-                                color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
-                            }
-                        }
-                    }
-                }
-
-                // 预览图选项
-                CheckBox {
-                    id: previewImagesCheckbox
-                    text: qsTranslate("MainWindow", "预览图")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportPreviewImages : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportPreviewImages(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出预览图文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: previewImagesCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: previewImagesCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: previewImagesCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: previewImagesCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: previewImagesCheckbox.text
-                        font: previewImagesCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: previewImagesCheckbox.indicator.width + previewImagesCheckbox.spacing
-                    }
-                }
-
-                // 手册选项
-                CheckBox {
-                    id: datasheetCheckbox
-                    text: qsTranslate("MainWindow", "手册")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportDatasheet : false
-                    onCheckedChanged: {
-                        if (exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportDatasheet(checked);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "导出数据手册文件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.checkbox
-                        implicitHeight: AppStyle.sizes.checkbox
-                        x: datasheetCheckbox.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: AppStyle.radius.xs
-                        color: datasheetCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                        border.color: datasheetCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Text {
-                            anchors.centerIn: parent
-                            text: "✓"
-                            font.pixelSize: AppStyle.fontSizes.sm
-                            color: AppStyle.colors.textOnPrimary
-                            visible: datasheetCheckbox.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: datasheetCheckbox.text
-                        font: datasheetCheckbox.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: datasheetCheckbox.indicator.width + datasheetCheckbox.spacing
+                        backgroundColor: AppStyle.colors.textSecondary
+                        hoverColor: AppStyle.colors.textPrimary
+                        pressedColor: AppStyle.colors.textPrimary
+                        onClicked: exportSettingsCard.openOutputFolderDialog()
                     }
                 }
             }
 
-            // ==================== 导出模式区块 ====================
-            SectionHeader {
-                id: exportModeHeader
-                sectionTitle: qsTranslate("MainWindow", "导出模式")
-            }
-
-            RowLayout {
+            // 库名称
+            ColumnLayout {
                 Layout.fillWidth: true
-                spacing: AppStyle.spacing.xl
-                // 追加模式
-                RadioButton {
-                    id: appendModeRadio
-                    text: qsTranslate("MainWindow", "追加模式")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
-                    onCheckedChanged: {
-                        if (checked && exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportMode(0);
-                        }
-                    }
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.radioButton
-                        implicitHeight: AppStyle.sizes.radioButton
-                        x: appendModeRadio.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: width / 2
-                        color: "transparent"
-                        border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Rectangle {
-                            anchors.centerIn: parent
-                            width: AppStyle.sizes.radioButtonIndicator
-                            height: AppStyle.sizes.radioButtonIndicator
-                            radius: width / 2
-                            color: AppStyle.colors.primary
-                            visible: appendModeRadio.checked
-                        }
-                    }
-                    contentItem: Text {
-                        text: appendModeRadio.text
-                        font: appendModeRadio.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: appendModeRadio.indicator.width + appendModeRadio.spacing
-                    }
-                }
-
+                spacing: AppStyle.spacing.xs
                 Text {
-                    text: qsTranslate("MainWindow", "保留已存在的元器件")
+                    text: qsTranslate("MainWindow", "库名称")
                     font.pixelSize: AppStyle.fontSizes.sm
-                    color: AppStyle.colors.textSecondary
-                    verticalAlignment: Text.AlignVCenter
+                    font.bold: true
+                    color: AppStyle.colors.textPrimary
+                    horizontalAlignment: Text.AlignHCenter
                 }
-
-                // 更新模式
-                RadioButton {
-                    id: updateModeRadio
-                    text: qsTranslate("MainWindow", "更新模式")
-                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
-                    onCheckedChanged: {
-                        if (checked && exportSettingsCard.exportSettingsController) {
-                            exportSettingsCard.exportSettingsController.setExportMode(1);
+                TextField {
+                    id: libNameInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.libName : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setLibName(text);
                         }
                     }
+                    placeholderText: qsTranslate("MainWindow", "输入库名称 (例如: MyLibrary)")
                     font.pixelSize: AppStyle.fontSizes.sm
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                    indicator: Rectangle {
-                        implicitWidth: AppStyle.sizes.radioButton
-                        implicitHeight: AppStyle.sizes.radioButton
-                        x: updateModeRadio.leftPadding
-                        y: parent.height / 2 - height / 2
-                        radius: width / 2
-                        color: "transparent"
-                        border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                        border.width: AppStyle.borderWidths.normal
-                        Rectangle {
-                            anchors.centerIn: parent
-                            width: AppStyle.sizes.radioButtonIndicator
-                            height: AppStyle.sizes.radioButtonIndicator
-                            radius: width / 2
-                            color: AppStyle.colors.primary
-                            visible: updateModeRadio.checked
-                        }
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: libNameInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: libNameInput.focus ? 2 : 1
+                        radius: AppStyle.radius.md
                     }
-                    contentItem: Text {
-                        text: updateModeRadio.text
-                        font: updateModeRadio.font
-                        color: AppStyle.colors.textPrimary
-                        verticalAlignment: Text.AlignVCenter
-                        leftPadding: updateModeRadio.indicator.width + updateModeRadio.spacing
-                    }
-                }
-
-                Text {
-                    text: qsTranslate("MainWindow", "覆盖已存在的元器件")
-                    font.pixelSize: AppStyle.fontSizes.sm
-                    color: AppStyle.colors.textSecondary
-                    verticalAlignment: Text.AlignVCenter
                 }
             }
         }
+
+        // ==================== 库元数据区块 ====================
+        SectionHeader {
+            id: metadataHeader
+            sectionTitle: qsTranslate("MainWindow", "库元数据")
+        }
+
+        GridLayout {
+            Layout.fillWidth: true
+            columns: 3
+            columnSpacing: AppStyle.spacing.md
+            rowSpacing: AppStyle.spacing.sm
+            // 符号库描述
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "符号库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textSecondary
+                }
+                TextField {
+                    id: symbolDescInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 32
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.symbolLibraryDescription : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setSymbolLibraryDescription(text);
+                        }
+                    }
+                    placeholderText: qsTranslate("MainWindow", "符号库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: symbolDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: symbolDescInput.focus ? 2 : 1
+                        radius: AppStyle.radius.sm
+                    }
+                }
+            }
+
+            // 封装库描述
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "封装库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textSecondary
+                }
+                TextField {
+                    id: footprintDescInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 32
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryDescription : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setFootprintLibraryDescription(text);
+                        }
+                    }
+                    placeholderText: qsTranslate("MainWindow", "封装库描述")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: footprintDescInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: footprintDescInput.focus ? 2 : 1
+                        radius: AppStyle.radius.sm
+                    }
+                }
+            }
+
+            // 封装库关键词
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: AppStyle.spacing.xs
+                Text {
+                    text: qsTranslate("MainWindow", "关键词")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textSecondary
+                }
+                TextField {
+                    id: footprintKeywordsInput
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 32
+                    text: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.footprintLibraryKeywords : ""
+                    onTextChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setFootprintLibraryKeywords(text);
+                        }
+                    }
+                    placeholderText: qsTranslate("MainWindow", "关键词")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textPrimary
+                    placeholderTextColor: AppStyle.colors.textSecondary
+                    background: Rectangle {
+                        color: AppStyle.colors.surface
+                        border.color: footprintKeywordsInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                        border.width: footprintKeywordsInput.focus ? 2 : 1
+                        radius: AppStyle.radius.sm
+                    }
+                }
+            }
+        }
+
+        // ==================== 导出选项区块 ====================
+        SectionHeader {
+            id: exportOptionsHeader
+            sectionTitle: qsTranslate("MainWindow", "导出选项")
+        }
+
+        Flow {
+            Layout.fillWidth: true
+            spacing: AppStyle.spacing.lg
+            // 符号库选项
+            CheckBox {
+                id: symbolCheckbox
+                text: qsTranslate("MainWindow", "符号库")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportSymbol : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportSymbol(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出符号库文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: symbolCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: symbolCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: symbolCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: symbolCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: symbolCheckbox.text
+                    font: symbolCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: symbolCheckbox.indicator.width + symbolCheckbox.spacing
+                }
+            }
+
+            // 封装库选项
+            CheckBox {
+                id: footprintCheckbox
+                text: qsTranslate("MainWindow", "封装库")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportFootprint : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportFootprint(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出封装库文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: footprintCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: footprintCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: footprintCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: footprintCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: footprintCheckbox.text
+                    font: footprintCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: footprintCheckbox.indicator.width + footprintCheckbox.spacing
+                }
+            }
+
+            // 3D模型选项
+            RowLayout {
+                spacing: AppStyle.spacing.sm
+                CheckBox {
+                    id: model3dCheckbox
+                    text: qsTranslate("MainWindow", "3D模型")
+                    checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportModel3D : false
+                    onCheckedChanged: {
+                        if (exportSettingsCard.exportSettingsController) {
+                            exportSettingsCard.exportSettingsController.setExportModel3D(checked);
+                        }
+                    }
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTranslate("MainWindow", "导出 3D 模型文件")
+                    indicator: Rectangle {
+                        implicitWidth: AppStyle.sizes.checkbox
+                        implicitHeight: AppStyle.sizes.checkbox
+                        x: model3dCheckbox.leftPadding
+                        y: parent.height / 2 - height / 2
+                        radius: AppStyle.radius.xs
+                        color: model3dCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                        border.color: model3dCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        Text {
+                            anchors.centerIn: parent
+                            text: "✓"
+                            font.pixelSize: AppStyle.fontSizes.sm
+                            color: AppStyle.colors.textOnPrimary
+                            visible: model3dCheckbox.checked
+                        }
+                    }
+                    contentItem: Text {
+                        text: model3dCheckbox.text
+                        font: model3dCheckbox.font
+                        color: AppStyle.colors.textPrimary
+                        verticalAlignment: Text.AlignVCenter
+                        leftPadding: model3dCheckbox.indicator.width + model3dCheckbox.spacing
+                    }
+                }
+
+                // 3D模型格式按钮组
+                RowLayout {
+                    visible: model3dCheckbox.checked
+                    spacing: AppStyle.spacing.xs
+                    Rectangle {
+                        Layout.preferredWidth: 46
+                        Layout.preferredHeight: 26
+                        radius: AppStyle.radius.xs
+                        property bool wrlActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 1) !== 0 : false
+                        color: wrlActive ? AppStyle.colors.primary : "transparent"
+                        border.color: wrlActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                if ((current & 1) !== 0) {
+                                    var newFormat = current & ~1;
+                                    if (newFormat === 0) {
+                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                    } else {
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                    }
+                                } else {
+                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 1);
+                                }
+                            }
+                        }
+                        Text {
+                            anchors.centerIn: parent
+                            text: "WRL"
+                            font.pixelSize: AppStyle.fontSizes.xs
+                            color: parent.wrlActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        }
+                    }
+                    Rectangle {
+                        Layout.preferredWidth: 50
+                        Layout.preferredHeight: 26
+                        radius: AppStyle.radius.xs
+                        property bool stepActive: exportSettingsCard.exportSettingsController ? (exportSettingsCard.exportSettingsController.exportModel3DFormat & 2) !== 0 : false
+                        color: stepActive ? AppStyle.colors.primary : "transparent"
+                        border.color: stepActive ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        border.width: AppStyle.borderWidths.normal
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                var current = exportSettingsCard.exportSettingsController.exportModel3DFormat;
+                                if ((current & 2) !== 0) {
+                                    var newFormat = current & ~2;
+                                    if (newFormat === 0) {
+                                        exportSettingsCard.exportSettingsController.setExportModel3D(false);
+                                    } else {
+                                        exportSettingsCard.exportSettingsController.setExportModel3DFormat(newFormat);
+                                    }
+                                } else {
+                                    exportSettingsCard.exportSettingsController.setExportModel3DFormat(current | 2);
+                                }
+                            }
+                        }
+                        Text {
+                            anchors.centerIn: parent
+                            text: "STEP"
+                            font.pixelSize: AppStyle.fontSizes.xs
+                            color: parent.stepActive ? "#ffffff" : AppStyle.colors.textSecondary
+                        }
+                    }
+                }
+            }
+
+            // 预览图选项
+            CheckBox {
+                id: previewImagesCheckbox
+                text: qsTranslate("MainWindow", "预览图")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportPreviewImages : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportPreviewImages(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出预览图文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: previewImagesCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: previewImagesCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: previewImagesCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: previewImagesCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: previewImagesCheckbox.text
+                    font: previewImagesCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: previewImagesCheckbox.indicator.width + previewImagesCheckbox.spacing
+                }
+            }
+
+            // 手册选项
+            CheckBox {
+                id: datasheetCheckbox
+                text: qsTranslate("MainWindow", "手册")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportDatasheet : false
+                onCheckedChanged: {
+                    if (exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportDatasheet(checked);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "导出数据手册文件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.checkbox
+                    implicitHeight: AppStyle.sizes.checkbox
+                    x: datasheetCheckbox.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: AppStyle.radius.xs
+                    color: datasheetCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                    border.color: datasheetCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Text {
+                        anchors.centerIn: parent
+                        text: "✓"
+                        font.pixelSize: AppStyle.fontSizes.sm
+                        color: AppStyle.colors.textOnPrimary
+                        visible: datasheetCheckbox.checked
+                    }
+                }
+                contentItem: Text {
+                    text: datasheetCheckbox.text
+                    font: datasheetCheckbox.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: datasheetCheckbox.indicator.width + datasheetCheckbox.spacing
+                }
+            }
+        }
+
+        // ==================== 导出模式区块 ====================
+        SectionHeader {
+            id: exportModeHeader
+            sectionTitle: qsTranslate("MainWindow", "导出模式")
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: AppStyle.spacing.xl
+            // 追加模式
+            RadioButton {
+                id: appendModeRadio
+                text: qsTranslate("MainWindow", "追加模式")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 0 : true
+                onCheckedChanged: {
+                    if (checked && exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportMode(0);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "保留已存在的元器件，只追加新的元器件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.radioButton
+                    implicitHeight: AppStyle.sizes.radioButton
+                    x: appendModeRadio.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: width / 2
+                    color: "transparent"
+                    border.color: appendModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: AppStyle.sizes.radioButtonIndicator
+                        height: AppStyle.sizes.radioButtonIndicator
+                        radius: width / 2
+                        color: AppStyle.colors.primary
+                        visible: appendModeRadio.checked
+                    }
+                }
+                contentItem: Text {
+                    text: appendModeRadio.text
+                    font: appendModeRadio.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: appendModeRadio.indicator.width + appendModeRadio.spacing
+                }
+            }
+
+            Text {
+                text: qsTranslate("MainWindow", "保留已存在的元器件")
+                font.pixelSize: AppStyle.fontSizes.sm
+                color: AppStyle.colors.textSecondary
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            // 更新模式
+            RadioButton {
+                id: updateModeRadio
+                text: qsTranslate("MainWindow", "更新模式")
+                checked: exportSettingsCard.exportSettingsController ? exportSettingsCard.exportSettingsController.exportMode === 1 : false
+                onCheckedChanged: {
+                    if (checked && exportSettingsCard.exportSettingsController) {
+                        exportSettingsCard.exportSettingsController.setExportMode(1);
+                    }
+                }
+                font.pixelSize: AppStyle.fontSizes.sm
+                ToolTip.visible: hovered
+                ToolTip.text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                indicator: Rectangle {
+                    implicitWidth: AppStyle.sizes.radioButton
+                    implicitHeight: AppStyle.sizes.radioButton
+                    x: updateModeRadio.leftPadding
+                    y: parent.height / 2 - height / 2
+                    radius: width / 2
+                    color: "transparent"
+                    border.color: updateModeRadio.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    border.width: AppStyle.borderWidths.normal
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: AppStyle.sizes.radioButtonIndicator
+                        height: AppStyle.sizes.radioButtonIndicator
+                        radius: width / 2
+                        color: AppStyle.colors.primary
+                        visible: updateModeRadio.checked
+                    }
+                }
+                contentItem: Text {
+                    text: updateModeRadio.text
+                    font: updateModeRadio.font
+                    color: AppStyle.colors.textPrimary
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: updateModeRadio.indicator.width + updateModeRadio.spacing
+                }
+            }
+
+            Text {
+                text: qsTranslate("MainWindow", "覆盖已存在的元器件")
+                font.pixelSize: AppStyle.fontSizes.sm
+                color: AppStyle.colors.textSecondary
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
     }
+    // ==================== SectionHeader 组件 ====================
+    component SectionHeader: RowLayout {
+        Layout.fillWidth: true
+        spacing: AppStyle.spacing.sm
+        property string sectionTitle: ""
+        Text {
+            text: sectionTitle
+            font.pixelSize: AppStyle.fontSizes.sm
+            font.bold: true
+            color: AppStyle.colors.textSecondary
+        }
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+            color: AppStyle.colors.border
+            opacity: 0.5
+        }
+    }
+}

--- a/src/ui/qml/components/HeaderSection.qml
+++ b/src/ui/qml/components/HeaderSection.qml
@@ -93,14 +93,25 @@ ColumnLayout {
                 y: languageComboBox.topPadding + (languageComboBox.availableHeight - height) / 2
                 width: 12
                 height: 8
-
                 ShapePath {
                     strokeWidth: 0
                     fillColor: AppStyle.colors.textSecondary
-                    PathMove { x: 0; y: 0 }
-                    PathLine { x: indicatorShape.width / 2; y: indicatorShape.height }
-                    PathLine { x: indicatorShape.width; y: 0 }
-                    PathLine { x: 0; y: 0 }
+                    PathMove {
+                        x: 0
+                        y: 0
+                    }
+                    PathLine {
+                        x: indicatorShape.width / 2
+                        y: indicatorShape.height
+                    }
+                    PathLine {
+                        x: indicatorShape.width
+                        y: 0
+                    }
+                    PathLine {
+                        x: 0
+                        y: 0
+                    }
                 }
             }
 

--- a/src/ui/qml/components/SliderDialogBase.qml
+++ b/src/ui/qml/components/SliderDialogBase.qml
@@ -28,6 +28,8 @@ FocusScope {
     focus: visible
     // ===== 子类可覆盖的属性 =====
     property bool hasOverlay: false
+    /** @property Component mainContentSource - 子类可通过此属性在按钮上方添加主要内容组件（如输入框） */
+    property Component mainContentSource: null
     /** @property Component extraContentSource - 子类可通过此属性添加额外内容组件（如复选框） */
     property Component extraContentSource: null
     // ===== 共用常量 =====
@@ -42,6 +44,7 @@ FocusScope {
     property alias dialogBox: dialogBox  // 对话框容器
     property alias dialogBoxTranslate: dialogBoxTranslate  // 对话框位移
     property alias buttonColLayout: buttonColLayout  // 按钮列布局
+    property alias showAnimation: showAnim  // 打开动画
     // ===== 按钮规格列表 =====
     // 格式: { text, color, action } 或 { isSeparator: true }
     property list<var> buttonSpecs
@@ -68,7 +71,7 @@ FocusScope {
     function open() {
         visible = true;
         if (hasOverlay) {
-            showAnim.start();
+            showAnimation.start();
         } else {
             dialogBox.rotation = 0;
             dialogBox.scale = 1.0;
@@ -167,6 +170,15 @@ FocusScope {
                 horizontalAlignment: Text.AlignHCenter
                 lineHeight: 1.3
                 text: root.message
+            }
+
+            // 主内容（由子类通过 mainContentSource 设置，位于按钮组上方）
+            Loader {
+                id: mainContentLoader
+                Layout.fillWidth: true
+                Layout.topMargin: AppStyle.spacing.sm
+                sourceComponent: root.mainContentSource
+                visible: root.mainContentSource
             }
 
             // 按钮组容器

--- a/src/ui/qml/components/qmldir
+++ b/src/ui/qml/components/qmldir
@@ -21,5 +21,6 @@ WindowPersistenceManager 1.0 WindowPersistenceManager.qml
 WindowStartupManager 1.0 WindowStartupManager.qml
 WindowResizeHandles 1.0 WindowResizeHandles.qml
 ConfirmDialog 1.0 ConfirmDialog.qml
+DescriptionEditDialog 1.0 DescriptionEditDialog.qml
 ExitDialog 1.0 ExitDialog.qml
 SliderDialogBase 1.0 SliderDialogBase.qml

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -827,7 +827,7 @@ void ComponentListViewModel::handleCadDataReady(const QString& componentId, cons
     item->setFetching(false);
     item->setValid(true);
     item->setRetryable(true);
-    item->setValidationPhase("fetching_preview");  // 预览图获取阶段
+    item->setValidationPhase("completed");
     item->setErrorMessage("");
     scheduleListUpdate();
 
@@ -1189,6 +1189,14 @@ void ComponentListViewModel::fetchPreviewImages(const QStringList& componentIds)
     m_pendingPreviewFetchIds = QSet<QString>(validIds.begin(), validIds.end());
     m_previewReadyHint = false;
     emit attentionStateChanged();
+
+    for (const QString& componentId : std::as_const(validIds)) {
+        auto item = findItemData(componentId);
+        if (item && item->isValid() && item->previewImageCount() == 0) {
+            item->setValidationPhase("fetching_preview");
+        }
+    }
+    scheduleListUpdate();
 
     // 使用批量获取预览图接口，避免为每个组件创建单独的定时器
     // LcscImageService 会自动处理缓存加载和队列管理

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -1249,6 +1249,18 @@ void ComponentListViewModel::dismissAttentionHints() {
     clearAttentionHints();
 }
 
+void ComponentListViewModel::updateComponentDescription(const QString& componentId, const QString& description) {
+    ComponentListItemData* item = findItemData(componentId);
+    if (!item) {
+        return;
+    }
+
+    item->setDescription(description);
+    if (m_service) {
+        m_service->updateComponentDescription(componentId, description);
+    }
+}
+
 void ComponentListViewModel::clearAttentionHints() {
     const bool changed = m_validationReadyHint || m_previewReadyHint || !m_pendingPreviewFetchIds.isEmpty();
     m_validationReadyHint = false;

--- a/src/ui/viewmodels/ComponentListViewModel.h
+++ b/src/ui/viewmodels/ComponentListViewModel.h
@@ -130,6 +130,7 @@ public slots:
     Q_INVOKABLE void fetchPreviewImages(const QStringList& componentIds);
     Q_INVOKABLE void updateExportStatus(const QString& componentId, int previewImageExported, int datasheetExported);
     Q_INVOKABLE void dismissAttentionHints();
+    Q_INVOKABLE void updateComponentDescription(const QString& componentId, const QString& description);
 
 signals:
     void componentCountChanged();

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -137,7 +137,9 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
                                           bool overwriteExistingFiles,
                                           bool updateMode,
                                           bool debugMode,
-                                          const QString& symbolLibraryDescription) {
+                                          const QString& symbolLibraryDescription,
+                                          const QString& footprintLibraryDescription,
+                                          const QString& footprintLibraryKeywords) {
     qDebug() << "ExportProgressViewModel: Starting export for" << componentIds.size() << "components";
 
     if (m_isExporting) {
@@ -207,7 +209,10 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
     options.updateMode = updateMode;
     options.debugMode = debugMode;
     options.exportSymbolDescription = true;
+    options.exportFootprintDescription = true;
     options.symbolLibraryDescription = symbolLibraryDescription;
+    options.footprintLibraryDescription = footprintLibraryDescription;
+    options.footprintLibraryKeywords = footprintLibraryKeywords;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(outputPath);

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -136,7 +136,8 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
                                           bool exportDatasheet,
                                           bool overwriteExistingFiles,
                                           bool updateMode,
-                                          bool debugMode) {
+                                          bool debugMode,
+                                          const QString& symbolLibraryDescription) {
     qDebug() << "ExportProgressViewModel: Starting export for" << componentIds.size() << "components";
 
     if (m_isExporting) {
@@ -205,6 +206,8 @@ void ExportProgressViewModel::startExport(const QStringList& componentIds,
     options.overwriteExistingFiles = overwriteExistingFiles;
     options.updateMode = updateMode;
     options.debugMode = debugMode;
+    options.exportSymbolDescription = true;
+    options.symbolLibraryDescription = symbolLibraryDescription;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(outputPath);

--- a/src/ui/viewmodels/ExportProgressViewModel.h
+++ b/src/ui/viewmodels/ExportProgressViewModel.h
@@ -155,7 +155,9 @@ public slots:
                      bool overwriteExistingFiles,
                      bool updateMode,
                      bool debugMode,
-                     const QString& symbolLibraryDescription = QString());
+                     const QString& symbolLibraryDescription = QString(),
+                     const QString& footprintLibraryDescription = QString(),
+                     const QString& footprintLibraryKeywords = QString());
     void cancelExport();
     void handleCloseRequest();
     void updateComponentExportStatus(const QString& componentId, int previewImageExported, int datasheetExported);

--- a/src/ui/viewmodels/ExportProgressViewModel.h
+++ b/src/ui/viewmodels/ExportProgressViewModel.h
@@ -154,7 +154,8 @@ public slots:
                      bool exportDatasheet,
                      bool overwriteExistingFiles,
                      bool updateMode,
-                     bool debugMode);
+                     bool debugMode,
+                     const QString& symbolLibraryDescription = QString());
     void cancelExport();
     void handleCloseRequest();
     void updateComponentExportStatus(const QString& componentId, int previewImageExported, int datasheetExported);

--- a/src/ui/viewmodels/ExportSettingsViewModel.cpp
+++ b/src/ui/viewmodels/ExportSettingsViewModel.cpp
@@ -33,6 +33,11 @@ ExportSettingsViewModel::ExportSettingsViewModel(ParallelExportService* exportSe
     , m_weakNetworkSupport(false)
     , m_exportMode(0)
     , m_debugMode(false)
+    , m_exportSymbolDescription(true)
+    , m_exportFootprintDescription(true)
+    , m_symbolLibraryDescription("")
+    , m_footprintLibraryDescription("")
+    , m_footprintLibraryKeywords("")
     , m_isExporting(false)
     , m_status("Ready") {
     // 初始化时检查调试模式（命令行参数优先，环境变量向后兼容）
@@ -176,6 +181,41 @@ void ExportSettingsViewModel::setDebugMode(bool enabled) {
     }
 }
 
+void ExportSettingsViewModel::setExportSymbolDescription(bool enabled) {
+    if (m_exportSymbolDescription != enabled) {
+        m_exportSymbolDescription = enabled;
+        emit exportSymbolDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setExportFootprintDescription(bool enabled) {
+    if (m_exportFootprintDescription != enabled) {
+        m_exportFootprintDescription = enabled;
+        emit exportFootprintDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setSymbolLibraryDescription(const QString& desc) {
+    if (m_symbolLibraryDescription != desc) {
+        m_symbolLibraryDescription = desc;
+        emit symbolLibraryDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setFootprintLibraryDescription(const QString& desc) {
+    if (m_footprintLibraryDescription != desc) {
+        m_footprintLibraryDescription = desc;
+        emit footprintLibraryDescriptionChanged();
+    }
+}
+
+void ExportSettingsViewModel::setFootprintLibraryKeywords(const QString& keywords) {
+    if (m_footprintLibraryKeywords != keywords) {
+        m_footprintLibraryKeywords = keywords;
+        emit footprintLibraryKeywordsChanged();
+    }
+}
+
 void ExportSettingsViewModel::startExport(const QStringList& componentIds) {
     qDebug() << "Starting export for" << componentIds.size() << "components";
 
@@ -255,6 +295,11 @@ void ExportSettingsViewModel::buildExportOptions() {
     options.weakNetworkSupport = m_weakNetworkSupport;
     options.updateMode = (m_exportMode == 1);
     options.debugMode = m_debugMode;
+    options.exportSymbolDescription = m_exportSymbolDescription;
+    options.exportFootprintDescription = m_exportFootprintDescription;
+    options.symbolLibraryDescription = m_symbolLibraryDescription;
+    options.footprintLibraryDescription = m_footprintLibraryDescription;
+    options.footprintLibraryKeywords = m_footprintLibraryKeywords;
 
     qInfo() << "Export options:" << "OutputPath:" << options.outputPath << "LibName:" << options.libName
             << "Symbol:" << options.exportSymbol << "Footprint:" << options.exportFootprint
@@ -262,7 +307,8 @@ void ExportSettingsViewModel::buildExportOptions() {
             << "(1=WRL, 2=STEP, 3=Both)" << "Preview Images:" << options.exportPreviewImages
             << "Datasheet:" << options.exportDatasheet
             << "Client Weak Network Adaptation:" << options.weakNetworkSupport << "Update Mode:" << options.updateMode
-            << "Debug Mode:" << options.debugMode;
+            << "Debug Mode:" << options.debugMode << "Symbol Description:" << options.exportSymbolDescription
+            << "Footprint Description:" << options.exportFootprintDescription;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(absoluteOutputPath);
@@ -382,6 +428,13 @@ void ExportSettingsViewModel::loadFromConfig() {
         m_debugMode = m_configService->getDebugMode();
     }
 
+    // 新字段使用默认值（ConfigService 暂未支持持久化）
+    m_exportSymbolDescription = true;
+    m_exportFootprintDescription = true;
+    m_symbolLibraryDescription.clear();
+    m_footprintLibraryDescription.clear();
+    m_footprintLibraryKeywords.clear();
+
     emit outputPathChanged();
     emit libNameChanged();
     emit exportSymbolChanged();
@@ -393,6 +446,11 @@ void ExportSettingsViewModel::loadFromConfig() {
     emit overwriteExistingFilesChanged();
     emit weakNetworkSupportChanged();
     emit debugModeChanged();
+    emit exportSymbolDescriptionChanged();
+    emit exportFootprintDescriptionChanged();
+    emit symbolLibraryDescriptionChanged();
+    emit footprintLibraryDescriptionChanged();
+    emit footprintLibraryKeywordsChanged();
 }
 
 void ExportSettingsViewModel::saveConfig() {
@@ -412,6 +470,11 @@ void ExportSettingsViewModel::resetConfig() {
     m_weakNetworkSupport = false;
     m_exportMode = 0;
     m_debugMode = false;
+    m_exportSymbolDescription = true;
+    m_exportFootprintDescription = true;
+    m_symbolLibraryDescription.clear();
+    m_footprintLibraryDescription.clear();
+    m_footprintLibraryKeywords.clear();
 
     m_configService->setOutputPath(m_outputPath);
     m_configService->setLibName(m_libName);
@@ -437,6 +500,11 @@ void ExportSettingsViewModel::resetConfig() {
     emit weakNetworkSupportChanged();
     emit exportModeChanged();
     emit debugModeChanged();
+    emit exportSymbolDescriptionChanged();
+    emit exportFootprintDescriptionChanged();
+    emit symbolLibraryDescriptionChanged();
+    emit footprintLibraryDescriptionChanged();
+    emit footprintLibraryKeywordsChanged();
 }
 
 }  // namespace EasyKiConverter

--- a/src/ui/viewmodels/ExportSettingsViewModel.cpp
+++ b/src/ui/viewmodels/ExportSettingsViewModel.cpp
@@ -308,7 +308,9 @@ void ExportSettingsViewModel::buildExportOptions() {
             << "Datasheet:" << options.exportDatasheet
             << "Client Weak Network Adaptation:" << options.weakNetworkSupport << "Update Mode:" << options.updateMode
             << "Debug Mode:" << options.debugMode << "Symbol Description:" << options.exportSymbolDescription
-            << "Footprint Description:" << options.exportFootprintDescription;
+            << "Footprint Description:" << options.exportFootprintDescription
+            << "Symbol Library Description:" << options.symbolLibraryDescription
+            << "Footprint Library Description:" << options.footprintLibraryDescription;
 
     m_exportService->setOptions(options);
     m_exportService->setOutputPath(absoluteOutputPath);

--- a/src/ui/viewmodels/ExportSettingsViewModel.h
+++ b/src/ui/viewmodels/ExportSettingsViewModel.h
@@ -31,6 +31,16 @@ class ExportSettingsViewModel : public QObject {
         bool weakNetworkSupport READ weakNetworkSupport WRITE setWeakNetworkSupport NOTIFY weakNetworkSupportChanged)
     Q_PROPERTY(int exportMode READ exportMode WRITE setExportMode NOTIFY exportModeChanged)
     Q_PROPERTY(bool debugMode READ debugMode WRITE setDebugMode NOTIFY debugModeChanged)
+    Q_PROPERTY(bool exportSymbolDescription READ exportSymbolDescription WRITE setExportSymbolDescription NOTIFY
+                   exportSymbolDescriptionChanged)
+    Q_PROPERTY(bool exportFootprintDescription READ exportFootprintDescription WRITE setExportFootprintDescription
+                   NOTIFY exportFootprintDescriptionChanged)
+    Q_PROPERTY(QString symbolLibraryDescription READ symbolLibraryDescription WRITE setSymbolLibraryDescription NOTIFY
+                   symbolLibraryDescriptionChanged)
+    Q_PROPERTY(QString footprintLibraryDescription READ footprintLibraryDescription WRITE setFootprintLibraryDescription
+                   NOTIFY footprintLibraryDescriptionChanged)
+    Q_PROPERTY(QString footprintLibraryKeywords READ footprintLibraryKeywords WRITE setFootprintLibraryKeywords NOTIFY
+                   footprintLibraryKeywordsChanged)
     Q_PROPERTY(bool isExporting READ isExporting NOTIFY isExportingChanged)
     Q_PROPERTY(QString status READ status NOTIFY statusChanged)
 
@@ -88,6 +98,26 @@ public:
         return m_debugMode;
     }
 
+    bool exportSymbolDescription() const {
+        return m_exportSymbolDescription;
+    }
+
+    bool exportFootprintDescription() const {
+        return m_exportFootprintDescription;
+    }
+
+    QString symbolLibraryDescription() const {
+        return m_symbolLibraryDescription;
+    }
+
+    QString footprintLibraryDescription() const {
+        return m_footprintLibraryDescription;
+    }
+
+    QString footprintLibraryKeywords() const {
+        return m_footprintLibraryKeywords;
+    }
+
     bool isExporting() const {
         return m_isExporting;
     }
@@ -109,6 +139,11 @@ public:
     Q_INVOKABLE void setWeakNetworkSupport(bool enabled);
     Q_INVOKABLE void setExportMode(int mode);
     Q_INVOKABLE void setDebugMode(bool enabled);
+    Q_INVOKABLE void setExportSymbolDescription(bool enabled);
+    Q_INVOKABLE void setExportFootprintDescription(bool enabled);
+    Q_INVOKABLE void setSymbolLibraryDescription(const QString& desc);
+    Q_INVOKABLE void setFootprintLibraryDescription(const QString& desc);
+    Q_INVOKABLE void setFootprintLibraryKeywords(const QString& keywords);
 
 public slots:
     Q_INVOKABLE void saveConfig();
@@ -130,6 +165,11 @@ signals:
     void weakNetworkSupportChanged();
     void exportModeChanged();
     void debugModeChanged();
+    void exportSymbolDescriptionChanged();
+    void exportFootprintDescriptionChanged();
+    void symbolLibraryDescriptionChanged();
+    void footprintLibraryDescriptionChanged();
+    void footprintLibraryKeywordsChanged();
     void isExportingChanged();
     void statusChanged();
     void preloadStarted();
@@ -165,6 +205,11 @@ private:
     bool m_weakNetworkSupport;
     int m_exportMode;  // 0 = 追加模式, 1 = 更新模式
     bool m_debugMode;
+    bool m_exportSymbolDescription;
+    bool m_exportFootprintDescription;
+    QString m_symbolLibraryDescription;
+    QString m_footprintLibraryDescription;
+    QString m_footprintLibraryKeywords;
     bool m_isExporting;
     QString m_status;
     QStringList m_pendingComponentIds;

--- a/src/ui/viewmodels/ValidationStateManager.cpp
+++ b/src/ui/viewmodels/ValidationStateManager.cpp
@@ -94,13 +94,11 @@ QStringList ValidationStateManager::validatedComponentIds() const {
 }
 
 void ValidationStateManager::checkAndNotifyCompletion() {
-    // 只有当所有应该验证的组件都验证完成时，才触发预览图获取
-    // 需要同时满足：
-    // 1. m_pendingValidationCount <= 0（没有待验证的组件）
-    // 2. m_validatedComponentIds.size() == m_totalValidationCount（验证的组件数等于总数）
-    if (m_pendingValidationCount <= 0 && m_validatedComponentIds.size() == m_totalValidationCount) {
-        qDebug() << "All validations completed," << m_validatedComponentIds.size() << "components validated (total was"
-                 << m_totalValidationCount << "), triggering preview fetch";
+    const int completedCount = m_validatedComponentIds.size() + m_failedComponentIds.size();
+    if (m_totalValidationCount > 0 && m_pendingValidationCount <= 0 && completedCount >= m_totalValidationCount) {
+        qDebug() << "All validations completed," << m_validatedComponentIds.size() << "components validated,"
+                 << m_failedComponentIds.size() << "components failed (total was" << m_totalValidationCount
+                 << "), triggering preview fetch for valid components";
         emit validationCompleted(m_validatedComponentIds);
     }
 }

--- a/src/workers/ProcessWorker.cpp
+++ b/src/workers/ProcessWorker.cpp
@@ -206,10 +206,16 @@ bool ProcessWorker::parse3DModelData(ComponentExportStatus& status) {
         return true;
     }
 
-    // 保存已有 model3DData 的 UUID（如果有的话）
+    // 保存已有 model3DData 的属性（如果有的话）
     QString existingUuid;
-    if (status.model3DData && !status.model3DData->uuid().isEmpty()) {
+    QString existingName;
+    Model3DBase existingTranslation;
+    Model3DBase existingRotation;
+    if (status.model3DData) {
         existingUuid = status.model3DData->uuid();
+        existingName = status.model3DData->name();
+        existingTranslation = status.model3DData->translation();
+        existingRotation = status.model3DData->rotation();
     }
 
     // 创建3D模型数据
@@ -223,6 +229,25 @@ bool ProcessWorker::parse3DModelData(ComponentExportStatus& status) {
     } else if (status.footprintData && !status.footprintData->model3D().uuid().isEmpty()) {
         status.model3DData->setUuid(status.footprintData->model3D().uuid());
         status.addDebugLog(QString("Using 3D model UUID from footprintData: %1").arg(status.model3DData->uuid()));
+    }
+
+    // 恢复 name、translation、rotation：优先使用预加载数据，其次从 footprintData 获取
+    if (!existingName.isEmpty()) {
+        status.model3DData->setName(existingName);
+    } else if (status.footprintData && !status.footprintData->model3D().name().isEmpty()) {
+        status.model3DData->setName(status.footprintData->model3D().name());
+    }
+
+    if (existingTranslation.x != 0.0 || existingTranslation.y != 0.0 || existingTranslation.z != 0.0) {
+        status.model3DData->setTranslation(existingTranslation);
+    } else if (status.footprintData) {
+        status.model3DData->setTranslation(status.footprintData->model3D().translation());
+    }
+
+    if (existingRotation.x != 0.0 || existingRotation.y != 0.0 || existingRotation.z != 0.0) {
+        status.model3DData->setRotation(existingRotation);
+    } else if (status.footprintData) {
+        status.model3DData->setRotation(status.footprintData->model3D().rotation());
     }
 
     return true;

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -26,7 +26,11 @@ set(QML_FILES
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowController.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowPersistenceManager.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowStartupManager.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/ConfirmDialog.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/DescriptionEditDialog.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/components/WindowResizeHandles.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/ExitDialog.qml
+    ${CMAKE_SOURCE_DIR}/src/ui/qml/components/SliderDialogBase.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/styles/AppStyle.qml
     ${CMAKE_SOURCE_DIR}/src/ui/qml/styles/ResponsiveHelper.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_BasicComponents.qml

--- a/tests/unit/test_component_list_viewmodel.cpp
+++ b/tests/unit/test_component_list_viewmodel.cpp
@@ -101,6 +101,24 @@ private slots:
         // cancelValidation 不会触发它，只会减少 pendingCount 并调用 checkAndNotifyCompletion
         // checkAndNotifyCompletion 只在 isAllDone() && m_previewFetchEnabled 时触发
     }
+
+    void testMixedSuccessAndFailure_CompletesWithValidIds() {
+        ValidationStateManager manager;
+
+        manager.startValidation(3);
+        QSignalSpy spy(&manager, &ValidationStateManager::validationCompleted);
+
+        manager.onComponentValidated("C1");
+        manager.onComponentFailed("C2");
+        manager.onComponentValidated("C3");
+
+        QCOMPARE(manager.pendingCount(), 0);
+        QCOMPARE(spy.count(), 1);
+
+        const QList<QVariant> arguments = spy.takeFirst();
+        const QStringList validatedIds = arguments.at(0).toStringList();
+        QCOMPARE(validatedIds, QStringList({"C1", "C3"}));
+    }
 };
 
 QTEST_GUILESS_MAIN(TestValidationStateManager)

--- a/tests/unit/test_models.cpp
+++ b/tests/unit/test_models.cpp
@@ -1,8 +1,8 @@
+#include "core/easyeda/EasyedaFootprintImporter.h"
 #include "models/FootprintData.h"
 #include "models/FootprintDataSerializer.h"
 #include "models/SymbolData.h"
 #include "models/SymbolDataSerializer.h"
-#include "core/easyeda/EasyedaFootprintImporter.h"
 
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -183,7 +183,8 @@ private:
         svgNode.insert(QStringLiteral("attrs"), attrs);
 
         QJsonArray shapes;
-        shapes.append(QStringLiteral("SVGNODE~") + QString::fromUtf8(QJsonDocument(svgNode).toJson(QJsonDocument::Compact)));
+        shapes.append(QStringLiteral("SVGNODE~") +
+                      QString::fromUtf8(QJsonDocument(svgNode).toJson(QJsonDocument::Compact)));
 
         QJsonObject dataStr;
         dataStr.insert(QStringLiteral("head"), head);

--- a/tests/unit/test_models.cpp
+++ b/tests/unit/test_models.cpp
@@ -2,7 +2,9 @@
 #include "models/FootprintDataSerializer.h"
 #include "models/SymbolData.h"
 #include "models/SymbolDataSerializer.h"
+#include "core/easyeda/EasyedaFootprintImporter.h"
 
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QtTest>
@@ -88,6 +90,39 @@ private slots:
         QCOMPARE(restored.pads().at(0).shape, original.pads().at(0).shape);
     }
 
+    void testModel3DAbsoluteOriginImport() {
+        EasyedaFootprintImporter importer;
+        const QJsonObject cadData = makeCadDataWithModelOrigin(QStringLiteral("3998.803,2982.7698"));
+
+        const QSharedPointer<FootprintData> footprint = importer.importFootprintData(cadData);
+
+        QVERIFY(footprint);
+        QCOMPARE(footprint->model3D().translation().x, 3998.803);
+        QCOMPARE(footprint->model3D().translation().y, 2982.7698);
+    }
+
+    void testModel3DRelativeOriginImport() {
+        EasyedaFootprintImporter importer;
+        const QJsonObject cadData = makeCadDataWithModelOrigin(QStringLiteral("1.5,-2"));
+
+        const QSharedPointer<FootprintData> footprint = importer.importFootprintData(cadData);
+
+        QVERIFY(footprint);
+        QCOMPARE(footprint->model3D().translation().x, 4000.3);
+        QCOMPARE(footprint->model3D().translation().y, 2980.35);
+    }
+
+    void testModel3DUnrelatedOriginFallsBackToFootprintCenter() {
+        EasyedaFootprintImporter importer;
+        const QJsonObject cadData = makeCadDataWithModelOrigin(QStringLiteral("400,300"));
+
+        const QSharedPointer<FootprintData> footprint = importer.importFootprintData(cadData);
+
+        QVERIFY(footprint);
+        QCOMPARE(footprint->model3D().translation().x, 3998.8);
+        QCOMPARE(footprint->model3D().translation().y, 2982.35);
+    }
+
     void testSymbolGeometrySerialization() {
         SymbolData original;
 
@@ -116,6 +151,50 @@ private slots:
         QCOMPARE(restored.rectangles().at(0).width, 50.0);
         QCOMPARE(restored.circles().size(), 1);
         QCOMPARE(restored.circles().at(0).radius, 20.0);
+    }
+
+private:
+    QJsonObject makeCadDataWithModelOrigin(const QString& origin) const {
+        QJsonObject cadData;
+        cadData.insert(QStringLiteral("SMT"), true);
+
+        QJsonObject cPara;
+        cPara.insert(QStringLiteral("package"), QStringLiteral("TEST_FOOTPRINT"));
+        cPara.insert(QStringLiteral("3DModel"), QStringLiteral("TEST_MODEL"));
+
+        QJsonObject head;
+        head.insert(QStringLiteral("c_para"), cPara);
+
+        QJsonObject bbox;
+        bbox.insert(QStringLiteral("x"), 3977.3);
+        bbox.insert(QStringLiteral("y"), 2971.0);
+        bbox.insert(QStringLiteral("width"), 43.0);
+        bbox.insert(QStringLiteral("height"), 22.7);
+
+        QJsonObject attrs;
+        attrs.insert(QStringLiteral("c_etype"), QStringLiteral("outline3D"));
+        attrs.insert(QStringLiteral("uuid"), QStringLiteral("model-uuid"));
+        attrs.insert(QStringLiteral("title"), QStringLiteral("TEST_MODEL"));
+        attrs.insert(QStringLiteral("c_origin"), origin);
+        attrs.insert(QStringLiteral("c_rotation"), QStringLiteral("0,0,0"));
+        attrs.insert(QStringLiteral("z"), QStringLiteral("0"));
+
+        QJsonObject svgNode;
+        svgNode.insert(QStringLiteral("attrs"), attrs);
+
+        QJsonArray shapes;
+        shapes.append(QStringLiteral("SVGNODE~") + QString::fromUtf8(QJsonDocument(svgNode).toJson(QJsonDocument::Compact)));
+
+        QJsonObject dataStr;
+        dataStr.insert(QStringLiteral("head"), head);
+        dataStr.insert(QStringLiteral("BBox"), bbox);
+        dataStr.insert(QStringLiteral("shape"), shapes);
+
+        QJsonObject packageDetail;
+        packageDetail.insert(QStringLiteral("dataStr"), dataStr);
+        cadData.insert(QStringLiteral("packageDetail"), packageDetail);
+
+        return cadData;
     }
 };
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "easykiconverter",
-  "version-string": "3.1.6",
+  "version-string": "3.1.7",
   "description": "EasyKiConverter - LCSC and EasyEDA component to KiCad library converter",
   "dependencies": [
     {


### PR DESCRIPTION
主要变更                                                                      
                                                                                
  导出功能增强                                                                  
  - 新增 KiCadLibraryTableManager 服务，支持 sym-lib-table / fp-lib-table       
  自动生成和注册                                                                
  - ExporterSymbol / ExporterFootprint 支持导出库描述信息（ki_description /
  ki_key_words）                                                                
  - SymbolExportStage 文件复制改用 64KB 分块流式拷贝，避免 readAll()
  的大文件内存问题                                                  
  - 提取 abortExport lambda 消除 9 处重复的错误处理样板代码                     
  - 修复 TempFileManager::createSymbolTempPath 中冗余的目录存在性检查
                                                                                
  UI 功能                                                                       
  - 新增 DescriptionEditDialog 组件，支持元器件描述文本编辑                     
  - ExportSettingsCard 布局重构优化（853 行变更）                               
  - ComponentListItem 展示元器件描述信息                                        
  - ExportSettingsViewModel 新增库描述相关属性和验证逻辑                        
                                                                                
  CI/文档                                                                       
  - 修复 macOS 打包工作流：Intel runner 名称、Info.plist 模板变量、SHA256       
  校验命令                                                                      
  - 新增 docs/developer/KICAD_FIELD_FORMATS.md KiCad 字段格式文档               
  - 更新 README 和架构文档，补充 CLI 模式说明                                   
                                                                                
  Bug 修复                                                                      
  - 修复 3D 模型导出时文件名与路径不一致的问题                                  
  - 修复 EasyEDA 封装导入器的 X/Y 轴偏移问题                                    
  - 修复符号/封装/3D 导出 Worker 的路径处理问题