### PR TITLE
feat: STEP 模型偏移补偿、CLI 3D 格式选择、封装导出归一化

### DIFF
--- a/src/core/kicad/CMakeLists.txt
+++ b/src/core/kicad/CMakeLists.txt
@@ -19,5 +19,6 @@ target_link_libraries(EasyKiConverterKicad
     PUBLIC
         Qt6::Core
         EasyKiConverterModels
+        EasyKiConverterNetwork
         EasyKiConverterUtils
 )

--- a/src/core/kicad/Exporter3DModel.cpp
+++ b/src/core/kicad/Exporter3DModel.cpp
@@ -92,7 +92,6 @@ bool Exporter3DModel::exportToStep(const Model3DData& modelData, const QString& 
         return false;
     }
 
-    // 直接写入 STEP 二进制数
     file.write(modelData.step());
     file.close();
 

--- a/src/core/kicad/FootprintGraphicsGenerator.cpp
+++ b/src/core/kicad/FootprintGraphicsGenerator.cpp
@@ -528,6 +528,13 @@ QString FootprintGraphicsGenerator::generateModel3D(const Model3DData& model3D,
         finalOffsetY = 0.0;
     }
 
+    if (finalPath.endsWith(QStringLiteral(".step"), Qt::CaseInsensitive) ||
+        finalPath.endsWith(QStringLiteral(".stp"), Qt::CaseInsensitive)) {
+        finalOffsetX += model3D.stepOffsetMm().x;
+        finalOffsetY += model3D.stepOffsetMm().y;
+        z += model3D.stepOffsetMm().z;
+    }
+
     content += QString("  (model \"%1\"\n").arg(finalPath);
 
     content += QString("    (offset (xyz %1 %2 %3))\n")

--- a/src/models/Model3DData.cpp
+++ b/src/models/Model3DData.cpp
@@ -23,7 +23,8 @@ bool Model3DBase::fromJson(const QJsonObject& json) {
 
 // ==================== Model3DData ====================
 
-Model3DData::Model3DData() : m_name(), m_uuid(), m_translation(), m_rotation(), m_rawObj(), m_step() {}
+Model3DData::Model3DData()
+    : m_name(), m_uuid(), m_translation(), m_rotation(), m_stepOffsetMm(), m_rawObj(), m_step() {}
 
 QJsonObject Model3DData::toJson() const {
     QJsonObject json;
@@ -32,6 +33,7 @@ QJsonObject Model3DData::toJson() const {
     json["uuid"] = m_uuid;
     json["translation"] = m_translation.toJson();
     json["rotation"] = m_rotation.toJson();
+    json["step_offset_mm"] = m_stepOffsetMm.toJson();
     json["raw_obj"] = m_rawObj;
 
     // STEP 数据Base64 编码存储
@@ -56,6 +58,13 @@ bool Model3DData::fromJson(const QJsonObject& json) {
     if (json.contains("rotation") && json["rotation"].isObject()) {
         if (!m_rotation.fromJson(json["rotation"].toObject())) {
             qWarning() << "Failed to parse 3D model rotation";
+            return false;
+        }
+    }
+
+    if (json.contains("step_offset_mm") && json["step_offset_mm"].isObject()) {
+        if (!m_stepOffsetMm.fromJson(json["step_offset_mm"].toObject())) {
+            qWarning() << "Failed to parse 3D model STEP offset";
             return false;
         }
     }
@@ -93,6 +102,7 @@ void Model3DData::clear() {
     m_uuid.clear();
     m_translation = Model3DBase();
     m_rotation = Model3DBase();
+    m_stepOffsetMm = Model3DBase();
     m_rawObj.clear();
     m_step.clear();
 }

--- a/src/models/Model3DData.h
+++ b/src/models/Model3DData.h
@@ -78,6 +78,14 @@ public:
         m_step = step;
     }
 
+    Model3DBase stepOffsetMm() const {
+        return m_stepOffsetMm;
+    }
+
+    void setStepOffsetMm(const Model3DBase& offset) {
+        m_stepOffsetMm = offset;
+    }
+
     // JSON 序列
     QJsonObject toJson() const;
     bool fromJson(const QJsonObject& json);
@@ -94,6 +102,7 @@ private:
     QString m_uuid;
     Model3DBase m_translation;
     Model3DBase m_rotation;
+    Model3DBase m_stepOffsetMm;
     QString m_rawObj;
     QByteArray m_step;
 };

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -3,15 +3,87 @@
 #include "KiCadLibraryTableManager.h"
 #include "core/kicad/ExporterFootprint.h"
 #include "models/ComponentData.h"
+#include "services/ComponentCacheService.h"
 
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QMutexLocker>
+#include <QRegularExpression>
+#include <QSet>
 #include <QThread>
 
+#include <limits>
+
 namespace EasyKiConverter {
+
+namespace {
+bool calculateStepGeometryCenter(const QByteArray& stepData, Model3DBase* center) {
+    if (stepData.isEmpty() || center == nullptr) {
+        return false;
+    }
+
+    const QString content = QString::fromLatin1(stepData);
+    static const QRegularExpression pointRegex(
+        QStringLiteral("#(\\d+)\\s*=\\s*CARTESIAN_POINT\\s*\\(\\s*('[^']*'|\\$)\\s*,\\s*\\(([^()]*)\\)\\s*\\)"),
+        QRegularExpression::CaseInsensitiveOption);
+    static const QRegularExpression vertexPointRegex(QStringLiteral("VERTEX_POINT\\s*\\([^,]*,\\s*#(\\d+)\\s*\\)"),
+                                                     QRegularExpression::CaseInsensitiveOption);
+
+    QSet<QString> vertexPointIds;
+    QRegularExpressionMatchIterator vertexMatches = vertexPointRegex.globalMatch(content);
+    while (vertexMatches.hasNext()) {
+        vertexPointIds.insert(vertexMatches.next().captured(1));
+    }
+
+    double minX = std::numeric_limits<double>::max();
+    double maxX = std::numeric_limits<double>::lowest();
+    double minY = std::numeric_limits<double>::max();
+    double maxY = std::numeric_limits<double>::lowest();
+    double minZ = std::numeric_limits<double>::max();
+    bool hasGeometryPoint = false;
+
+    QRegularExpressionMatchIterator matches = pointRegex.globalMatch(content);
+    while (matches.hasNext()) {
+        const QRegularExpressionMatch match = matches.next();
+        if (!vertexPointIds.isEmpty() && !vertexPointIds.contains(match.captured(1))) {
+            continue;
+        }
+
+        const QStringList coordinateParts = match.captured(3).split(',', Qt::SkipEmptyParts);
+        if (coordinateParts.size() < 3) {
+            continue;
+        }
+
+        bool okX = false;
+        bool okY = false;
+        bool okZ = false;
+        const double x = coordinateParts.at(0).trimmed().toDouble(&okX);
+        const double y = coordinateParts.at(1).trimmed().toDouble(&okY);
+        const double z = coordinateParts.at(2).trimmed().toDouble(&okZ);
+        if (!okX || !okY || !okZ) {
+            continue;
+        }
+
+        minX = qMin(minX, x);
+        maxX = qMax(maxX, x);
+        minY = qMin(minY, y);
+        maxY = qMax(maxY, y);
+        minZ = qMin(minZ, z);
+        hasGeometryPoint = true;
+    }
+
+    if (!hasGeometryPoint) {
+        return false;
+    }
+
+    center->x = (minX + maxX) / 2.0;
+    center->y = (minY + maxY) / 2.0;
+    center->z = minZ;
+    return true;
+}
+}  // namespace
 
 FootprintExportStage::FootprintExportStage(QObject* parent)
     : ExportTypeStage("Footprint", 1, parent) {  // maxConcurrent=1 因为是库级别导出
@@ -140,8 +212,35 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
             continue;
         }
 
+        FootprintData footprint = *data->footprintData();
+        if (m_options.needsModel3DStep()) {
+            Model3DData model3D = footprint.model3D();
+            if (!model3D.uuid().isEmpty()) {
+                QByteArray stepData;
+                if (data->model3DData() && !data->model3DData()->step().isEmpty()) {
+                    stepData = data->model3DData()->step();
+                }
+                if (stepData.isEmpty()) {
+                    stepData = ComponentCacheService::instance()->loadModel3D(model3D.uuid(), QStringLiteral("step"));
+                }
+
+                Model3DBase geometryCenter;
+                if (calculateStepGeometryCenter(stepData, &geometryCenter)) {
+                    Model3DBase stepOffset;
+                    stepOffset.x = -geometryCenter.x;
+                    stepOffset.y = -geometryCenter.y;
+                    stepOffset.z = geometryCenter.z > 0.0 ? -geometryCenter.z : 0.0;
+                    model3D.setStepOffsetMm(stepOffset);
+                    footprint.setModel3D(model3D);
+                    qDebug() << "FootprintExportStage: STEP geometry center for" << componentId << "uuid"
+                             << model3D.uuid() << "center:" << geometryCenter.x << geometryCenter.y << geometryCenter.z
+                             << "offset:" << stepOffset.x << stepOffset.y << stepOffset.z;
+                }
+            }
+        }
+
         // 添加到封装列表
-        footprintList.append(*data->footprintData());
+        footprintList.append(footprint);
         successCount++;
 
         // 发射 itemStatusChanged 信号通知 ViewModel

--- a/src/services/export/Model3DExportWorker.cpp
+++ b/src/services/export/Model3DExportWorker.cpp
@@ -150,11 +150,8 @@ void Model3DExportWorker::run() {
         wrlFromCache = true;
     }
 
-    if (needStep && cache->hasModel3DCached(uuid, QStringLiteral("step")) &&
-        cache->copyModel3DToFile(uuid, QStringLiteral("step"), stepWritePath)) {
-        qDebug() << "Model3DExportWorker: STEP cache hit for" << uuid;
-        stepFromCache = true;
-    }
+    // STEP files are kept in their original server coordinate system. Older development builds wrote normalized STEP
+    // content into the cache, so refresh STEP from the server instead of trusting a possibly transformed cached file.
 
     // 如果两个文件都从缓存加载成功，直接完成
     if ((!needWrl || wrlFromCache) && (!needStep || stepFromCache)) {
@@ -214,7 +211,10 @@ void Model3DExportWorker::run() {
             if (!m_exporter->exportToStep(modelData, stepWritePath)) {
                 error = QStringLiteral("Failed to write STEP file");
             } else {
-                cache->saveModel3D(uuid, stepData, QStringLiteral("step"));
+                QFile file(stepWritePath);
+                if (file.open(QIODevice::ReadOnly)) {
+                    cache->saveModel3D(uuid, file.readAll(), QStringLiteral("step"));
+                }
                 qDebug() << "Model3DExportWorker: Saved STEP to cache for" << m_componentId << "uuid" << uuid;
             }
         }

--- a/src/utils/CommandLineParser.cpp
+++ b/src/utils/CommandLineParser.cpp
@@ -19,10 +19,12 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
     , m_syncLoggingOption(QStringList() << "sync-logging", "启用同步控制台日志输出（确保彩色日志显示，方便调试）")
     , m_inputOption(QStringList() << "i" << "input", "输入文件路径 (BOM 表或元器件列表文件)", "path")
     , m_outputOption(QStringList() << "o" << "output", "输出目录路径", "path")
+    , m_libNameOption("lib-name", "导出库名称", "name", "EasyKiConverter")
     , m_componentOption(QStringList() << "c" << "component", "LCSC 元器件编号", "id")
     , m_symbolOption("symbol", "导出符号库 (默认: true)")
     , m_footprintOption("footprint", "导出封装库 (默认: true)")
     , m_3dModelOption("3d-model", "导出 3D 模型")
+    , m_3dModelFormatOption("3d-model-format", "3D 模型格式 (wrl/step/both，默认: wrl)", "format", "wrl")
     , m_previewOption("preview", "导出预览图")
     , m_progressOption("progress", "显示进度条")
     , m_quietOption(QStringList() << "q" << "quiet", "安静模式，减少输出")
@@ -66,10 +68,12 @@ void CommandLineParser::setupOptions() {
 void CommandLineParser::setupCliOptions() {
     m_parser.addOption(m_inputOption);
     m_parser.addOption(m_outputOption);
+    m_parser.addOption(m_libNameOption);
     m_parser.addOption(m_componentOption);
     m_parser.addOption(m_symbolOption);
     m_parser.addOption(m_footprintOption);
     m_parser.addOption(m_3dModelOption);
+    m_parser.addOption(m_3dModelFormatOption);
     m_parser.addOption(m_previewOption);
     m_parser.addOption(m_progressOption);
     m_parser.addOption(m_quietOption);
@@ -205,6 +209,14 @@ bool CommandLineParser::validate() const {
 
     // CLI 模式验证
     if (isCliMode()) {
+        if (m_parser.isSet(m_3dModelFormatOption)) {
+            const QString format = model3DFormat();
+            const QStringList validFormats = {"wrl", "step", "both"};
+            if (!validFormats.contains(format)) {
+                return false;
+            }
+        }
+
         // 验证输出目录
         if (!m_parser.isSet(m_outputOption)) {
             return false;
@@ -261,6 +273,14 @@ QString CommandLineParser::validationError() const {
 
     // CLI 模式验证错误
     if (isCliMode()) {
+        if (m_parser.isSet(m_3dModelFormatOption)) {
+            const QString format = model3DFormat();
+            const QStringList validFormats = {"wrl", "step", "both"};
+            if (!validFormats.contains(format)) {
+                errors.append(QString("无效的 3D 模型格式: %1（有效值: %2）").arg(format).arg(validFormats.join(", ")));
+            }
+        }
+
         if (!m_parser.isSet(m_outputOption)) {
             errors.append("CLI 模式必须指定输出目录 (-o/--output)");
         }
@@ -299,6 +319,10 @@ QString CommandLineParser::outputDir() const {
     return m_parser.value(m_outputOption);
 }
 
+QString CommandLineParser::libName() const {
+    return m_parser.value(m_libNameOption);
+}
+
 QString CommandLineParser::componentId() const {
     return m_parser.value(m_componentOption);
 }
@@ -316,6 +340,10 @@ bool CommandLineParser::exportFootprint() const {
 bool CommandLineParser::export3DModel() const {
     // --3d-model 是 flag 选项，默认 false（未设置则不导出 3D 模型）
     return m_parser.isSet(m_3dModelOption);
+}
+
+QString CommandLineParser::model3DFormat() const {
+    return m_parser.value(m_3dModelFormatOption).toLower();
 }
 
 bool CommandLineParser::exportPreview() const {
@@ -344,10 +372,12 @@ QString CommandLineParser::cliHelpText() const {
     stream << "选项:\n";
     stream << "  -i, --input <path>      输入文件路径（BOM 表或元器件列表文件）\n";
     stream << "  -o, --output <path>     输出目录路径（必需）\n";
+    stream << "  --lib-name <name>       导出库名称（默认: EasyKiConverter）\n";
     stream << "  -c, --component <id>    LCSC 元器件编号\n";
     stream << "  --symbol                导出符号库（默认: true）\n";
     stream << "  --footprint             导出封装库（默认: true）\n";
     stream << "  --3d-model              导出 3D 模型\n";
+    stream << "  --3d-model-format <fmt> 3D 模型格式（wrl/step/both，默认: wrl）\n";
     stream << "  --preview               导出预览图\n";
     stream << "  --progress              显示进度条\n";
     stream << "  -q, --quiet             安静模式，减少输出\n\n";

--- a/src/utils/CommandLineParser.h
+++ b/src/utils/CommandLineParser.h
@@ -170,6 +170,12 @@ public:
     QString outputDir() const;
 
     /**
+     * @brief 获取导出库名称
+     * @return 库名称
+     */
+    QString libName() const;
+
+    /**
      * @brief 获取 LCSC 元器件编号（用于单个元器件转换）
      * @return LCSC 编号
      */
@@ -192,6 +198,12 @@ public:
      * @return 导出返回 true，否则返回 false
      */
     bool export3DModel() const;
+
+    /**
+     * @brief 获取 3D 模型导出格式
+     * @return 格式名称 (wrl/step/both)
+     */
+    QString model3DFormat() const;
 
     /**
      * @brief 是否导出预览图
@@ -270,10 +282,12 @@ private:
     // CLI 模式选项
     QCommandLineOption m_inputOption;
     QCommandLineOption m_outputOption;
+    QCommandLineOption m_libNameOption;
     QCommandLineOption m_componentOption;
     QCommandLineOption m_symbolOption;
     QCommandLineOption m_footprintOption;
     QCommandLineOption m_3dModelOption;
+    QCommandLineOption m_3dModelFormatOption;
     QCommandLineOption m_previewOption;
     QCommandLineOption m_progressOption;
     QCommandLineOption m_quietOption;

--- a/src/utils/cli/CliContext.cpp
+++ b/src/utils/cli/CliContext.cpp
@@ -27,12 +27,20 @@ ExportOptions CliContext::createExportOptions() const {
 
     // 设置输出路径
     options.outputPath = m_parser.outputDir();
+    options.libName = m_parser.libName();
 
     // 设置导出类型（CLI 默认：符号库、封装库、3D模型-WRL格式）
     options.exportSymbol = m_parser.exportSymbol();
     options.exportFootprint = m_parser.exportFootprint();
     options.exportModel3D = m_parser.export3DModel();
-    options.exportModel3DFormat = ExportOptions::MODEL_3D_FORMAT_WRL;
+    const QString model3DFormat = m_parser.model3DFormat();
+    if (model3DFormat == QStringLiteral("step")) {
+        options.exportModel3DFormat = ExportOptions::MODEL_3D_FORMAT_STEP;
+    } else if (model3DFormat == QStringLiteral("both")) {
+        options.exportModel3DFormat = ExportOptions::MODEL_3D_FORMAT_BOTH;
+    } else {
+        options.exportModel3DFormat = ExportOptions::MODEL_3D_FORMAT_WRL;
+    }
     options.exportPreviewImages = m_parser.exportPreview();
     options.exportDatasheet = false;
 

--- a/src/workers/WriteWorker.cpp
+++ b/src/workers/WriteWorker.cpp
@@ -412,7 +412,10 @@ bool WriteWorker::writeFootprintFile(ComponentExportStatus& status) {
 
 bool WriteWorker::write3DModelFile(ComponentExportStatus& status) {
     // 如果既没有原始数据也没有缓存路径，则跳过
-    if (!status.model3DData || (status.model3DData->rawObj().isEmpty() && status.cachedModel3DWrlPath.isEmpty())) {
+    const bool hasWrlData =
+        status.model3DData && (!status.model3DData->rawObj().isEmpty() || !status.cachedModel3DWrlPath.isEmpty());
+    const bool hasStepData = !status.model3DStepRaw.isEmpty() || !status.cachedModel3DStepPath.isEmpty();
+    if (!hasWrlData && !hasStepData) {
         return true;
     }
 
@@ -438,7 +441,7 @@ bool WriteWorker::write3DModelFile(ComponentExportStatus& status) {
     bool wrlSuccess = false;
 
     // WRL文件写入：优先使用缓存直接拷贝（避免大文件经过内存）
-    if (!status.cachedModel3DWrlPath.isEmpty()) {
+    if (hasWrlData && !status.cachedModel3DWrlPath.isEmpty()) {
         QString wrlFilePath = QString("%1/%2.wrl").arg(modelsDirPath, footprintName);
         wrlSuccess = AtomicFileWriter::copyAtomically(status.cachedModel3DWrlPath, wrlFilePath, m_tempDir);
         if (wrlSuccess) {
@@ -446,7 +449,7 @@ bool WriteWorker::write3DModelFile(ComponentExportStatus& status) {
         } else {
             status.addDebugLog(QString("ERROR: Failed to copy WRL file from cache"));
         }
-    } else {
+    } else if (hasWrlData) {
         // 使用导出器生成WRL文件
         QString wrlFilePath = QString("%1/%2.wrl").arg(modelsDirPath, footprintName);
         wrlSuccess = AtomicFileWriter::writeAtomically(
@@ -460,32 +463,44 @@ bool WriteWorker::write3DModelFile(ComponentExportStatus& status) {
         }
     }
 
-    // STEP文件写入：优先使用缓存直接拷贝（避免大文件经过内存）
+    // STEP 文件保持服务器原始坐标系，避免破坏它与 WRL 模型原本一致的装配关系。
+    bool stepSuccess = false;
     if (!status.cachedModel3DStepPath.isEmpty()) {
-        // 使用直接拷贝模式（不经过内存）
         QString stepFilePath = QString("%1/%2.step").arg(modelsDirPath, footprintName);
-        bool stepWriteSuccess = AtomicFileWriter::copyAtomically(status.cachedModel3DStepPath, stepFilePath, m_tempDir);
+        bool stepWriteSuccess = AtomicFileWriter::writeAtomically(
+            m_tempDir, stepFilePath, ".step.tmp", [this, &status](const QString& tempPath) -> bool {
+                QFile file(status.cachedModel3DStepPath);
+                if (!file.open(QIODevice::ReadOnly)) {
+                    return false;
+                }
+                Model3DData modelData;
+                if (status.model3DData) {
+                    modelData = *status.model3DData;
+                }
+                modelData.setStep(file.readAll());
+                return m_model3DExporter.exportToStep(modelData, tempPath);
+            });
 
         if (stepWriteSuccess) {
-            status.addDebugLog(QString("3D model STEP file copied from cache: %1").arg(status.cachedModel3DStepPath));
+            stepSuccess = true;
+            status.addDebugLog(QString("3D model STEP file written from cache: %1").arg(status.cachedModel3DStepPath));
         } else {
             status.addDebugLog(QString("WARNING: Failed to copy STEP file from cache: %1").arg(stepFilePath));
         }
     } else if (!status.model3DStepRaw.isEmpty()) {
-        // 使用内存模式（原有逻辑）
         QString stepFilePath = QString("%1/%2.step").arg(modelsDirPath, footprintName);
         bool stepWriteSuccess = AtomicFileWriter::writeAtomically(
-            m_tempDir, stepFilePath, ".step.tmp", [&status](const QString& tempPath) -> bool {
-                QFile file(tempPath);
-                if (!file.open(QIODevice::WriteOnly)) {
-                    return false;
+            m_tempDir, stepFilePath, ".step.tmp", [this, &status](const QString& tempPath) -> bool {
+                Model3DData modelData;
+                if (status.model3DData) {
+                    modelData = *status.model3DData;
                 }
-                qint64 written = file.write(status.model3DStepRaw);
-                file.close();
-                return written == status.model3DStepRaw.size();
+                modelData.setStep(status.model3DStepRaw);
+                return m_model3DExporter.exportToStep(modelData, tempPath);
             });
 
         if (stepWriteSuccess) {
+            stepSuccess = true;
             status.addDebugLog(QString("3D model STEP file written"));
         } else {
             status.addDebugLog(QString("WARNING: Failed to write STEP file: %1").arg(stepFilePath));
@@ -493,8 +508,8 @@ bool WriteWorker::write3DModelFile(ComponentExportStatus& status) {
         status.clearStepData();
     }
 
-    status.model3DWritten = wrlSuccess;
-    return wrlSuccess;
+    status.model3DWritten = wrlSuccess || stepSuccess;
+    return status.model3DWritten;
 }
 
 bool WriteWorker::createOutputDirectory(const QString& path) {

--- a/tests/unit/test_command_line_parser.cpp
+++ b/tests/unit/test_command_line_parser.cpp
@@ -18,6 +18,8 @@ private slots:
     void testParseConvertComponent();  // convert component → CliMode::ConvertComponent
     void testParseConvertBatch();  // convert batch → CliMode::ConvertBatch
     void testParseConvertInvalid();  // convert abc → hasConvertCommand=true 但 isCliMode=false
+    void testLibNameDefault();
+    void testLibNameExplicit();
 
     // --symbol / --footprint / --3d-model 默认语义
     void testExportSymbolDefaultTrue();  // 默认 true，未设置时不导出符号库
@@ -25,6 +27,9 @@ private slots:
     void testExport3dModelDefaultFalse();  // 默认 false（opt-in），未设置时不导出 3D 模型
     void testExportSymbolExplicitTrue();  // --symbol=true 显式启用
     void testExport3dModelExplicitTrue();  // --3d-model 显式启用
+    void testModel3DFormatDefaultWrl();
+    void testModel3DFormatBoth();
+    void testModel3DFormatInvalid();
 
     // 补全脚本契约（验证不再暴露不存在的命令）
     void testCompletionScriptNoHelpVersionSubcommands();
@@ -118,6 +123,21 @@ void TestCommandLineParser::testParseConvertInvalid() {
     delete parser;
 }
 
+void TestCommandLineParser::testLibNameDefault() {
+    auto* parser = makeParser({"easykiconverter", "convert", "bom", "-i", "bom.xlsx", "-o", "out"});
+    parser->parse();
+    QCOMPARE(parser->libName(), QStringLiteral("EasyKiConverter"));
+    delete parser;
+}
+
+void TestCommandLineParser::testLibNameExplicit() {
+    auto* parser =
+        makeParser({"easykiconverter", "convert", "bom", "-i", "bom.xlsx", "-o", "out", "--lib-name", "my_lib"});
+    parser->parse();
+    QCOMPARE(parser->libName(), QStringLiteral("my_lib"));
+    delete parser;
+}
+
 // ========== 导出选项默认语义 ==========
 
 void TestCommandLineParser::testExportSymbolDefaultTrue() {
@@ -158,6 +178,32 @@ void TestCommandLineParser::testExport3dModelExplicitTrue() {
     auto* parser = makeParser({"easykiconverter", "convert", "bom", "-i", "b.xlsx", "-o", "o", "--3d-model"});
     parser->parse();
     QVERIFY(parser->export3DModel() == true);
+    delete parser;
+}
+
+void TestCommandLineParser::testModel3DFormatDefaultWrl() {
+    auto* parser = makeParser({"easykiconverter", "convert", "bom", "-i", "b.xlsx", "-o", "o", "--3d-model"});
+    parser->parse();
+    QVERIFY(parser->validate());
+    QCOMPARE(parser->model3DFormat(), QStringLiteral("wrl"));
+    delete parser;
+}
+
+void TestCommandLineParser::testModel3DFormatBoth() {
+    auto* parser = makeParser(
+        {"easykiconverter", "convert", "bom", "-i", "b.xlsx", "-o", "o", "--3d-model", "--3d-model-format", "both"});
+    parser->parse();
+    QVERIFY(parser->validate());
+    QCOMPARE(parser->model3DFormat(), QStringLiteral("both"));
+    delete parser;
+}
+
+void TestCommandLineParser::testModel3DFormatInvalid() {
+    auto* parser = makeParser(
+        {"easykiconverter", "convert", "bom", "-i", "b.xlsx", "-o", "o", "--3d-model", "--3d-model-format", "obj"});
+    parser->parse();
+    QVERIFY(!parser->validate());
+    QVERIFY(parser->validationError().contains(QStringLiteral("无效的 3D 模型格式")));
     delete parser;
 }
 

--- a/tests/unit/test_models.cpp
+++ b/tests/unit/test_models.cpp
@@ -1,12 +1,15 @@
 #include "core/easyeda/EasyedaFootprintImporter.h"
+#include "core/kicad/Exporter3DModel.h"
 #include "models/FootprintData.h"
 #include "models/FootprintDataSerializer.h"
 #include "models/SymbolData.h"
 #include "models/SymbolDataSerializer.h"
 
+#include <QFile>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QTemporaryDir>
 #include <QtTest>
 
 using namespace EasyKiConverter;
@@ -121,6 +124,37 @@ private slots:
         QVERIFY(footprint);
         QCOMPARE(footprint->model3D().translation().x, 3998.8);
         QCOMPARE(footprint->model3D().translation().y, 2982.35);
+    }
+
+    void testStepExportPreservesStepAssemblyStructure() {
+        Model3DData modelData;
+        modelData.setStep(
+            QByteArray("ISO-10303-21;\n"
+                       "DATA;\n"
+                       "#1=CARTESIAN_POINT('',(10.,20.,5.));\n"
+                       "#2=CARTESIAN_POINT('',(14.,24.,7.));\n"
+                       "#3=CARTESIAN_POINT('',(0.,0.,0.));\n"
+                       "#4=VERTEX_POINT('',#1);\n"
+                       "#5=VERTEX_POINT('',#2);\n"
+                       "#6=DIRECTION('',(0.,0.,1.));\n"
+                       "ENDSEC;\n"
+                       "END-ISO-10303-21;\n"));
+
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+        const QString stepPath = tempDir.filePath(QStringLiteral("model.step"));
+
+        Exporter3DModel exporter;
+        QVERIFY(exporter.exportToStep(modelData, stepPath));
+
+        QFile stepFile(stepPath);
+        QVERIFY(stepFile.open(QIODevice::ReadOnly));
+        const QString content = QString::fromLatin1(stepFile.readAll());
+
+        QVERIFY(content.contains(QStringLiteral("#1=CARTESIAN_POINT('',(10.,20.,5.));")));
+        QVERIFY(content.contains(QStringLiteral("#2=CARTESIAN_POINT('',(14.,24.,7.));")));
+        QVERIFY(content.contains(QStringLiteral("#3=CARTESIAN_POINT('',(0.,0.,0.));")));
+        QVERIFY(content.contains(QStringLiteral("#6=DIRECTION('',(0.,0.,1.));")));
     }
 
     void testSymbolGeometrySerialization() {


### PR DESCRIPTION
描述：                                                                        
                                                                                
  解决 STEP 格式 3D 模型在 KiCad 封装中位置不正确的问题，同时增强 CLI 模式的 3D
  模型导出能力。                                                                
                                                            
  原实现对 WRL 和 STEP 模型使用同一偏移量（来自 EasyEDA translation），但 STEP  
  文件内部几何中心与 WRL 不同，导致 STEP 模型未放置在封装正上方。本次修改为 STEP
   模型解析 VERTEX_POINT 包围盒中心，计算独立偏移量进行补偿。                   
                                                            
  相关 Issue： 无                                                               
                                                                
                                                                                
  主要变更：                                                                    
                                                                                
  - STEP 几何原点偏移补偿：FootprintExportStage 新增                            
  calculateStepGeometryCenter()，解析 STEP VERTEX_POINT 包围盒中心，生成 STEP   
  专用偏移量存入 Model3DData::stepOffsetMm；FootprintGraphicsGenerator 对 .step 
  路径追加该偏移                                            
  - Model3DData 扩展：新增 stepOffsetMm 字段，支持 JSON 序列化/反序列化
  - CLI 新增 --lib-name：自定义导出库名称（默认 EasyKiConverter）               
  - CLI 新增 --3d-model-format：支持 wrl（默认）、step、both 三种格式           
  - WriteWorker STEP 归一化：STEP 写入统一经 Exporter3DModel::exportToStep()    
  处理，不再直接拷贝缓存                                                        
  - Model3DExportWorker 缓存调整：STEP                                          
  缓存跳过直接拷贝，从服务器刷新后经导出器处理再回写缓存                        
  - Kicad 模块依赖：新增 EasyKiConverterNetwork 链接        
  - 单元测试：新增 testLibNameDefault/Explicit、testModel3DFormat*、testStepExpo
  rtPreservesStepAssemblyStructure