### PR TITLE
feat: 缓存配置、3D模型路径模式、导出状态管理优化、CLI国际化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,26 @@ qt_add_qml_module(appEasyKiconverter_Cpp_Version
         resources/icons/app_icon.ico
         resources/icons/app_icon.png
         resources/icons/app_icon.svg
+        resources/icons/app_icon_dark.icns
+        resources/icons/app_icon_dark.ico
+        resources/icons/app_icon_dark.png
+        resources/icons/app_icon_dark.svg
+        resources/icons/hicolor/16x16/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor/24x24/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor/32x32/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor/48x48/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor/64x64/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor/128x128/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor/256x256/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor/512x512/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/16x16/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/24x24/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/32x32/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/48x48/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/64x64/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/128x128/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/256x256/apps/io.github.tangsangsimida.easykiconverter.png
+        resources/icons/hicolor-dark/512x512/apps/io.github.tangsangsimida.easykiconverter.png
         resources/icons/play.svg
         resources/icons/play_black.svg
         resources/icons/folder.svg

--- a/src/core/kicad/ExporterFootprint.cpp
+++ b/src/core/kicad/ExporterFootprint.cpp
@@ -68,7 +68,7 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
                                                bool exportStep,
                                                const QString& libraryDescription,
                                                const QString& libraryKeywords,
-                                               int model3DPathMode,
+                                               bool useAbsolutePaths,
                                                const QString& model3DBaseDir) {
     qDebug() << "=== Export Footprint Library ===";
     qDebug() << "Library name:" << libName;
@@ -131,17 +131,17 @@ bool ExporterFootprint::exportFootprintLibrary(const QList<FootprintData>& footp
 
             if (useWrl && useStep) {
                 QString wrlPath =
-                    buildModel3DPath(safeLibName, modelName, QStringLiteral("wrl"), model3DPathMode, resolvedBaseDir);
+                    buildModel3DPath(safeLibName, modelName, QStringLiteral("wrl"), useAbsolutePaths, resolvedBaseDir);
                 QString stepPath =
-                    buildModel3DPath(safeLibName, modelName, QStringLiteral("step"), model3DPathMode, resolvedBaseDir);
+                    buildModel3DPath(safeLibName, modelName, QStringLiteral("step"), useAbsolutePaths, resolvedBaseDir);
                 content = generateFootprintContent(footprint, wrlPath, stepPath, libraryDescription, libraryKeywords);
             } else if (useWrl) {
                 QString wrlPath =
-                    buildModel3DPath(safeLibName, modelName, QStringLiteral("wrl"), model3DPathMode, resolvedBaseDir);
+                    buildModel3DPath(safeLibName, modelName, QStringLiteral("wrl"), useAbsolutePaths, resolvedBaseDir);
                 content = generateFootprintContent(footprint, wrlPath, libraryDescription, libraryKeywords);
             } else if (useStep) {
                 QString stepPath =
-                    buildModel3DPath(safeLibName, modelName, QStringLiteral("step"), model3DPathMode, resolvedBaseDir);
+                    buildModel3DPath(safeLibName, modelName, QStringLiteral("step"), useAbsolutePaths, resolvedBaseDir);
                 content = generateFootprintContent(footprint, stepPath, libraryDescription, libraryKeywords);
             } else {
                 content = generateFootprintContent(footprint, QString(), libraryDescription, libraryKeywords);
@@ -189,12 +189,12 @@ QString ExporterFootprint::generateHeader(const QString& libName) const {
 QString ExporterFootprint::buildModel3DPath(const QString& safeLibName,
                                             const QString& modelName,
                                             const QString& extension,
-                                            int model3DPathMode,
+                                            bool useAbsolutePaths,
                                             const QString& resolvedBaseDir) const {
     const QString modelFileName = QStringLiteral("%1.%2").arg(modelName, extension);
     const QString modelDirName = QStringLiteral("%1.3dmodels").arg(safeLibName);
 
-    if (model3DPathMode == ExportOptions::MODEL_3D_PATH_ABSOLUTE) {
+    if (useAbsolutePaths) {
         return QDir::cleanPath(QDir(resolvedBaseDir).absoluteFilePath(modelDirName + "/" + modelFileName));
     }
 

--- a/src/core/kicad/ExporterFootprint.h
+++ b/src/core/kicad/ExporterFootprint.h
@@ -4,7 +4,6 @@
 #include "FootprintGraphicsGenerator.h"
 #include "models/FootprintData.h"
 #include "models/Model3DData.h"
-#include "services/export/ExportProgress.h"
 
 #include <QJsonObject>
 #include <QString>
@@ -57,6 +56,7 @@ public:
      * @param filePath 输出目录路径（.pretty 目录）
      * @param preferWrl 是否优先使用 WRL 格式（默认 true，向后兼容）
      * @param exportStep 是否同时导出 STEP 格式（默认 false，向后兼容）
+     * @param useAbsolutePaths 3D模型路径是否使用绝对路径（默认 false，使用相对路径）
      * @note 默认参数仅导出 WRL，以保持与旧版本的兼容行为。
      *       调用方应显式传入 exportStep=true 以启用双格式导出。
      * @return bool 是否成功
@@ -68,7 +68,7 @@ public:
                                 bool exportStep = false,
                                 const QString& libraryDescription = QString(),
                                 const QString& libraryKeywords = QString(),
-                                int model3DPathMode = ExportOptions::MODEL_3D_PATH_RELATIVE,
+                                bool useAbsolutePaths = false,
                                 const QString& model3DBaseDir = QString());
 
     /**
@@ -90,7 +90,7 @@ private:
     QString buildModel3DPath(const QString& safeLibName,
                              const QString& modelName,
                              const QString& extension,
-                             int model3DPathMode,
+                             bool useAbsolutePaths,
                              const QString& resolvedBaseDir) const;
     void generateFootprintBaseContent(const FootprintData& footprintData,
                                       QString& content,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QGuiApplication>
 #include <QIcon>
 #include <QImage>
@@ -42,6 +43,7 @@
 #include <QTextStream>
 #include <QTimer>
 #include <QUrl>
+#include <QWindow>
 
 #ifdef _WIN32
 #    include <conio.h>
@@ -245,6 +247,100 @@ QString resolveProjectRootFromAppDir(QString appDir) {
         return appDir.chopped(4);  // 去掉 /bin
     }
     return appDir;
+}
+
+QStringList themedTaskbarIconPaths(bool darkMode) {
+    const QString iconThemeDir = darkMode ? QStringLiteral("hicolor-dark") : QStringLiteral("hicolor");
+    const QString fallbackIconThemeDir = QStringLiteral("hicolor");
+    const QString themedAppIcon = darkMode ? QStringLiteral("app_icon_dark.png") : QStringLiteral("app_icon.png");
+    const QString appImagePath = qgetenv("APPIMAGE");
+    const QString runtimeAppDir = resolveRuntimeAppDir(appImagePath);
+    const QString mountedAppDir = normalizeMountedAppDir(QCoreApplication::applicationDirPath());
+    const QString projectRoot = resolveProjectRootFromAppDir(mountedAppDir);
+    const bool isAppImage = !appImagePath.isEmpty();
+    const QStringList sizes = {"512x512", "256x256", "128x128", "64x64", "48x48", "32x32", "24x24", "16x16"};
+
+    QStringList qrcIconPaths = {
+        QStringLiteral(":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/") + themedAppIcon,
+        QStringLiteral(":/resources/icons/") + themedAppIcon,
+    };
+    QStringList appImageIconPaths;
+    QStringList devIconPaths;
+    QStringList systemIconPaths = {
+        QStringLiteral("io.github.tangsangsimida.easykiconverter"),
+    };
+
+    for (const QString& size : sizes) {
+        const QString iconName = QStringLiteral("/apps/io.github.tangsangsimida.easykiconverter.png");
+        const QString themedIconPath = iconThemeDir + "/" + size + iconName;
+        qrcIconPaths << QStringLiteral(":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/") + themedIconPath
+                     << QStringLiteral(":/resources/icons/") + themedIconPath;
+        appImageIconPaths << mountedAppDir + "/usr/share/icons/" + themedIconPath
+                          << runtimeAppDir + "/usr/share/icons/" + themedIconPath
+                          << mountedAppDir + "/resources/icons/" + themedIconPath;
+        devIconPaths << projectRoot + "/resources/icons/" + themedIconPath;
+        systemIconPaths << "/usr/share/icons/" + themedIconPath;
+
+        if (darkMode) {
+            const QString fallbackIconPath = fallbackIconThemeDir + "/" + size + iconName;
+            qrcIconPaths << QStringLiteral(":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/") + fallbackIconPath
+                         << QStringLiteral(":/resources/icons/") + fallbackIconPath;
+            appImageIconPaths << mountedAppDir + "/usr/share/icons/" + fallbackIconPath
+                              << runtimeAppDir + "/usr/share/icons/" + fallbackIconPath
+                              << mountedAppDir + "/resources/icons/" + fallbackIconPath;
+            devIconPaths << projectRoot + "/resources/icons/" + fallbackIconPath;
+            systemIconPaths << "/usr/share/icons/" + fallbackIconPath;
+        }
+    }
+
+    QStringList genericPaths = {
+        mountedAppDir + "/" + themedAppIcon,
+        runtimeAppDir + "/" + themedAppIcon,
+        projectRoot + "/resources/icons/" + themedAppIcon,
+        mountedAppDir + "/io.github.tangsangsimida.easykiconverter.png",
+        runtimeAppDir + "/io.github.tangsangsimida.easykiconverter.png",
+        projectRoot + "/io.github.tangsangsimida.easykiconverter.png",
+        QStringLiteral(":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/app_icon.png"),
+        QStringLiteral(":/resources/icons/app_icon.png"),
+        projectRoot + "/resources/icons/app_icon.png",
+    };
+
+    QStringList iconPaths = isAppImage
+                                ? appImageIconPaths + qrcIconPaths + devIconPaths + genericPaths + systemIconPaths
+                                : qrcIconPaths + devIconPaths + appImageIconPaths + genericPaths + systemIconPaths;
+    iconPaths.removeDuplicates();
+    return iconPaths;
+}
+
+bool applyTaskbarIcon(bool darkMode, QWindow* window = nullptr, const char* context = "应用程序") {
+    const QStringList iconPaths = themedTaskbarIconPaths(darkMode);
+
+    for (const QString& iconPath : iconPaths) {
+        const bool canTryIconTheme = !iconPath.contains('/');
+        if (!canTryIconTheme && !QFile::exists(iconPath)) {
+            continue;
+        }
+
+        const QIcon icon = canTryIconTheme ? QIcon::fromTheme(iconPath) : QIcon(iconPath);
+        if (icon.isNull()) {
+            continue;
+        }
+
+        QGuiApplication::setWindowIcon(icon);
+        if (auto* application = qobject_cast<QApplication*>(QCoreApplication::instance())) {
+            application->setWindowIcon(icon);
+        }
+        if (window) {
+            window->setIcon(icon);
+        }
+
+        qDebug() << context << "任务栏图标已设置:" << iconPath << "darkMode=" << darkMode
+                 << "availableSizes=" << icon.availableSizes();
+        return true;
+    }
+
+    qWarning() << context << "任务栏图标设置失败，darkMode=" << darkMode << "尝试路径数:" << iconPaths.size();
+    return false;
 }
 
 }  // anonymous namespace
@@ -545,52 +641,8 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // 根据主题设置确定图标目录
-    bool isDarkMode = EasyKiConverter::ConfigService::instance()->getDarkMode();
-    QString iconThemeDir = isDarkMode ? "hicolor-dark" : "hicolor";
-    bool isAppImage = !appImagePath.isEmpty();
-    qDebug() << "主题模式:" << (isDarkMode ? "dark" : "light") << ", 图标目录:" << iconThemeDir;
-    qDebug() << "AppImage 模式:" << isAppImage;
-
-    // 加载应用图标（根据主题选择不同的图标目录）
-    QStringList iconPaths;
-
-    if (isAppImage) {
-        // AppImage: 优先使用内部图标路径
-        iconPaths = {
-            appDir + "/io.github.tangsangsimida.easykiconverter.png",
-            appDir + "/usr/share/icons/" + iconThemeDir + "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            appDir + "/usr/share/icons/hicolor/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            appDir + "/resources/icons/" + iconThemeDir + "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            ":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/" + iconThemeDir +
-                "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-        };
-    } else {
-        // 非AppImage: 优先使用资源路径和开发路径
-        iconPaths = {
-            ":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/" + iconThemeDir +
-                "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            ":/qt/qml/EasyKiconverter_Cpp_Version/resources/icons/app_icon.png",
-            ":/resources/icons/" + iconThemeDir + "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            ":/resources/icons/app_icon.png",
-            appDir + "/resources/icons/" + iconThemeDir + "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            appDir + "/resources/icons/app_icon.png",
-            appDir + "/io.github.tangsangsimida.easykiconverter.png",
-            appDir + "/usr/share/icons/" + iconThemeDir + "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            appDir + "/usr/share/icons/hicolor/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-        };
-    }
-
-    for (const QString& iconPath : iconPaths) {
-        qDebug() << "尝试加载图标:" << iconPath << "存在:" << QFile::exists(iconPath);
-        QIcon icon(iconPath);
-        if (!icon.isNull()) {
-            QGuiApplication::setWindowIcon(icon);
-            app.setWindowIcon(icon);
-            qDebug() << "应用程序图标已设置：" << iconPath;
-            break;
-        }
-    }
+    // 加载应用图标（根据当前主题选择浅色/深色任务栏图标）。
+    applyTaskbarIcon(EasyKiConverter::ConfigService::instance()->getDarkMode(), nullptr, "启动");
 
     // 创建 Service 实例（使用流水线架构，不设置 parent，手动管理生命周期）
     // 预先初始化缓存服务，避免首次添加组件时阻塞UI
@@ -659,8 +711,6 @@ int main(int argc, char* argv[]) {
     const QUrl url("qrc:/qt/qml/EasyKiconverter_Cpp_Version/src/ui/qml/Main.qml");
     engine->load(url);
 
-    qWarning() << "===== QML 加载完成，开始设置图标 =====";
-
     if (engine->rootObjects().isEmpty()) {
         qCritical() << "严重错误：QML引擎根对象加载后为空！";
         delete engine;
@@ -670,98 +720,18 @@ int main(int argc, char* argv[]) {
     // 获取根窗口对象并设置窗口位置和图标
     auto* rootObject = engine->rootObjects().first();
     if (auto* window = qobject_cast<QQuickWindow*>(rootObject)) {
-        // 调试：显示所有可能的图标路径
-        QString appImagePath = qgetenv("APPIMAGE");
-        qWarning() << "===== 图标调试信息 =====";
-        qWarning() << "APPIMAGE 环境变量:" << appImagePath;
-        qWarning() << "applicationDirPath:" << QCoreApplication::applicationDirPath();
-        qWarning() << "XDG_DATA_DIRS:" << qgetenv("XDG_DATA_DIRS");
-
-        // AppImage 挂载点在 /tmp/.mount_XXX/，需要获取父目录
-        QString appDir = normalizeMountedAppDir(QCoreApplication::applicationDirPath());
-        qWarning() << "使用 appDir:" << appDir;
-
-        bool isDarkModeForIcon = EasyKiConverter::ConfigService::instance()->getDarkMode();
-        QString iconThemeDir = isDarkModeForIcon ? "hicolor-dark" : "hicolor";
-        bool isAppImage = !qgetenv("APPIMAGE").isEmpty();
-
-        // AppImage 内部的图标路径（优先级最高）
-        QStringList appImageIconPaths = {
-            appDir + "/usr/share/icons/" + iconThemeDir +
-                "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",  // 优先使用 256x256
-            appDir +
-                "/usr/share/icons/hicolor/256x256/apps/io.github.tangsangsimida.easykiconverter.png",  // fallback 到 hicolor
-            appDir + "/io.github.tangsangsimida.easykiconverter.png",  // AppDir 根目录（可能是 64x64，作为 fallback）
-            appDir + "/usr/share/icons/" + iconThemeDir +
-                "/128x128/apps/io.github.tangsangsimida.easykiconverter.png",  // 128x128
-            appDir + "/usr/share/icons/hicolor/128x128/apps/io.github.tangsangsimida.easykiconverter.png",  // 128x128
-            appDir + "/usr/share/icons/" + iconThemeDir +
-                "/64x64/apps/io.github.tangsangsimida.easykiconverter.png",  // 64x64
-            appDir + "/usr/share/icons/hicolor/64x64/apps/io.github.tangsangsimida.easykiconverter.png",  // 64x64
+        auto refreshTaskbarIcon = [window]() {
+            const bool isDarkModeForIcon = EasyKiConverter::ConfigService::instance()->getDarkMode();
+            applyTaskbarIcon(isDarkModeForIcon, window, "窗口");
         };
 
-        // 计算项目根目录（用于开发模式）
-        QString projectRoot = resolveProjectRootFromAppDir(appDir);
+        refreshTaskbarIcon();
 
-        // 开发时的图标路径（优先级较低）
-        QStringList devIconPaths = {
-            projectRoot + "/resources/icons/" + iconThemeDir +
-                "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            projectRoot + "/resources/icons/" + iconThemeDir +
-                "/64x64/apps/io.github.tangsangsimida.easykiconverter.png",
-            projectRoot + "/resources/icons/" + iconThemeDir +
-                "/128x128/apps/io.github.tangsangsimida.easykiconverter.png",
-            projectRoot + "/resources/icons/" + iconThemeDir +
-                "/32x32/apps/io.github.tangsangsimida.easykiconverter.png",
-            QCoreApplication::applicationDirPath() + "/io.github.tangsangsimida.easykiconverter.png",
-            projectRoot + "/io.github.tangsangsimida.easykiconverter.png",
-        };
-
-        // 系统图标路径（fallback）
-        QStringList systemIconPaths = {
-            "io.github.tangsangsimida.easykiconverter",  // 让 Qt 在标准路径查找
-            "/usr/share/icons/hicolor/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-            "/usr/share/icons/" + iconThemeDir + "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-        };
-
-        QStringList iconPaths;
-        if (isAppImage) {
-            // AppImage: 优先使用内部图标
-            iconPaths = appImageIconPaths + devIconPaths + systemIconPaths;
-        } else {
-            // 非AppImage: 优先使用开发路径
-            iconPaths = devIconPaths + appImageIconPaths + systemIconPaths;
-        }
-
-        bool iconSet = false;
-        for (const QString& path : iconPaths) {
-            qWarning() << "尝试图标路径:" << path << "存在:" << QFile::exists(path);
-            QIcon icon(path);
-            if (!icon.isNull()) {
-                QWindow* qwindow = window;
-                qwindow->setIcon(icon);
-                QGuiApplication::setWindowIcon(icon);
-
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-                qwindow->raise();
-                qwindow->requestActivate();
-                QCoreApplication::processEvents();
-#endif
-
-                qWarning() << "[OK] 任务栏图标已设置:" << path;
-                qWarning() << "  图标可用尺寸:" << icon.availableSizes();
-                qWarning() << "  图标是否为空:" << icon.isNull();
-                iconSet = true;
-                break;
-            }
-        }
-
-        if (!iconSet) {
-            qWarning() << "[FAIL] 未能设置任务栏图标";
-            qWarning() << "  尝试了" << iconPaths.size() << "个路径，但都失败";
-        }
-
-        qWarning() << "===== 图标调试信息结束 =====";
+        QObject::connect(themeSettingsViewModel,
+                         &EasyKiConverter::ThemeSettingsViewModel::darkModeChanged,
+                         window,
+                         refreshTaskbarIcon,
+                         Qt::QueuedConnection);
 
         QTimer::singleShot(100, [window]() {
             qDebug() << "Startup window state:" << "visible=" << window->isVisible()
@@ -783,66 +753,8 @@ int main(int argc, char* argv[]) {
             }
 
             // 窗口显示后再次设置任务栏图标
-            QString appDir = normalizeMountedAppDir(QCoreApplication::applicationDirPath());
-            QString projectRoot = resolveProjectRootFromAppDir(appDir);
-
-            bool isDarkModeForIcon = EasyKiConverter::ConfigService::instance()->getDarkMode();
-            QString iconThemeDir = isDarkModeForIcon ? "hicolor-dark" : "hicolor";
-            bool isAppImage = !qgetenv("APPIMAGE").isEmpty();
-
-            // 定义图标路径列表（与初始化时相同，优先使用 256x256）
-            QStringList iconPaths;
-            if (isAppImage) {
-                iconPaths = {
-                    appDir + "/usr/share/icons/" + iconThemeDir +
-                        "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/usr/share/icons/hicolor/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/usr/share/icons/" + iconThemeDir +
-                        "/128x128/apps/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/usr/share/icons/hicolor/128x128/apps/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/resources/icons/" + iconThemeDir +
-                        "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-                };
-            } else {
-                iconPaths = {
-                    projectRoot + "/resources/icons/" + iconThemeDir +
-                        "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-                    projectRoot + "/resources/icons/" + iconThemeDir +
-                        "/128x128/apps/io.github.tangsangsimida.easykiconverter.png",
-                    projectRoot + "/resources/icons/" + iconThemeDir +
-                        "/64x64/apps/io.github.tangsangsimida.easykiconverter.png",
-                    projectRoot + "/resources/icons/" + iconThemeDir +
-                        "/32x32/apps/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/io.github.tangsangsimida.easykiconverter.png",
-                    projectRoot + "/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/usr/share/icons/" + iconThemeDir +
-                        "/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-                    appDir + "/usr/share/icons/hicolor/256x256/apps/io.github.tangsangsimida.easykiconverter.png",
-                };
-            }
-
-            bool iconSet = false;
-            for (const QString& path : iconPaths) {
-                if (QFile::exists(path)) {
-                    QIcon icon(path);
-                    window->setIcon(icon);
-
-#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
-                    // 对于 FramelessWindowHint，强制刷新任务栏图标
-                    window->raise();
-                    window->requestActivate();
-#endif
-
-                    qWarning() << "窗口显示后重新设置任务栏图标:" << path;
-                    iconSet = true;
-                    break;
-                }
-            }
-
-            if (!iconSet) {
-                qWarning() << "[FAIL] 窗口显示后未能重新设置任务栏图标";
-            }
+            const bool isDarkModeForIcon = EasyKiConverter::ConfigService::instance()->getDarkMode();
+            applyTaskbarIcon(isDarkModeForIcon, window, "窗口显示后");
         });
     }
 

--- a/src/services/ComponentCacheService.cpp
+++ b/src/services/ComponentCacheService.cpp
@@ -17,7 +17,6 @@
 #include <QJsonObject>
 #include <QSaveFile>
 #include <QSet>
-#include <QStandardPaths>
 #include <QUrl>
 #include <QtConcurrent>
 
@@ -31,10 +30,7 @@ ComponentCacheService::ComponentCacheService(QObject* parent)
     , m_diskCacheLimitMB(ConfigService::DEFAULT_DISK_CACHE_LIMIT_MB)
     , m_memoryCacheSize(0) {
     m_lastEnforceTimer.start();
-    // 默认缓存目录：{用户数据目录}/easykiconverter/cache
-    QString defaultCacheDir =
-        QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/cache");
-    setCacheDir(defaultCacheDir);
+    setCacheDir(ConfigService::defaultCacheDir());
 
     // 初始化L1内存缓存，设置大小限制（50MB = 50 * 1024 * 1024 bytes）
     // QCache 的 cost 是存储的字节数

--- a/src/services/ConfigService.cpp
+++ b/src/services/ConfigService.cpp
@@ -10,11 +10,9 @@
 
 namespace EasyKiConverter {
 
-namespace {
-QString defaultCacheDir() {
+QString ConfigService::defaultCacheDir() {
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/cache");
 }
-}  // namespace
 
 // 静态成员初始化
 ConfigService* ConfigService::s_instance = nullptr;
@@ -121,6 +119,33 @@ void ConfigService::resetToDefaults() {
     qDebug() << "Config reset to defaults";
 }
 
+void ConfigService::beginBatchUpdate() {
+    QMutexLocker locker(&m_configMutex);
+    m_batchUpdateDepth++;
+}
+
+void ConfigService::endBatchUpdate() {
+    QMutexLocker locker(&m_configMutex);
+    if (m_batchUpdateDepth > 0) {
+        m_batchUpdateDepth--;
+        if (m_batchUpdateDepth == 0 && m_batchDirty) {
+            m_batchDirty = false;
+            locker.unlock();
+            saveConfig();
+        }
+    }
+}
+
+void ConfigService::saveIfNotBatching() {
+    QMutexLocker locker(&m_configMutex);
+    if (m_batchUpdateDepth > 0) {
+        m_batchDirty = true;
+        return;
+    }
+    locker.unlock();
+    saveConfig();
+}
+
 QString ConfigService::getOutputPath() const {
     QMutexLocker locker(&m_configMutex);
     return m_config["outputPath"].toString(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
@@ -133,7 +158,7 @@ void ConfigService::setOutputPath(const QString& path) {
 
     // 释放锁后保存（因为 saveConfig 内部也会加锁，避免死锁）
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 QString ConfigService::getLibName() const {
@@ -148,7 +173,7 @@ void ConfigService::setLibName(const QString& name) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getExportSymbol() const {
@@ -163,7 +188,7 @@ void ConfigService::setExportSymbol(bool enabled) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getExportFootprint() const {
@@ -178,7 +203,7 @@ void ConfigService::setExportFootprint(bool enabled) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getExportModel3D() const {
@@ -193,7 +218,7 @@ void ConfigService::setExportModel3D(bool enabled) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 int ConfigService::getExportModel3DFormat() const {
@@ -208,7 +233,7 @@ void ConfigService::setExportModel3DFormat(int format) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 int ConfigService::getExportModel3DPathMode() const {
@@ -223,7 +248,7 @@ void ConfigService::setExportModel3DPathMode(int mode) {
     emit configChanged();
 
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getExportPreviewImages() const {
@@ -238,7 +263,7 @@ void ConfigService::setExportPreviewImages(bool enabled) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getExportDatasheet() const {
@@ -253,7 +278,7 @@ void ConfigService::setExportDatasheet(bool enabled) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getWeakNetworkSupport() const {
@@ -267,7 +292,7 @@ void ConfigService::setWeakNetworkSupport(bool enabled) {
     emit configChanged();
 
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 int ConfigService::getValidationConcurrentCount() const {
@@ -290,7 +315,7 @@ void ConfigService::setOverwriteExistingFiles(bool enabled) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 int ConfigService::getExportMode() const {
@@ -304,7 +329,7 @@ void ConfigService::setExportMode(int mode) {
     emit configChanged();
 
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getDarkMode() const {
@@ -319,7 +344,7 @@ void ConfigService::setDarkMode(bool enabled) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 bool ConfigService::getDebugMode() const {
@@ -370,7 +395,7 @@ void ConfigService::setWindowState(const QVariantMap& state) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 QString ConfigService::getExitPreference() const {
@@ -385,7 +410,7 @@ void ConfigService::setExitPreference(const QString& preference) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 void ConfigService::initializeDefaultConfig() {
@@ -442,7 +467,7 @@ void ConfigService::setLanguage(const QString& languageCode) {
 
     // 释放锁后保存
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 QString ConfigService::getCacheDir() const {
@@ -458,7 +483,7 @@ void ConfigService::setCacheDir(const QString& path) {
     emit configChanged();
 
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 int ConfigService::getDiskCacheLimitMB() const {
@@ -472,7 +497,7 @@ void ConfigService::setDiskCacheLimitMB(int maxSizeMB) {
     emit configChanged();
 
     locker.unlock();
-    saveConfig();
+    saveIfNotBatching();
 }
 
 }  // namespace EasyKiConverter

--- a/src/services/ConfigService.h
+++ b/src/services/ConfigService.h
@@ -47,6 +47,20 @@ public:
      */
     void resetToDefaults();
 
+    /**
+     * @brief 开始批量更新（抑制 saveConfig 调用）
+     *
+     * 与 endBatchUpdate() 配对使用。在批量更新期间，
+     * 所有 setter 不会触发 saveConfig()，而是在 endBatchUpdate() 时统一保存一次。
+     * 支持嵌套调用。
+     */
+    void beginBatchUpdate();
+
+    /**
+     * @brief 结束批量更新，统一保存一次配置
+     */
+    void endBatchUpdate();
+
     // 配置访问方法
 
     /**
@@ -340,6 +354,9 @@ public:
     static constexpr int DEFAULT_DISK_CACHE_LIMIT_MB = 5120;
     static constexpr int MAX_DISK_CACHE_LIMIT_MB = 1048576;
 
+    /** @brief 默认缓存目录路径（静态工具方法，不依赖单例状态） */
+    static QString defaultCacheDir();
+
 private:
     static constexpr int DEFAULT_WINDOW_WIDTH = -1;
     static constexpr int DEFAULT_WINDOW_HEIGHT = -1;
@@ -375,9 +392,13 @@ private:
     static ConfigService* s_instance;
     static QMutex s_mutex;
 
+    void saveIfNotBatching();
+
     QJsonObject m_config;
     QString m_configPath;
     mutable QMutex m_configMutex;
+    int m_batchUpdateDepth = 0;
+    bool m_batchDirty = false;
 };
 
 }  // namespace EasyKiConverter

--- a/src/services/export/DatasheetExportStage.cpp
+++ b/src/services/export/DatasheetExportStage.cpp
@@ -71,14 +71,14 @@ void DatasheetExportStage::start(const QStringList& componentIds,
         }
     }
 
+    m_isExporting.store(true);
+
     // 调用基类的初始化方法（设置状态，并处理空列表情况）
     ExportTypeStage::start(componentIds, cachedData);
-
-    m_isExporting.store(true);
 }
 
 void DatasheetExportStage::cancel() {
-    cancelWithTempRollback(m_isExporting, m_tempManager);
+    cancelWithTempRollback(m_tempManager);
 }
 
 void DatasheetExportStage::commitTempFile(const QString& tempPath, const QString& finalPath) {

--- a/src/services/export/DatasheetExportStage.cpp
+++ b/src/services/export/DatasheetExportStage.cpp
@@ -78,23 +78,7 @@ void DatasheetExportStage::start(const QStringList& componentIds,
 }
 
 void DatasheetExportStage::cancel() {
-    if (!m_isExporting.load()) {
-        return;
-    }
-
-    qDebug() << "DatasheetExportStage: Cancelling...";
-
-    ExportTypeStage::cancel();
-
-    // 回滚所有临时文件
-    m_tempManager.rollbackAll();
-
-    m_isExporting.store(false);
-    if (!hasActiveWorkers()) {
-        m_isRunning.store(false);
-    }
-
-    qDebug() << "DatasheetExportStage: Cancelled";
+    cancelWithTempRollback(m_isExporting, m_tempManager);
 }
 
 void DatasheetExportStage::commitTempFile(const QString& tempPath, const QString& finalPath) {

--- a/src/services/export/DatasheetExportStage.h
+++ b/src/services/export/DatasheetExportStage.h
@@ -88,7 +88,6 @@ private:
     TempFileManager m_tempManager;  ///< 临时文件管理器
     QMap<QString, QString> m_tempPaths;  ///< componentId -> tempPath
     QMap<QString, QString> m_finalPaths;  ///< componentId -> finalPath
-    std::atomic<bool> m_isExporting{false};  ///< 是否正在导出
 };
 
 }  // namespace EasyKiConverter

--- a/src/services/export/ExportTypeStage.cpp
+++ b/src/services/export/ExportTypeStage.cpp
@@ -14,6 +14,9 @@ ExportTypeStage::ExportTypeStage(const QString& typeName, int maxConcurrent, QOb
     m_threadPool.setMaxThreadCount(maxConcurrent);
     m_threadPool.setExpiryTimeout(60000);
     m_progress.typeName = typeName;
+
+    // completed 信号发射时自动清除 m_isExporting 标志（DirectConnection：原子写操作，跨线程安全）
+    connect(this, &ExportTypeStage::completed, this, [this]() { m_isExporting.store(false); }, Qt::DirectConnection);
 }
 
 ExportTypeStage::~ExportTypeStage() {
@@ -165,8 +168,8 @@ void ExportTypeStage::cancel() {
     qDebug() << "ExportTypeStage:" << m_typeName << "cancelled";
 }
 
-void ExportTypeStage::cancelWithTempRollback(std::atomic<bool>& isExporting, TempFileManager& tempManager) {
-    if (!isExporting.load()) {
+void ExportTypeStage::cancelWithTempRollback(TempFileManager& tempManager) {
+    if (!m_isExporting.load()) {
         return;
     }
 
@@ -175,7 +178,7 @@ void ExportTypeStage::cancelWithTempRollback(std::atomic<bool>& isExporting, Tem
     cancel();
     tempManager.rollbackAll();
 
-    isExporting.store(false);
+    m_isExporting.store(false);
     if (!hasActiveWorkers()) {
         m_isRunning.store(false);
     }
@@ -286,8 +289,8 @@ void ExportTypeStage::completeItemProgress(QObject* worker,
                 << "status:" << (int)statusSnapshot.status;
         qDebug() << "ExportTypeStage:" << m_typeName << "completed. Success:" << progressSnapshot.successCount
                  << "Failed:" << progressSnapshot.failedCount << "Skipped:" << progressSnapshot.skippedCount;
-        emit completed(progressSnapshot.successCount, progressSnapshot.failedCount, progressSnapshot.skippedCount);
         m_isRunning.store(false);
+        emit completed(progressSnapshot.successCount, progressSnapshot.failedCount, progressSnapshot.skippedCount);
         return;
     }
 

--- a/src/services/export/ExportTypeStage.cpp
+++ b/src/services/export/ExportTypeStage.cpp
@@ -1,6 +1,7 @@
 #include "ExportTypeStage.h"
 
 #include "IExportWorker.h"
+#include "TempFileManager.h"
 
 #include <QDebug>
 #include <QMutexLocker>
@@ -162,6 +163,44 @@ void ExportTypeStage::cancel() {
     }
 
     qDebug() << "ExportTypeStage:" << m_typeName << "cancelled";
+}
+
+void ExportTypeStage::cancelWithTempRollback(std::atomic<bool>& isExporting, TempFileManager& tempManager) {
+    if (!isExporting.load()) {
+        return;
+    }
+
+    qDebug() << "ExportTypeStage:" << m_typeName << "cancelling (with temp rollback)...";
+
+    cancel();
+    tempManager.rollbackAll();
+
+    isExporting.store(false);
+    if (!hasActiveWorkers()) {
+        m_isRunning.store(false);
+    }
+
+    qDebug() << "ExportTypeStage:" << m_typeName << "cancelled";
+}
+
+bool ExportTypeStage::waitForWorkerThread(QThread*& thread, int timeoutMs) {
+    m_cancelled.store(true);
+
+    if (!thread || !thread->isRunning()) {
+        thread = nullptr;
+        return true;
+    }
+
+    qDebug() << "ExportTypeStage:" << m_typeName << "waiting for worker thread to finish...";
+    thread->quit();
+    if (!thread->wait(timeoutMs)) {
+        qWarning() << "ExportTypeStage:" << m_typeName << "thread did not finish in" << timeoutMs
+                   << "ms, leaving it to finish asynchronously";
+        return false;
+    }
+
+    thread = nullptr;
+    return true;
 }
 
 ExportTypeProgress ExportTypeStage::getProgress() const {

--- a/src/services/export/ExportTypeStage.h
+++ b/src/services/export/ExportTypeStage.h
@@ -10,11 +10,14 @@
 #include <QSharedPointer>
 #include <QString>
 #include <QStringList>
+#include <QThread>
 #include <QThreadPool>
 
 #include <atomic>
 
 namespace EasyKiConverter {
+
+class TempFileManager;
 
 class ComponentData;
 
@@ -154,6 +157,27 @@ protected:
      * 线程安全：由m_workerMutex保护。
      */
     void startNextWorker();
+
+    /**
+     * @brief 带临时文件回滚的取消操作（供使用 TempFileManager 的子类调用）
+     * @param isExporting 子类的 m_isExporting 原子标志引用
+     * @param tempManager 子类的 TempFileManager 实例引用
+     *
+     * 统一执行：基类取消 → 临时文件回滚 → 状态清理。
+     * DatasheetExportStage、PreviewImagesExportStage、Model3DExportStage 共用此逻辑。
+     */
+    void cancelWithTempRollback(std::atomic<bool>& isExporting, TempFileManager& tempManager);
+
+    /**
+     * @brief 等待单个工作线程退出（供使用独立 QThread 的子类调用）
+     * @param thread 子类的 m_workerThread 指针引用
+     * @param timeoutMs 超时时间（毫秒），默认 5000
+     * @return true 线程已退出，false 超时
+     *
+     * SymbolExportStage 和 FootprintExportStage 共用此逻辑：
+     * 设置取消标志 → 请求线程退出 → 等待超时 → 置空指针。
+     */
+    bool waitForWorkerThread(QThread*& thread, int timeoutMs = 5000);
 
     /**
      * @brief 初始化单个元器件的进度状态

--- a/src/services/export/ExportTypeStage.h
+++ b/src/services/export/ExportTypeStage.h
@@ -160,13 +160,13 @@ protected:
 
     /**
      * @brief 带临时文件回滚的取消操作（供使用 TempFileManager 的子类调用）
-     * @param isExporting 子类的 m_isExporting 原子标志引用
      * @param tempManager 子类的 TempFileManager 实例引用
      *
      * 统一执行：基类取消 → 临时文件回滚 → 状态清理。
      * DatasheetExportStage、PreviewImagesExportStage、Model3DExportStage 共用此逻辑。
+     * 使用基类 m_isExporting 标志判断是否正在导出。
      */
-    void cancelWithTempRollback(std::atomic<bool>& isExporting, TempFileManager& tempManager);
+    void cancelWithTempRollback(TempFileManager& tempManager);
 
     /**
      * @brief 等待单个工作线程退出（供使用独立 QThread 的子类调用）
@@ -211,6 +211,7 @@ public:
     QThreadPool m_threadPool;  ///< 线程池，用于管理并行导出任务
     std::atomic<bool> m_isRunning{false};  ///< 任务是否正在运行的原子标志
     std::atomic<bool> m_cancelled{false};  ///< 取消请求的原子标志
+    std::atomic<bool> m_isExporting{false};  ///< 是否正在导出（子类可直接读写）
     QStringList m_componentIds;  ///< 需要导出的元器件ID列表
     QMap<QString, QSharedPointer<ComponentData>> m_cachedData;  ///< 预加载的元器件数据缓存
     mutable QMutex m_progressMutex;  ///< 保护m_progress的互斥量

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -198,10 +198,7 @@ FootprintExportStage::FootprintExportStage(QObject* parent)
 }
 
 FootprintExportStage::~FootprintExportStage() {
-    m_cancelled.store(true);
-    if (m_workerThread && m_workerThread->isRunning()) {
-        m_workerThread->wait();
-    }
+    waitForWorkerThread(m_workerThread, 30000);
 }
 
 void FootprintExportStage::start(const QStringList& componentIds,
@@ -257,23 +254,11 @@ void FootprintExportStage::cancel() {
 
     qDebug() << "FootprintExportStage: Cancelling...";
 
-    // 设置取消标志
-    m_cancelled.store(true);
-
-    // 等待工作线程协作式退出（最多等待 5 秒）。不能 terminate()：强杀线程可能中断 Qt/C++ 对象析构或持锁区。
-    if (m_workerThread && m_workerThread->isRunning()) {
-        qDebug() << "FootprintExportStage: Waiting for worker thread to finish...";
-        m_workerThread->quit();
-        if (!m_workerThread->wait(5000)) {
-            qWarning() << "FootprintExportStage: Thread did not finish in 5s, leaving it to finish asynchronously";
-            return;
-        }
-        m_workerThread = nullptr;
+    if (!waitForWorkerThread(m_workerThread)) {
+        return;  // 超时，交由析构函数再次等待
     }
 
-    // 清理临时文件
     m_tempManager.rollbackAll();
-
     m_isExporting.store(false);
     m_isRunning.store(false);
 
@@ -488,15 +473,16 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         const bool preferWrl = m_options.needsModel3DWrl();
         const bool exportStep = m_options.needsModel3DStep();
         QString libraryKeywords = m_options.footprintLibraryKeywords;
-        exportSuccess = exporter.exportFootprintLibrary(footprintList,
-                                                        libName,
-                                                        tempDirPath,
-                                                        preferWrl,
-                                                        exportStep,
-                                                        libraryDescription,
-                                                        libraryKeywords,
-                                                        m_options.exportModel3DPathMode,
-                                                        outputDir);
+        exportSuccess =
+            exporter.exportFootprintLibrary(footprintList,
+                                            libName,
+                                            tempDirPath,
+                                            preferWrl,
+                                            exportStep,
+                                            libraryDescription,
+                                            libraryKeywords,
+                                            m_options.exportModel3DPathMode == ExportOptions::MODEL_3D_PATH_ABSOLUTE,
+                                            outputDir);
     }
 
     if (m_cancelled.load()) {

--- a/src/services/export/FootprintExportStage.h
+++ b/src/services/export/FootprintExportStage.h
@@ -86,7 +86,6 @@ private:
 
     struct ExportOptions m_options;  ///< 导出选项（库级别）
     TempFileManager m_tempManager;  ///< 临时文件管理器
-    std::atomic<bool> m_isExporting{false};  ///< 是否正在导出
     QThread* m_workerThread = nullptr;  ///< 工作线程指针
 };
 

--- a/src/services/export/Model3DExportStage.cpp
+++ b/src/services/export/Model3DExportStage.cpp
@@ -103,14 +103,14 @@ void Model3DExportStage::start(const QStringList& componentIds,
         }
     }
 
+    m_isExporting.store(true);
+
     // 调用基类的初始化方法（在路径准备完毕后再启动 worker，避免竞态）
     ExportTypeStage::start(componentIds, cachedData);
-
-    m_isExporting.store(true);
 }
 
 void Model3DExportStage::cancel() {
-    cancelWithTempRollback(m_isExporting, m_tempManager);
+    cancelWithTempRollback(m_tempManager);
 }
 
 bool Model3DExportStage::commitTempFile(const QString& tempPath, const QString& finalPath) {

--- a/src/services/export/Model3DExportStage.cpp
+++ b/src/services/export/Model3DExportStage.cpp
@@ -110,23 +110,7 @@ void Model3DExportStage::start(const QStringList& componentIds,
 }
 
 void Model3DExportStage::cancel() {
-    if (!m_isExporting.load()) {
-        return;
-    }
-
-    qDebug() << "Model3DExportStage: Cancelling...";
-
-    ExportTypeStage::cancel();
-
-    // 回滚所有临时文件
-    m_tempManager.rollbackAll();
-
-    m_isExporting.store(false);
-    if (!hasActiveWorkers()) {
-        m_isRunning.store(false);
-    }
-
-    qDebug() << "Model3DExportStage: Cancelled";
+    cancelWithTempRollback(m_isExporting, m_tempManager);
 }
 
 bool Model3DExportStage::commitTempFile(const QString& tempPath, const QString& finalPath) {

--- a/src/services/export/Model3DExportStage.h
+++ b/src/services/export/Model3DExportStage.h
@@ -96,7 +96,6 @@ private:
     struct ExportOptions m_options;  ///< 导出选项
     TempFileManager m_tempManager;  ///< 临时文件管理器
     QMap<QString, TempFilePaths> m_componentPaths;  ///< componentId -> temp/final paths
-    std::atomic<bool> m_isExporting{false};  ///< 是否正在导出
 };
 
 }  // namespace EasyKiConverter

--- a/src/services/export/PreviewImagesExportStage.cpp
+++ b/src/services/export/PreviewImagesExportStage.cpp
@@ -59,23 +59,7 @@ void PreviewImagesExportStage::start(const QStringList& componentIds,
 }
 
 void PreviewImagesExportStage::cancel() {
-    if (!m_isExporting.load()) {
-        return;
-    }
-
-    qDebug() << "PreviewImagesExportStage: Cancelling...";
-
-    ExportTypeStage::cancel();
-
-    // 回滚所有临时文件
-    m_tempManager.rollbackAll();
-
-    m_isExporting.store(false);
-    if (!hasActiveWorkers()) {
-        m_isRunning.store(false);
-    }
-
-    qDebug() << "PreviewImagesExportStage: Cancelled";
+    cancelWithTempRollback(m_isExporting, m_tempManager);
 }
 
 QMap<QString, QString> PreviewImagesExportStage::createTempPathsForComponent(const QString& componentId,

--- a/src/services/export/PreviewImagesExportStage.cpp
+++ b/src/services/export/PreviewImagesExportStage.cpp
@@ -52,14 +52,14 @@ void PreviewImagesExportStage::start(const QStringList& componentIds,
         m_outputDirs[componentId] = outputDir;
     }
 
+    m_isExporting.store(true);
+
     // 调用基类的初始化方法（设置状态，并处理空列表情况）
     ExportTypeStage::start(componentIds, cachedData);
-
-    m_isExporting.store(true);
 }
 
 void PreviewImagesExportStage::cancel() {
-    cancelWithTempRollback(m_isExporting, m_tempManager);
+    cancelWithTempRollback(m_tempManager);
 }
 
 QMap<QString, QString> PreviewImagesExportStage::createTempPathsForComponent(const QString& componentId,

--- a/src/services/export/PreviewImagesExportStage.h
+++ b/src/services/export/PreviewImagesExportStage.h
@@ -91,7 +91,6 @@ private:
     TempFileManager m_tempManager;  ///< 临时文件管理器
     QMap<QString, QMap<QString, QString>> m_componentTempPaths;  ///< componentId -> (filename -> tempPath)
     QMap<QString, QString> m_outputDirs;  ///< componentId -> outputDir
-    std::atomic<bool> m_isExporting{false};  ///< 是否正在导出
 };
 
 }  // namespace EasyKiConverter

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -21,10 +21,7 @@ SymbolExportStage::SymbolExportStage(QObject* parent)
 }
 
 SymbolExportStage::~SymbolExportStage() {
-    m_cancelled.store(true);
-    if (m_workerThread && m_workerThread->isRunning()) {
-        m_workerThread->wait();
-    }
+    waitForWorkerThread(m_workerThread, 30000);
 }
 
 void SymbolExportStage::start(const QStringList& componentIds,
@@ -80,23 +77,11 @@ void SymbolExportStage::cancel() {
 
     qDebug() << "SymbolExportStage: Cancelling...";
 
-    // 设置取消标志
-    m_cancelled.store(true);
-
-    // 等待工作线程协作式退出（最多等待 5 秒）。不能 terminate()：强杀线程可能中断 Qt/C++ 对象析构或持锁区。
-    if (m_workerThread && m_workerThread->isRunning()) {
-        qDebug() << "SymbolExportStage: Waiting for worker thread to finish...";
-        m_workerThread->quit();
-        if (!m_workerThread->wait(5000)) {
-            qWarning() << "SymbolExportStage: Thread did not finish in 5s, leaving it to finish asynchronously";
-            return;
-        }
-        m_workerThread = nullptr;
+    if (!waitForWorkerThread(m_workerThread)) {
+        return;  // 超时，交由析构函数再次等待
     }
 
-    // 清理临时文件
     m_tempManager.rollbackAll();
-
     m_isExporting.store(false);
     m_isRunning.store(false);
 

--- a/src/services/export/SymbolExportStage.h
+++ b/src/services/export/SymbolExportStage.h
@@ -84,7 +84,6 @@ private:
 
     struct ExportOptions m_options;  ///< 导出选项（库级别）
     TempFileManager m_tempManager;  ///< 临时文件管理器
-    std::atomic<bool> m_isExporting{false};  ///< 是否正在导出
     QThread* m_workerThread = nullptr;  ///< 工作线程指针
 };
 

--- a/src/ui/viewmodels/ExportSettingsViewModel.cpp
+++ b/src/ui/viewmodels/ExportSettingsViewModel.cpp
@@ -448,6 +448,23 @@ void ExportSettingsViewModel::setStatus(const QString& status) {
 }
 
 void ExportSettingsViewModel::loadFromConfig() {
+    // 保存旧值以便比较，仅在值变化时发射信号（避免不必要的 QML 绑定刷新）
+    const QString oldOutputPath = m_outputPath;
+    const QString oldLibName = m_libName;
+    const bool oldExportSymbol = m_exportSymbol;
+    const bool oldExportFootprint = m_exportFootprint;
+    const bool oldExportModel3D = m_exportModel3D;
+    const int oldExportModel3DFormat = m_exportModel3DFormat;
+    const int oldExportModel3DPathMode = m_exportModel3DPathMode;
+    const bool oldExportPreviewImages = m_exportPreviewImages;
+    const bool oldExportDatasheet = m_exportDatasheet;
+    const bool oldOverwriteExistingFiles = m_overwriteExistingFiles;
+    const bool oldWeakNetworkSupport = m_weakNetworkSupport;
+    const int oldExportMode = m_exportMode;
+    const bool oldDebugMode = m_debugMode;
+    const QString oldCacheDir = m_cacheDir;
+    const int oldDiskCacheLimitMB = m_diskCacheLimitMB;
+
     m_outputPath = m_configService->getOutputPath();
     m_libName = m_configService->getLibName();
     m_exportSymbol = m_configService->getExportSymbol();
@@ -478,26 +495,43 @@ void ExportSettingsViewModel::loadFromConfig() {
     m_footprintLibraryDescription.clear();
     m_footprintLibraryKeywords.clear();
 
-    emit outputPathChanged();
-    emit libNameChanged();
-    emit exportSymbolChanged();
-    emit exportFootprintChanged();
-    emit exportModel3DChanged();
-    emit exportModel3DFormatChanged();
-    emit exportModel3DPathModeChanged();
-    emit exportPreviewImagesChanged();
-    emit exportDatasheetChanged();
-    emit overwriteExistingFilesChanged();
-    emit weakNetworkSupportChanged();
-    emit exportModeChanged();
-    emit debugModeChanged();
+    // 仅在值变化时发射信号
+    if (m_outputPath != oldOutputPath)
+        emit outputPathChanged();
+    if (m_libName != oldLibName)
+        emit libNameChanged();
+    if (m_exportSymbol != oldExportSymbol)
+        emit exportSymbolChanged();
+    if (m_exportFootprint != oldExportFootprint)
+        emit exportFootprintChanged();
+    if (m_exportModel3D != oldExportModel3D)
+        emit exportModel3DChanged();
+    if (m_exportModel3DFormat != oldExportModel3DFormat)
+        emit exportModel3DFormatChanged();
+    if (m_exportModel3DPathMode != oldExportModel3DPathMode)
+        emit exportModel3DPathModeChanged();
+    if (m_exportPreviewImages != oldExportPreviewImages)
+        emit exportPreviewImagesChanged();
+    if (m_exportDatasheet != oldExportDatasheet)
+        emit exportDatasheetChanged();
+    if (m_overwriteExistingFiles != oldOverwriteExistingFiles)
+        emit overwriteExistingFilesChanged();
+    if (m_weakNetworkSupport != oldWeakNetworkSupport)
+        emit weakNetworkSupportChanged();
+    if (m_exportMode != oldExportMode)
+        emit exportModeChanged();
+    if (m_debugMode != oldDebugMode)
+        emit debugModeChanged();
+    // 非持久化字段始终发射（首次加载时需要通知 QML）
     emit exportSymbolDescriptionChanged();
     emit exportFootprintDescriptionChanged();
     emit symbolLibraryDescriptionChanged();
     emit footprintLibraryDescriptionChanged();
     emit footprintLibraryKeywordsChanged();
-    emit cacheDirChanged();
-    emit diskCacheLimitMBChanged();
+    if (m_cacheDir != oldCacheDir)
+        emit cacheDirChanged();
+    if (m_diskCacheLimitMB != oldDiskCacheLimitMB)
+        emit diskCacheLimitMBChanged();
 }
 
 void ExportSettingsViewModel::saveConfig() {
@@ -526,6 +560,7 @@ void ExportSettingsViewModel::resetConfig() {
     m_cacheDir = m_configService->getCacheDir();
     m_diskCacheLimitMB = m_configService->getDiskCacheLimitMB();
 
+    m_configService->beginBatchUpdate();
     m_configService->setOutputPath(m_outputPath);
     m_configService->setLibName(m_libName);
     m_configService->setExportSymbol(m_exportSymbol);
@@ -541,6 +576,7 @@ void ExportSettingsViewModel::resetConfig() {
     m_configService->setDebugMode(m_debugMode);
     m_configService->setCacheDir(m_cacheDir);
     m_configService->setDiskCacheLimitMB(m_diskCacheLimitMB);
+    m_configService->endBatchUpdate();
     ComponentCacheService::instance()->setCacheDir(m_cacheDir);
     ComponentCacheService::instance()->setDiskCacheLimit(m_diskCacheLimitMB);
 

--- a/tests/unit/test_export_type_stage.cpp
+++ b/tests/unit/test_export_type_stage.cpp
@@ -207,8 +207,7 @@ private slots:
                  "Footprint should contain relative WRL model path");
 
         const QString absolutePrefix = QDir::cleanPath(tempDir.path());
-        QVERIFY2(!content.contains(absolutePrefix),
-                 "Footprint should not contain absolute paths in relative mode");
+        QVERIFY2(!content.contains(absolutePrefix), "Footprint should not contain absolute paths in relative mode");
     }
 
 private:

--- a/tests/unit/test_export_type_stage.cpp
+++ b/tests/unit/test_export_type_stage.cpp
@@ -73,6 +73,22 @@ private slots:
         QCOMPARE(progress.failedCount, 0);
     }
 
+    void completedSignalSeesStageNotRunning() {
+        ImmediateSuccessStage stage;
+        bool wasRunningWhenCompleted = true;
+        connect(&stage, &ExportTypeStage::completed, &stage, [&stage, &wasRunningWhenCompleted]() {
+            wasRunningWhenCompleted = stage.isRunning();
+        });
+
+        QMap<QString, QSharedPointer<ComponentData>> cachedData;
+        cachedData[QStringLiteral("C1001")] = QSharedPointer<ComponentData>::create();
+
+        stage.start({QStringLiteral("C1001")}, cachedData);
+
+        QVERIFY(!wasRunningWhenCompleted);
+        QVERIFY(!stage.isRunning());
+    }
+
     void cancelledStageStaysRunningUntilActiveWorkersDrain() {
         DeferredStage stage;
         QSignalSpy completedSpy(&stage, &ExportTypeStage::completed);


### PR DESCRIPTION
描述：

  ## 改动目的

  本次改动涵盖多个功能增强和重构：新增可配置的磁盘缓存目录和大小限制（GUI + CLI）、3D
  模型路径模式选择（相对/绝对）、导出阶段取消/完成状态管理的统一重构、CLI
  命令行界面的国际化支持，以及深色主题任务栏图标适配。

  ## 主要变更

  ### 缓存配置系统
  - **ConfigService**: 新增 `cacheDir`、`diskCacheLimitMB`、`exportMode`、`exportModel3DPathMode`
  等配置项的持久化，支持批量更新（`beginBatchUpdate`/`endBatchUpdate`）减少重复写盘
  - **ComponentCacheService**:
  新增磁盘缓存自动清理机制（`enforceDiskCacheLimit`），支持缓存目录迁移（`migrateCacheDirectory`），`CachePruner`
  支持文件级 LRU 淘汰
  - **GUI**: `ExportSettingsCard.qml` 新增缓存配置区块（缓存目录选择、磁盘缓存上限输入）
  - **CLI**: 新增 `--cache-dir` 和 `--cache-size-mb` 命令行参数

  ### 3D 模型路径模式
  - **ExportOptions**: 新增 `exportModel3DPathMode` 字段（`MODEL_3D_PATH_RELATIVE` / `MODEL_3D_PATH_ABSOLUTE`）
  - **ExporterFootprint**: 封装库导出支持绝对路径模式，新增 `buildModel3DPath()` 辅助方法
  - **GUI**: `ExportSettingsCard.qml` 新增相对/绝对路径切换按钮组

  ### 导出阶段状态管理重构
  - **ExportTypeStage**: 提取 `cancelWithTempRollback()` 和 `waitForWorkerThread()`
  公共方法，统一子类取消逻辑；`completed` 信号自动清除 `m_isExporting` 标志；修复取消时与 `completeItemProgress`
  的竞态条件
  - **DatasheetExportStage / PreviewImagesExportStage / Model3DExportStage**: 简化 `cancel()` 为单行调用
  `cancelWithTempRollback()`
  - **SymbolExportStage / FootprintExportStage**: 析构函数改用 `waitForWorkerThread(30000)` 替代 `cancel()`，避免
  `terminate()` 强制终止
  - **ParallelExportService**: 新增 `discardExportStage()` 统一 stage 生命周期管理，`onExportTypeCompleted()`
  减小锁粒度

  ### CLI 国际化
  - **CommandLineParser**: 验证错误消息和帮助文本改用 `QCoreApplication::translate()` 支持多语言
  - **BatchConverter / BomConverter / ComponentConverter / CliConverter**: 用户可见消息全部使用翻译函数
  - **LanguageManager**: `setLanguage()` 新增 `force` 参数，CLI 模式下命令行语言参数优先于配置文件

  ### 深色主题图标
  - **CMakeLists.txt**: 添加深色主题图标资源（`app_icon_dark.*`）和多分辨率 hicolor 图标（16x16 ~ 512x512）
  - **main.cpp**: 重构图标加载逻辑为 `themedTaskbarIconPaths()` 和
  `applyTaskbarIcon()`，支持深色/浅色主题自动切换，覆盖 AppImage、QRC、开发目录、系统图标等多种路径
