### PR TITLE
feat: 完善测试基础设施与导出GUI自动化覆盖

### DIFF
--- a/src/ui/qml/components/ExportButtonsSection.qml
+++ b/src/ui/qml/components/ExportButtonsSection.qml
@@ -14,6 +14,7 @@ ColumnLayout {
     // 错误提示对话框
     Dialog {
         id: errorDialog
+        objectName: "exportErrorDialog"
         parent: Overlay.overlay
         modal: true
         title: qsTranslate("MainWindow", "错误")
@@ -41,6 +42,7 @@ ColumnLayout {
     }
     // 打开导出目录按钮（始终显示，只要导出已完成）
     ModernButton {
+        objectName: "openExportFolderButton"
         Layout.fillWidth: true
         Layout.topMargin: AppStyle.spacing.sm
         text: qsTranslate("MainWindow", "打开导出目录")
@@ -65,6 +67,7 @@ ColumnLayout {
         // "开始转换"或"重试"按钮
         ModernButton {
             id: exportButton
+            objectName: "startExportButton"
             Layout.preferredHeight: 56
             Layout.fillWidth: true
             // 根据是否有失败项来决定按钮文本
@@ -132,6 +135,7 @@ ColumnLayout {
         // "停止转换"按钮
         ModernButton {
             id: stopButton
+            objectName: "stopExportButton"
             Layout.preferredHeight: 56
             Layout.preferredWidth: 180
             // 仅在导出进行时可见

--- a/src/ui/qml/components/ExportButtonsSection.qml
+++ b/src/ui/qml/components/ExportButtonsSection.qml
@@ -10,6 +10,7 @@ ColumnLayout {
     property var exportProgressController
     property var exportSettingsController
     property var componentListController
+    property alias exportErrorDialog: errorDialog
     spacing: AppStyle.spacing.md
     // 错误提示对话框
     Dialog {

--- a/src/ui/qml/components/ExportProgressCard.qml
+++ b/src/ui/qml/components/ExportProgressCard.qml
@@ -137,6 +137,7 @@ Card {
 
             // 总进度文字 (放在右侧)
             Text {
+                objectName: "exportProgressPercentLabel"
                 text: Math.round(exportProgressCard.exportProgressController ? exportProgressCard.exportProgressController.progress : 0) + "%"
                 font.pixelSize: AppStyle.fontSizes.sm
                 font.bold: true

--- a/src/ui/qml/components/ExportProgressCard.qml
+++ b/src/ui/qml/components/ExportProgressCard.qml
@@ -5,6 +5,7 @@ import EasyKiconverter_Cpp_Version.src.ui.qml.styles 1.0
 
 Card {
     id: exportProgressCard
+    objectName: "exportProgressCard"
     // 外部依赖
     property var exportProgressController
     title: qsTranslate("MainWindow", "转换进度")
@@ -82,6 +83,7 @@ Card {
             // 自定义多色进度条容器
             Rectangle {
                 id: progressBar
+                objectName: "exportProgressBar"
                 Layout.fillWidth: true
                 height: 12
                 color: AppStyle.colors.border
@@ -145,6 +147,7 @@ Card {
 
         Text {
             id: statusLabel
+            objectName: "exportStatusLabel"
             Layout.fillWidth: true
             text: exportProgressCard.exportProgressController ? exportProgressCard.exportProgressController.status : ""
             font.pixelSize: AppStyle.fontSizes.sm

--- a/src/ui/qml/components/ExportResultsCard.qml
+++ b/src/ui/qml/components/ExportResultsCard.qml
@@ -6,6 +6,7 @@ import EasyKiconverter_Cpp_Version.src.ui.qml.styles 1.0
 
 Loader {
     id: resultsLoader
+    objectName: "exportResultsCard"
     // 外部依赖
     property var exportProgressController
     active: resultsLoader.exportProgressController ? (resultsLoader.exportProgressController.isExporting || resultsLoader.exportProgressController.resultsList.length > 0) : false
@@ -39,6 +40,7 @@ Loader {
 
             Rectangle {
                 id: filterSegmentedControl
+                objectName: "exportResultsFilterSegmentedControl"
                 Layout.preferredWidth: 560
                 Layout.preferredHeight: 40
                 Layout.alignment: Qt.AlignLeft
@@ -99,6 +101,7 @@ Loader {
                     // 全部
 
                     Item {
+                        objectName: "exportResultsFilterAllButton"
                         width: (filterSegmentedControl.width - 8) / 4
                         height: parent.height
                         Text {
@@ -124,6 +127,7 @@ Loader {
                     // 导出中
 
                     Item {
+                        objectName: "exportResultsFilterExportingButton"
                         width: (filterSegmentedControl.width - 8) / 4
                         height: parent.height
                         enabled: resultsLoader.exportProgressController.filteredPendingCount > 0
@@ -151,6 +155,7 @@ Loader {
                     // 成功
 
                     Item {
+                        objectName: "exportResultsFilterSuccessButton"
                         width: (filterSegmentedControl.width - 8) / 4
                         height: parent.height
                         enabled: resultsLoader.exportProgressController.successCount > 0
@@ -178,6 +183,7 @@ Loader {
                     // 失败
 
                     Item {
+                        objectName: "exportResultsFilterFailedButton"
                         width: (filterSegmentedControl.width - 8) / 4
                         height: parent.height
                         enabled: resultsLoader.exportProgressController.failureCount > 0
@@ -207,6 +213,7 @@ Loader {
             // 结果列表（使用 GridView 实现五列显示）
             GridView {
                 id: resultsList
+                objectName: "exportResultsList"
                 Layout.fillWidth: true
                 Layout.minimumHeight: 200
                 Layout.preferredHeight: visible ? 500 : 0
@@ -245,6 +252,7 @@ Loader {
                 ]
                 filterOnGroup: "display"
                 delegate: ResultListItem {
+                    objectName: "exportResultItem_" + (modelData.componentId || "")
                     width: resultsList.cellWidth - AppStyle.spacing.md
                     anchors.horizontalCenter: parent ? undefined : undefined
                     componentId: modelData.componentId || ""

--- a/src/ui/qml/components/ResultListItem.qml
+++ b/src/ui/qml/components/ResultListItem.qml
@@ -285,6 +285,7 @@ Rectangle {
 
         Item {
             id: retryButton
+            objectName: "retryResultButton"
             visible: status === "failed"
             Layout.preferredWidth: 28
             Layout.preferredHeight: 28
@@ -308,6 +309,7 @@ Rectangle {
 
         Item {
             id: deleteButton
+            objectName: "deleteResultButton"
             visible: status === "failed"
             Layout.preferredWidth: 28
             Layout.preferredHeight: 28

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,6 +29,18 @@
 - `fixtures/`: EasyEDA 响应、CAD JSON、BOM 文件等输入样例。
 - `golden/`: KiCad 输出、库表和报告等期望结果，用于稳定的 golden-file 对比。
 
+## 已自动化的导出 GUI 回归流程
+
+以下原本需要手动点选的导出相关流程已经纳入自动化：
+
+- 导出按钮状态：无元器件、未选择导出类型、导出中禁用、停止导出按钮显示。
+- 导出参数传递：元器件 ID、输出目录、库名、符号/封装/3D、预览图、数据手册、覆盖、更新模式、调试模式和库描述字段。
+- 导出进度展示：空闲隐藏、导出中显示、百分比取整、状态文案联动。
+- 导出结果列表：结果列表显示、全部/导出中/成功/失败筛选、失败项重试和删除回调。
+- 关闭窗口流程：导出中关闭弹出强制退出确认，空闲关闭弹出退出选项，已有对话框时不重复弹出，`Esc` 关闭/打开正确提示。
+- 并行导出管线：fixture 数据成功导出、缺失预加载数据失败、导出中取消。
+- ViewModel 状态：取消时 pending/in_progress 项转为失败，批量重试只重置失败项。
+
 ## 如何运行测试
 
 推荐使用项目构建脚本：
@@ -60,18 +72,40 @@ cd build
 ctest --output-on-failure
 ```
 
+也可以按标签分层运行：
+
+```bash
+cd build
+ctest -L fast --output-on-failure         # 单元测试 + QML UI 快速回归
+ctest -L export-flow --output-on-failure  # 导出 GUI/集成流程
+ctest -L integration --output-on-failure  # 跨模块集成测试
+ctest -L slow --output-on-failure         # benchmark 等较慢测试
+```
+
 在 CI、WSL 或无桌面环境中运行 Qt/QML 测试时，需要设置：
 
 ```bash
 export QT_QPA_PLATFORM=offscreen
+export QT_QPA_PLATFORMTHEME=none
 ```
 
 ### 3. 手动测试
 
-窗口状态、桌面映射、任务栏可见性这类场景目前不适合完全依赖自动化测试。执行相关回归时，请参考：
+窗口状态、系统托盘、真实文件管理器打开、桌面映射、任务栏可见性这类场景目前不适合完全依赖 headless 自动化测试。执行相关回归时，请参考：
 
 - [窗口状态手动测试清单](./manual/WINDOW_STATE_MANUAL_CHECKLIST.md)
 - [CLI 模式手动测试手册](./manual/CLI_TEST_MANUAL.md)
+
+## CI 分层建议
+
+- PR 快速校验：`ctest -L fast --output-on-failure`，覆盖大部分单元和 QML 交互回归。
+- 导出相关改动：额外运行 `ctest -L export-flow --output-on-failure`。
+- 发布前/夜间：运行完整 `ctest --output-on-failure`，包含 benchmark 和全量集成测试。
+- 所有 headless UI/CI 场景都应设置 `QT_QPA_PLATFORM=offscreen` 和 `QT_QPA_PLATFORMTHEME=none`，避免 Qt 在无显示环境中加载 GTK 平台主题。
+
+## Golden 文件策略
+
+KiCad 输出格式、符号/封装结构和 3D 模型引用使用 `tests/golden/kicad/` 下的期望文件做稳定对比。新增导出格式或修复 KiCad 兼容性问题时，优先补 golden 测试；只有确认输出格式变更符合预期后，才更新 golden 文件。
 
 ## 测试规范
 

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -19,5 +19,5 @@ add_test(NAME test_benchmark_core COMMAND test_benchmark_core)
 
 set_tests_properties(test_benchmark_core
     PROPERTIES
-        LABELS "benchmark"
+        LABELS "benchmark;slow"
 )

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -5,7 +5,17 @@ add_executable(test_fixture_to_kicad_export
     ../common/TestPaths.hpp
 )
 
+add_executable(test_parallel_export_cancellation
+    test_parallel_export_cancellation.cpp
+    ../common/TestPaths.hpp
+)
+
 target_link_libraries(test_fixture_to_kicad_export PRIVATE
+    Qt6::Test
+    EasyKiConverterLib
+)
+
+target_link_libraries(test_parallel_export_cancellation PRIVATE
     Qt6::Test
     EasyKiConverterLib
 )
@@ -15,9 +25,20 @@ target_include_directories(test_fixture_to_kicad_export PRIVATE
     ${CMAKE_SOURCE_DIR}
 )
 
+target_include_directories(test_parallel_export_cancellation PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}
+)
+
 add_test(NAME test_fixture_to_kicad_export COMMAND test_fixture_to_kicad_export)
+add_test(NAME test_parallel_export_cancellation COMMAND test_parallel_export_cancellation)
 
 set_tests_properties(test_fixture_to_kicad_export
+    PROPERTIES
+        LABELS "integration"
+)
+
+set_tests_properties(test_parallel_export_cancellation
     PROPERTIES
         LABELS "integration"
 )

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -35,10 +35,10 @@ add_test(NAME test_parallel_export_cancellation COMMAND test_parallel_export_can
 
 set_tests_properties(test_fixture_to_kicad_export
     PROPERTIES
-        LABELS "integration"
+        LABELS "integration;export-flow"
 )
 
 set_tests_properties(test_parallel_export_cancellation
     PROPERTIES
-        LABELS "integration"
+        LABELS "integration;export-flow"
 )

--- a/tests/integration/test_parallel_export_cancellation.cpp
+++ b/tests/integration/test_parallel_export_cancellation.cpp
@@ -4,6 +4,7 @@
 #include "services/export/ParallelExportService.h"
 #include "tests/common/TestPaths.hpp"
 
+#include <QDir>
 #include <QFileInfo>
 #include <QSignalSpy>
 #include <QTemporaryDir>
@@ -25,21 +26,106 @@ private slots:
         qRegisterMetaType<QList<ComponentData>>();
     }
 
+    void testFixtureDataCompletesExportPipeline() {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        ParallelExportService service;
+        const QString libName = QStringLiteral("FixturePipeline");
+        service.setOptions(makeOptions(tempDir.path(), libName));
+        service.setOutputPath(tempDir.path());
+
+        const QStringList componentIds = makeComponentIds(3);
+        const QList<ComponentData> componentData = makeFixtureComponents(componentIds);
+
+        service.startPreload(componentIds);
+
+        QSignalSpy preloadSpy(&service, &ParallelExportService::preloadCompleted);
+        const bool preloadInjected = QMetaObject::invokeMethod(
+            &service, "onAllComponentDataCollected", Qt::DirectConnection, Q_ARG(QList<ComponentData>, componentData));
+        QVERIFY(preloadInjected);
+        QCOMPARE(preloadSpy.count(), 1);
+
+        QSignalSpy completedSpy(&service, &ParallelExportService::completed);
+        QSignalSpy cancelledSpy(&service, &ParallelExportService::cancelled);
+        QSignalSpy failedSpy(&service, &ParallelExportService::failed);
+
+        service.startExport();
+
+        QVERIFY2(completedSpy.wait(3000), "Parallel export should complete with fixture data");
+        QCOMPARE(completedSpy.count(), 1);
+        QCOMPARE(completedSpy.at(0).at(0).toInt(), componentIds.size());
+        QCOMPARE(completedSpy.at(0).at(1).toInt(), 0);
+        QCOMPARE(cancelledSpy.count(), 0);
+        QCOMPARE(failedSpy.count(), 0);
+        QCOMPARE(service.getProgress().currentStage, ExportOverallProgress::Stage::Completed);
+
+        QString error;
+        const QString symbolLibraryPath = tempDir.filePath(libName + QStringLiteral(".kicad_sym"));
+        QVERIFY2(QFileInfo::exists(symbolLibraryPath), qPrintable(symbolLibraryPath));
+        const QString symbolContent = TestPaths::readText(symbolLibraryPath, &error);
+        QVERIFY2(error.isEmpty(), qPrintable(error));
+        QVERIFY(symbolContent.contains(QStringLiteral("(kicad_symbol_lib")));
+        QVERIFY(symbolContent.contains(QStringLiteral("(symbol \"CANCEL_SYM_0\"")));
+        QVERIFY(symbolContent.contains(QStringLiteral("\"FixturePipeline:CANCEL_FP_0\"")));
+
+        const QString prettyDirPath = tempDir.filePath(libName + QStringLiteral(".pretty"));
+        QVERIFY2(QDir(prettyDirPath).exists(), qPrintable(prettyDirPath));
+        const QString footprintPath = QDir(prettyDirPath).filePath(QStringLiteral("CANCEL_FP_0.kicad_mod"));
+        QVERIFY2(QFileInfo::exists(footprintPath), qPrintable(footprintPath));
+        const QString footprintContent = TestPaths::readText(footprintPath, &error);
+        QVERIFY2(error.isEmpty(), qPrintable(error));
+        QVERIFY(footprintContent.contains(QStringLiteral("(footprint easykiconverter:CANCEL_FP_0")));
+        QVERIFY(footprintContent.contains(QStringLiteral("(pad 1 smd rect")));
+    }
+
+    void testMissingPreloadedDataFailsExportPipeline() {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        ParallelExportService service;
+        const QString libName = QStringLiteral("MissingDataPipeline");
+        service.setOptions(makeOptions(tempDir.path(), libName));
+        service.setOutputPath(tempDir.path());
+
+        const QStringList componentIds = makeComponentIds(2);
+        const QList<ComponentData> invalidComponentData = makeInvalidComponents(componentIds);
+
+        service.startPreload(componentIds);
+
+        QSignalSpy preloadSpy(&service, &ParallelExportService::preloadCompleted);
+        const bool preloadInjected = QMetaObject::invokeMethod(&service,
+                                                               "onAllComponentDataCollected",
+                                                               Qt::DirectConnection,
+                                                               Q_ARG(QList<ComponentData>, invalidComponentData));
+        QVERIFY(preloadInjected);
+        QCOMPARE(preloadSpy.count(), 1);
+        QCOMPARE(preloadSpy.at(0).at(0).toInt(), 0);
+        QCOMPARE(preloadSpy.at(0).at(1).toInt(), componentIds.size());
+        QVERIFY(service.cachedData().isEmpty());
+
+        QSignalSpy completedSpy(&service, &ParallelExportService::completed);
+        QSignalSpy cancelledSpy(&service, &ParallelExportService::cancelled);
+        QSignalSpy failedSpy(&service, &ParallelExportService::failed);
+
+        service.startExport();
+
+        QCOMPARE(failedSpy.count(), 1);
+        QCOMPARE(failedSpy.at(0).at(0).toString(), QStringLiteral("No exportable components after preload"));
+        QCOMPARE(completedSpy.count(), 0);
+        QCOMPARE(cancelledSpy.count(), 0);
+        QCOMPARE(service.getProgress().currentStage, ExportOverallProgress::Stage::Failed);
+        QVERIFY(!service.isRunning());
+        QVERIFY(!QFileInfo::exists(tempDir.filePath(libName + QStringLiteral(".kicad_sym"))));
+        QVERIFY(!QDir(tempDir.filePath(libName + QStringLiteral(".pretty"))).exists());
+    }
+
     void testCancellationStopsRunningExportPipeline() {
         QTemporaryDir tempDir;
         QVERIFY(tempDir.isValid());
 
         ParallelExportService service;
-        ExportOptions options;
-        options.outputPath = tempDir.path();
-        options.libName = QStringLiteral("CancelledPipeline");
-        options.exportSymbol = true;
-        options.exportFootprint = true;
-        options.exportModel3D = false;
-        options.exportPreviewImages = false;
-        options.exportDatasheet = false;
-        options.overwriteExistingFiles = true;
-        service.setOptions(options);
+        service.setOptions(makeOptions(tempDir.path(), QStringLiteral("CancelledPipeline")));
         service.setOutputPath(tempDir.path());
 
         const QStringList componentIds = makeComponentIds(80);
@@ -75,6 +161,19 @@ private slots:
     }
 
 private:
+    static ExportOptions makeOptions(const QString& outputPath, const QString& libName) {
+        ExportOptions options;
+        options.outputPath = outputPath;
+        options.libName = libName;
+        options.exportSymbol = true;
+        options.exportFootprint = true;
+        options.exportModel3D = false;
+        options.exportPreviewImages = false;
+        options.exportDatasheet = false;
+        options.overwriteExistingFiles = true;
+        return options;
+    }
+
     static QStringList makeComponentIds(int count) {
         QStringList ids;
         ids.reserve(count);
@@ -82,6 +181,20 @@ private:
             ids.append(QStringLiteral("C9%1").arg(10000 + i));
         }
         return ids;
+    }
+
+    static QList<ComponentData> makeInvalidComponents(const QStringList& componentIds) {
+        QList<ComponentData> components;
+        components.reserve(componentIds.size());
+
+        for (const QString& componentId : componentIds) {
+            ComponentData component;
+            component.setLcscId(componentId);
+            component.setName(QStringLiteral("Invalid Fixture %1").arg(componentId));
+            components.append(component);
+        }
+
+        return components;
     }
 
     static QList<ComponentData> makeFixtureComponents(const QStringList& componentIds) {

--- a/tests/integration/test_parallel_export_cancellation.cpp
+++ b/tests/integration/test_parallel_export_cancellation.cpp
@@ -1,0 +1,141 @@
+#include "core/easyeda/EasyedaFootprintImporter.h"
+#include "core/easyeda/EasyedaSymbolImporter.h"
+#include "models/ComponentData.h"
+#include "services/export/ParallelExportService.h"
+#include "tests/common/TestPaths.hpp"
+
+#include <QFileInfo>
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTest>
+
+using namespace EasyKiConverter;
+using namespace EasyKiConverter::Test;
+
+Q_DECLARE_METATYPE(QList<EasyKiConverter::ComponentData>)
+
+class TestParallelExportCancellation : public QObject {
+    Q_OBJECT
+
+private slots:
+
+    void initTestCase() {
+        qRegisterMetaType<ExportOverallProgress>();
+        qRegisterMetaType<ExportItemStatus>();
+        qRegisterMetaType<QList<ComponentData>>();
+    }
+
+    void testCancellationStopsRunningExportPipeline() {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        ParallelExportService service;
+        ExportOptions options;
+        options.outputPath = tempDir.path();
+        options.libName = QStringLiteral("CancelledPipeline");
+        options.exportSymbol = true;
+        options.exportFootprint = true;
+        options.exportModel3D = false;
+        options.exportPreviewImages = false;
+        options.exportDatasheet = false;
+        options.overwriteExistingFiles = true;
+        service.setOptions(options);
+        service.setOutputPath(tempDir.path());
+
+        const QStringList componentIds = makeComponentIds(80);
+        const QList<ComponentData> componentData = makeFixtureComponents(componentIds);
+        QCOMPARE(componentData.size(), componentIds.size());
+
+        service.startPreload(componentIds);
+
+        QSignalSpy preloadSpy(&service, &ParallelExportService::preloadCompleted);
+        const bool preloadInjected = QMetaObject::invokeMethod(
+            &service, "onAllComponentDataCollected", Qt::DirectConnection, Q_ARG(QList<ComponentData>, componentData));
+        QVERIFY(preloadInjected);
+        QCOMPARE(preloadSpy.count(), 1);
+        QCOMPARE(preloadSpy.at(0).at(0).toInt(), componentIds.size());
+        QCOMPARE(preloadSpy.at(0).at(1).toInt(), 0);
+        QCOMPARE(service.cachedData().size(), componentIds.size());
+
+        QSignalSpy cancelledSpy(&service, &ParallelExportService::cancelled);
+        QSignalSpy completedSpy(&service, &ParallelExportService::completed);
+        QSignalSpy failedSpy(&service, &ParallelExportService::failed);
+
+        service.startExport();
+        service.cancelExport();
+
+        QCOMPARE(cancelledSpy.count(), 1);
+        QCOMPARE(failedSpy.count(), 0);
+        QCOMPARE(service.getProgress().currentStage, ExportOverallProgress::Stage::Cancelled);
+        QVERIFY(!service.isRunning());
+
+        QTest::qWait(100);
+        QCOMPARE(completedSpy.count(), 0);
+        QCOMPARE(service.getProgress().currentStage, ExportOverallProgress::Stage::Cancelled);
+    }
+
+private:
+    static QStringList makeComponentIds(int count) {
+        QStringList ids;
+        ids.reserve(count);
+        for (int i = 0; i < count; ++i) {
+            ids.append(QStringLiteral("C9%1").arg(10000 + i));
+        }
+        return ids;
+    }
+
+    static QList<ComponentData> makeFixtureComponents(const QStringList& componentIds) {
+        QString error;
+        const QJsonObject symbolFixture =
+            TestPaths::readJsonObject(TestPaths::fixturePath(QStringLiteral("easyeda/symbol_basic.json")), &error);
+        if (!error.isEmpty()) {
+            qFatal("Unable to read symbol fixture: %s", qPrintable(error));
+        }
+
+        const QJsonObject footprintFixture =
+            TestPaths::readJsonObject(TestPaths::fixturePath(QStringLiteral("easyeda/footprint_basic.json")), &error);
+        if (!error.isEmpty()) {
+            qFatal("Unable to read footprint fixture: %s", qPrintable(error));
+        }
+
+        EasyedaSymbolImporter symbolImporter;
+        EasyedaFootprintImporter footprintImporter;
+        const QSharedPointer<SymbolData> baseSymbol = symbolImporter.importSymbolData(symbolFixture);
+        const QSharedPointer<FootprintData> baseFootprint = footprintImporter.importFootprintData(footprintFixture);
+        if (!baseSymbol || !baseFootprint) {
+            qFatal("Unable to import EasyEDA fixtures");
+        }
+
+        QList<ComponentData> components;
+        components.reserve(componentIds.size());
+
+        for (int i = 0; i < componentIds.size(); ++i) {
+            const QString& componentId = componentIds.at(i);
+            const QString suffix = QString::number(i);
+
+            auto symbol = QSharedPointer<SymbolData>::create(*baseSymbol);
+            SymbolInfo symbolInfo = symbol->info();
+            symbolInfo.name = QStringLiteral("CANCEL_SYM_%1").arg(suffix);
+            symbolInfo.package = QStringLiteral("CANCEL_FP_%1").arg(suffix);
+            symbolInfo.lcscId = componentId;
+            symbol->setInfo(symbolInfo);
+
+            auto footprint = QSharedPointer<FootprintData>::create(*baseFootprint);
+            FootprintInfo footprintInfo = footprint->info();
+            footprintInfo.name = QStringLiteral("CANCEL_FP_%1").arg(suffix);
+            footprint->setInfo(footprintInfo);
+
+            ComponentData component;
+            component.setLcscId(componentId);
+            component.setName(QStringLiteral("Cancellation Fixture %1").arg(suffix));
+            component.setSymbolData(symbol);
+            component.setFootprintData(footprint);
+            components.append(component);
+        }
+
+        return components;
+    }
+};
+
+QTEST_GUILESS_MAIN(TestParallelExportCancellation)
+#include "test_parallel_export_cancellation.moc"

--- a/tests/integration/test_parallel_export_cancellation.cpp
+++ b/tests/integration/test_parallel_export_cancellation.cpp
@@ -146,8 +146,10 @@ private slots:
         QSignalSpy cancelledSpy(&service, &ParallelExportService::cancelled);
         QSignalSpy completedSpy(&service, &ParallelExportService::completed);
         QSignalSpy failedSpy(&service, &ParallelExportService::failed);
+        QSignalSpy itemStatusSpy(&service, &ParallelExportService::itemStatusChanged);
 
         service.startExport();
+        QVERIFY2(itemStatusSpy.wait(3000), "Export should start processing at least one item before cancellation");
         service.cancelExport();
 
         QCOMPARE(cancelledSpy.count(), 1);

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -35,6 +35,7 @@ set(QML_FILES
     ${CMAKE_SOURCE_DIR}/src/ui/qml/styles/ResponsiveHelper.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_BasicComponents.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportSettingsCard.qml
+    ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportFlow.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_Card.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ControllerBinding.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ThemeBinding.qml

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -37,6 +37,7 @@ set(QML_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportSettingsCard.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportFlow.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportProgressCard.qml
+    ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportResultsCard.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_Card.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ControllerBinding.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ThemeBinding.qml

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -39,6 +39,7 @@ set(QML_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportProgressCard.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportResultsCard.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_WindowControllerClosing.qml
+    ${CMAKE_CURRENT_SOURCE_DIR}/tst_MainDialogBindings.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_Card.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ControllerBinding.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ThemeBinding.qml
@@ -96,6 +97,6 @@ add_test(NAME test_ui COMMAND test_ui)
 
 set_tests_properties(test_ui
     PROPERTIES
-        LABELS "ui"
-        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+        LABELS "ui;fast;export-flow"
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen;QT_QPA_PLATFORMTHEME=none"
 )

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -36,6 +36,7 @@ set(QML_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_BasicComponents.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportSettingsCard.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportFlow.qml
+    ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportProgressCard.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_Card.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ControllerBinding.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ThemeBinding.qml

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -38,6 +38,7 @@ set(QML_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportFlow.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportProgressCard.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ExportResultsCard.qml
+    ${CMAKE_CURRENT_SOURCE_DIR}/tst_WindowControllerClosing.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_Card.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ControllerBinding.qml
     ${CMAKE_CURRENT_SOURCE_DIR}/tst_ThemeBinding.qml

--- a/tests/ui/main.cpp
+++ b/tests/ui/main.cpp
@@ -1,8 +1,37 @@
 
+#include <QObject>
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QQuickStyle>
+#include <QString>
 #include <QtQuickTest>
+
+class FakeLanguageManager : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString currentLanguage READ currentLanguage WRITE setLanguage NOTIFY languageChanged)
+
+public:
+    explicit FakeLanguageManager(QObject* parent = nullptr) : QObject(parent) {}
+
+    QString currentLanguage() const {
+        return m_currentLanguage;
+    }
+
+    Q_INVOKABLE void setLanguage(const QString& language) {
+        if (m_currentLanguage == language) {
+            return;
+        }
+
+        m_currentLanguage = language;
+        emit languageChanged(m_currentLanguage);
+    }
+
+signals:
+    void languageChanged(const QString& language);
+
+private:
+    QString m_currentLanguage{QStringLiteral("zh_CN")};
+};
 
 class Setup : public QObject {
     Q_OBJECT
@@ -16,6 +45,7 @@ public slots:
 
     void qmlEngineAvailable(QQmlEngine* engine) {
         engine->addImportPath("qrc:/qt/qml");
+        engine->rootContext()->setContextProperty("LanguageManager", new FakeLanguageManager(engine));
 
         // 注册 AppStyle 单例类型 (必须手动注册以匹配 ModernButton.qml 中的导入 URI)
         qmlRegisterSingletonType(QUrl("qrc:/qt/qml/EasyKiconverter_Cpp_Version/src/ui/qml/styles/AppStyle.qml"),

--- a/tests/ui/tst_ExportFlow.qml
+++ b/tests/ui/tst_ExportFlow.qml
@@ -25,9 +25,19 @@ TestCase {
         property bool lastExportSymbol: false
         property bool lastExportFootprint: false
         property bool lastExportModel3D: false
+        property int lastExportModel3DFormat: -1
+        property int lastExportModel3DPathMode: -1
+        property bool lastExportPreviewImages: false
+        property bool lastExportDatasheet: false
+        property bool lastOverwriteExistingFiles: false
+        property bool lastUpdateMode: false
+        property bool lastDebugMode: false
+        property string lastSymbolLibraryDescription: ""
+        property string lastFootprintLibraryDescription: ""
+        property string lastFootprintLibraryKeywords: ""
         property bool openLastExportedFolderResult: true
 
-        function startExport(componentIds, outputPath, libName, exportSymbol, exportFootprint, exportModel3D) {
+        function startExport(componentIds, outputPath, libName, exportSymbol, exportFootprint, exportModel3D, exportModel3DFormat, exportModel3DPathMode, exportPreviewImages, exportDatasheet, overwriteExistingFiles, updateMode, debugMode, symbolLibraryDescription, footprintLibraryDescription, footprintLibraryKeywords) {
             startExportCallCount += 1
             lastComponentIds = componentIds
             lastOutputPath = outputPath
@@ -35,6 +45,16 @@ TestCase {
             lastExportSymbol = exportSymbol
             lastExportFootprint = exportFootprint
             lastExportModel3D = exportModel3D
+            lastExportModel3DFormat = exportModel3DFormat
+            lastExportModel3DPathMode = exportModel3DPathMode
+            lastExportPreviewImages = exportPreviewImages
+            lastExportDatasheet = exportDatasheet
+            lastOverwriteExistingFiles = overwriteExistingFiles
+            lastUpdateMode = updateMode
+            lastDebugMode = debugMode
+            lastSymbolLibraryDescription = symbolLibraryDescription
+            lastFootprintLibraryDescription = footprintLibraryDescription
+            lastFootprintLibraryKeywords = footprintLibraryKeywords
         }
 
         function cancelExport() {
@@ -104,11 +124,31 @@ TestCase {
         progressController.lastExportSymbol = false
         progressController.lastExportFootprint = false
         progressController.lastExportModel3D = false
+        progressController.lastExportModel3DFormat = -1
+        progressController.lastExportModel3DPathMode = -1
+        progressController.lastExportPreviewImages = false
+        progressController.lastExportDatasheet = false
+        progressController.lastOverwriteExistingFiles = false
+        progressController.lastUpdateMode = false
+        progressController.lastDebugMode = false
+        progressController.lastSymbolLibraryDescription = ""
+        progressController.lastFootprintLibraryDescription = ""
+        progressController.lastFootprintLibraryKeywords = ""
         progressController.openLastExportedFolderResult = true
 
         settingsController.exportSymbol = true
         settingsController.exportFootprint = true
         settingsController.exportModel3D = false
+        settingsController.exportModel3DFormat = 3
+        settingsController.exportModel3DPathMode = 0
+        settingsController.exportPreviewImages = false
+        settingsController.exportDatasheet = false
+        settingsController.overwriteExistingFiles = false
+        settingsController.exportMode = 0
+        settingsController.debugMode = false
+        settingsController.symbolLibraryDescription = ""
+        settingsController.footprintLibraryDescription = ""
+        settingsController.footprintLibraryKeywords = ""
         componentListController.ids = ["C2040", "C25804"]
         buttons.exportErrorDialog.close()
         wait(0)
@@ -184,6 +224,56 @@ TestCase {
         compare(progressController.lastExportSymbol, true)
         compare(progressController.lastExportFootprint, true)
         compare(progressController.lastExportModel3D, false)
+    }
+
+    function test_startExportPassesAdvancedExportSettings() {
+        settingsController.exportSymbol = false
+        settingsController.exportFootprint = true
+        settingsController.exportModel3D = true
+        settingsController.exportModel3DFormat = 1
+        settingsController.exportModel3DPathMode = 2
+        settingsController.exportPreviewImages = true
+        settingsController.exportDatasheet = true
+        settingsController.overwriteExistingFiles = true
+        settingsController.exportMode = 1
+        settingsController.debugMode = true
+        settingsController.symbolLibraryDescription = "symbol library description"
+        settingsController.footprintLibraryDescription = "footprint library description"
+        settingsController.footprintLibraryKeywords = "resistor capacitor"
+        wait(0)
+
+        mouseClick(startButton())
+
+        compare(progressController.startExportCallCount, 1)
+        compare(progressController.lastExportSymbol, false)
+        compare(progressController.lastExportFootprint, true)
+        compare(progressController.lastExportModel3D, true)
+        compare(progressController.lastExportModel3DFormat, 1)
+        compare(progressController.lastExportModel3DPathMode, 2)
+        compare(progressController.lastExportPreviewImages, true)
+        compare(progressController.lastExportDatasheet, true)
+        compare(progressController.lastOverwriteExistingFiles, true)
+        compare(progressController.lastUpdateMode, true)
+        compare(progressController.lastDebugMode, true)
+        compare(progressController.lastSymbolLibraryDescription, "symbol library description")
+        compare(progressController.lastFootprintLibraryDescription, "footprint library description")
+        compare(progressController.lastFootprintLibraryKeywords, "resistor capacitor")
+    }
+
+    function test_model3DOnlyExportIsAllowed() {
+        settingsController.exportSymbol = false
+        settingsController.exportFootprint = false
+        settingsController.exportModel3D = true
+        wait(0)
+
+        compare(startButton().enabled, true)
+
+        mouseClick(startButton())
+
+        compare(progressController.startExportCallCount, 1)
+        compare(progressController.lastExportSymbol, false)
+        compare(progressController.lastExportFootprint, false)
+        compare(progressController.lastExportModel3D, true)
     }
 
     function test_exportingStateShowsStopAndDisablesStart() {

--- a/tests/ui/tst_ExportFlow.qml
+++ b/tests/ui/tst_ExportFlow.qml
@@ -1,0 +1,215 @@
+import QtQuick
+import QtTest
+import "../../src/ui/qml/components"
+
+TestCase {
+    name: "ExportFlow"
+    width: 720
+    height: 260
+    visible: true
+    when: windowShown
+
+    QtObject {
+        id: progressController
+        property bool isExporting: false
+        property bool isStopping: false
+        property bool hasCompletedExport: false
+        property int failureCount: 0
+        property int startExportCallCount: 0
+        property int cancelExportCallCount: 0
+        property int retryFailedCallCount: 0
+        property int openFolderCallCount: 0
+        property var lastComponentIds: []
+        property string lastOutputPath: ""
+        property string lastLibName: ""
+        property bool lastExportSymbol: false
+        property bool lastExportFootprint: false
+        property bool lastExportModel3D: false
+        property bool openLastExportedFolderResult: true
+
+        function startExport(componentIds, outputPath, libName, exportSymbol, exportFootprint, exportModel3D) {
+            startExportCallCount += 1
+            lastComponentIds = componentIds
+            lastOutputPath = outputPath
+            lastLibName = libName
+            lastExportSymbol = exportSymbol
+            lastExportFootprint = exportFootprint
+            lastExportModel3D = exportModel3D
+        }
+
+        function cancelExport() {
+            cancelExportCallCount += 1
+            isStopping = true
+        }
+
+        function retryFailedComponents() {
+            retryFailedCallCount += 1
+        }
+
+        function openLastExportedFolder() {
+            openFolderCallCount += 1
+            return openLastExportedFolderResult
+        }
+    }
+
+    QtObject {
+        id: settingsController
+        property string outputPath: "/tmp/easykiconverter-ui-flow"
+        property string libName: "UiFlowLib"
+        property bool exportSymbol: true
+        property bool exportFootprint: true
+        property bool exportModel3D: false
+        property int exportModel3DFormat: 3
+        property int exportModel3DPathMode: 0
+        property bool exportPreviewImages: false
+        property bool exportDatasheet: false
+        property bool overwriteExistingFiles: false
+        property int exportMode: 0
+        property bool debugMode: false
+        property string symbolLibraryDescription: ""
+        property string footprintLibraryDescription: ""
+        property string footprintLibraryKeywords: ""
+    }
+
+    QtObject {
+        id: componentListController
+        property var ids: ["C2040", "C25804"]
+        property int componentCount: ids.length
+
+        function getAllComponentIds() {
+            return ids
+        }
+    }
+
+    ExportButtonsSection {
+        id: buttons
+        width: parent.width
+        exportProgressController: progressController
+        exportSettingsController: settingsController
+        componentListController: componentListController
+    }
+
+    function init() {
+        progressController.isExporting = false
+        progressController.isStopping = false
+        progressController.hasCompletedExport = false
+        progressController.failureCount = 0
+        progressController.startExportCallCount = 0
+        progressController.cancelExportCallCount = 0
+        progressController.retryFailedCallCount = 0
+        progressController.openFolderCallCount = 0
+        progressController.lastComponentIds = []
+        progressController.lastOutputPath = ""
+        progressController.lastLibName = ""
+        progressController.lastExportSymbol = false
+        progressController.lastExportFootprint = false
+        progressController.lastExportModel3D = false
+        progressController.openLastExportedFolderResult = true
+
+        settingsController.exportSymbol = true
+        settingsController.exportFootprint = true
+        settingsController.exportModel3D = false
+        componentListController.ids = ["C2040", "C25804"]
+        wait(0)
+    }
+
+    function findByObjectName(item, objectName) {
+        if (!item)
+            return null
+        if (item.objectName === objectName)
+            return item
+
+        for (var i = 0; i < item.children.length; ++i) {
+            var child = findByObjectName(item.children[i], objectName)
+            if (child)
+                return child
+        }
+
+        return null
+    }
+
+    function startButton() {
+        var button = findByObjectName(buttons, "startExportButton")
+        verify(button !== null, "start export button should be discoverable")
+        return button
+    }
+
+    function stopButton() {
+        var button = findByObjectName(buttons, "stopExportButton")
+        verify(button !== null, "stop export button should be discoverable")
+        return button
+    }
+
+    function openFolderButton() {
+        var button = findByObjectName(buttons, "openExportFolderButton")
+        verify(button !== null, "open export folder button should be discoverable")
+        return button
+    }
+
+    function test_startExportButtonDisabledWithoutComponents() {
+        componentListController.ids = []
+        wait(0)
+
+        compare(startButton().enabled, false)
+    }
+
+    function test_startExportPassesSelectedComponentsAndSettings() {
+        var button = startButton()
+        compare(button.enabled, true)
+
+        mouseClick(button)
+
+        compare(progressController.startExportCallCount, 1)
+        compare(progressController.lastComponentIds.length, 2)
+        compare(progressController.lastComponentIds[0], "C2040")
+        compare(progressController.lastComponentIds[1], "C25804")
+        compare(progressController.lastOutputPath, settingsController.outputPath)
+        compare(progressController.lastLibName, settingsController.libName)
+        compare(progressController.lastExportSymbol, true)
+        compare(progressController.lastExportFootprint, true)
+        compare(progressController.lastExportModel3D, false)
+    }
+
+    function test_exportingStateShowsStopAndDisablesStart() {
+        progressController.isExporting = true
+        wait(0)
+
+        compare(startButton().enabled, false)
+        compare(stopButton().visible, true)
+        compare(stopButton().enabled, true)
+    }
+
+    function test_stopExportCallsCancelAndDisablesWhileStopping() {
+        progressController.isExporting = true
+        progressController.isStopping = false
+        wait(0)
+
+        mouseClick(stopButton())
+
+        compare(progressController.cancelExportCallCount, 1)
+        compare(stopButton().enabled, false)
+    }
+
+    function test_failedStateRetriesInsteadOfStartingNewExport() {
+        progressController.failureCount = 2
+        wait(0)
+
+        mouseClick(startButton())
+
+        compare(progressController.retryFailedCallCount, 1)
+        compare(progressController.startExportCallCount, 0)
+    }
+
+    function test_completedExportShowsOpenFolderAction() {
+        progressController.hasCompletedExport = true
+        wait(0)
+
+        var button = openFolderButton()
+        compare(button.visible, true)
+        compare(button.enabled, true)
+
+        button.clicked()
+
+        compare(progressController.openFolderCallCount, 1)
+    }
+}

--- a/tests/ui/tst_ExportFlow.qml
+++ b/tests/ui/tst_ExportFlow.qml
@@ -110,6 +110,7 @@ TestCase {
         settingsController.exportFootprint = true
         settingsController.exportModel3D = false
         componentListController.ids = ["C2040", "C25804"]
+        buttons.exportErrorDialog.close()
         wait(0)
     }
 
@@ -146,8 +147,23 @@ TestCase {
         return button
     }
 
+    function errorDialog() {
+        var dialog = buttons.exportErrorDialog
+        verify(dialog !== null, "export error dialog should be discoverable")
+        return dialog
+    }
+
     function test_startExportButtonDisabledWithoutComponents() {
         componentListController.ids = []
+        wait(0)
+
+        compare(startButton().enabled, false)
+    }
+
+    function test_startExportButtonDisabledWithoutLibraryExportType() {
+        settingsController.exportSymbol = false
+        settingsController.exportFootprint = false
+        settingsController.exportModel3D = false
         wait(0)
 
         compare(startButton().enabled, false)
@@ -184,10 +200,13 @@ TestCase {
         progressController.isStopping = false
         wait(0)
 
+        compare(stopButton().text, qsTranslate("MainWindow", "停止转换"))
+
         mouseClick(stopButton())
 
         compare(progressController.cancelExportCallCount, 1)
         compare(stopButton().enabled, false)
+        compare(stopButton().text, qsTranslate("MainWindow", "正在停止..."))
     }
 
     function test_failedStateRetriesInsteadOfStartingNewExport() {
@@ -211,5 +230,22 @@ TestCase {
         button.clicked()
 
         compare(progressController.openFolderCallCount, 1)
+    }
+
+    function test_openFolderFailureShowsErrorDialog() {
+        progressController.hasCompletedExport = true
+        progressController.openLastExportedFolderResult = false
+        wait(0)
+
+        var dialog = errorDialog()
+        compare(dialog.visible, false)
+
+        openFolderButton().clicked()
+        wait(0)
+
+        compare(progressController.openFolderCallCount, 1)
+        compare(dialog.visible, true)
+
+        dialog.close()
     }
 }

--- a/tests/ui/tst_ExportProgressCard.qml
+++ b/tests/ui/tst_ExportProgressCard.qml
@@ -1,0 +1,103 @@
+import QtQuick
+import QtTest
+import "../../src/ui/qml/components"
+
+TestCase {
+    name: "ExportProgressCard"
+    width: 720
+    height: 320
+    visible: true
+    when: windowShown
+
+    QtObject {
+        id: progressController
+        property bool isExporting: false
+        property real progress: 0
+        property int fetchProgress: 0
+        property int processProgress: 0
+        property int writeProgress: 0
+        property string status: ""
+    }
+
+    ExportProgressCard {
+        id: progressCard
+        width: parent.width
+        exportProgressController: progressController
+    }
+
+    function init() {
+        progressController.isExporting = false
+        progressController.progress = 0
+        progressController.fetchProgress = 0
+        progressController.processProgress = 0
+        progressController.writeProgress = 0
+        progressController.status = ""
+        wait(0)
+    }
+
+    function findByObjectName(item, objectName) {
+        if (!item)
+            return null
+        if (item.objectName === objectName)
+            return item
+
+        for (var i = 0; i < item.children.length; ++i) {
+            var child = findByObjectName(item.children[i], objectName)
+            if (child)
+                return child
+        }
+
+        return null
+    }
+
+    function statusLabel() {
+        var label = findByObjectName(progressCard, "exportStatusLabel")
+        verify(label !== null, "export status label should be discoverable")
+        return label
+    }
+
+    function percentLabel() {
+        var label = findByObjectName(progressCard, "exportProgressPercentLabel")
+        verify(label !== null, "export progress percent label should be discoverable")
+        return label
+    }
+
+    function progressBar() {
+        var bar = findByObjectName(progressCard, "exportProgressBar")
+        verify(bar !== null, "export progress bar should be discoverable")
+        return bar
+    }
+
+    function test_hiddenWhenIdleWithNoProgress() {
+        compare(progressCard.visible, false)
+    }
+
+    function test_visibleWhileExportingEvenBeforeProgress() {
+        progressController.isExporting = true
+        wait(0)
+
+        compare(progressCard.visible, true)
+        compare(percentLabel().text, "0%")
+        compare(progressBar().height, 12)
+    }
+
+    function test_visibleAfterProgressAndShowsRoundedPercent() {
+        progressController.progress = 42.6
+        wait(0)
+
+        compare(progressCard.visible, true)
+        compare(percentLabel().text, "43%")
+    }
+
+    function test_statusLabelTracksControllerStatus() {
+        var label = statusLabel()
+        compare(label.visible, false)
+
+        progressController.isExporting = true
+        progressController.status = "Exporting components..."
+        wait(0)
+
+        compare(label.visible, true)
+        compare(label.text, "Exporting components...")
+    }
+}

--- a/tests/ui/tst_ExportResultsCard.qml
+++ b/tests/ui/tst_ExportResultsCard.qml
@@ -1,0 +1,209 @@
+import QtQuick
+import QtTest
+import "../../src/ui/qml/components"
+
+TestCase {
+    name: "ExportResultsCard"
+    width: 760
+    height: 520
+    visible: true
+    when: windowShown
+
+    QtObject {
+        id: progressController
+        property bool isExporting: false
+        property var resultsList: []
+        property string filterMode: "all"
+        property int filteredPendingCount: 0
+        property int successCount: 0
+        property int failureCount: 0
+        property string lastFilterMode: ""
+        property string lastRetryComponentId: ""
+        property string lastRemovedComponentId: ""
+
+        function setFilterMode(mode) {
+            filterMode = mode
+            lastFilterMode = mode
+        }
+
+        function retryComponent(componentId) {
+            lastRetryComponentId = componentId
+        }
+
+        function removeResult(componentId) {
+            lastRemovedComponentId = componentId
+        }
+    }
+
+    ExportResultsCard {
+        id: resultsCard
+        width: parent.width
+        exportProgressController: progressController
+    }
+
+    function init() {
+        progressController.isExporting = false
+        progressController.resultsList = []
+        progressController.filterMode = "all"
+        progressController.filteredPendingCount = 0
+        progressController.successCount = 0
+        progressController.failureCount = 0
+        progressController.lastFilterMode = ""
+        progressController.lastRetryComponentId = ""
+        progressController.lastRemovedComponentId = ""
+        wait(0)
+    }
+
+    function findByObjectName(item, objectName) {
+        if (!item)
+            return null
+        if (item.objectName === objectName)
+            return item
+
+        var i
+        if (item.children) {
+            for (i = 0; i < item.children.length; ++i) {
+                var child = findByObjectName(item.children[i], objectName)
+                if (child)
+                    return child
+            }
+        }
+
+        if (item.contentItem && item.contentItem.children) {
+            for (i = 0; i < item.contentItem.children.length; ++i) {
+                var contentChild = findByObjectName(item.contentItem.children[i], objectName)
+                if (contentChild)
+                    return contentChild
+            }
+        }
+
+        return null
+    }
+
+    function makeResults() {
+        return [
+            {
+                "componentId": "C100",
+                "status": "success",
+                "message": "Exported",
+                "symbolStatus": "success",
+                "footprintStatus": "success",
+                "model3DStatus": "disabled",
+                "previewStatus": "disabled",
+                "datasheetStatus": "disabled",
+                "symbolSuccess": true,
+                "footprintSuccess": true
+            },
+            {
+                "componentId": "C200",
+                "status": "failed",
+                "error": "Fixture failure",
+                "symbolStatus": "failed",
+                "footprintStatus": "pending",
+                "model3DStatus": "disabled",
+                "previewStatus": "disabled",
+                "datasheetStatus": "disabled"
+            },
+            {
+                "componentId": "C300",
+                "status": "in_progress",
+                "message": "Exporting",
+                "symbolStatus": "in_progress",
+                "footprintStatus": "pending",
+                "model3DStatus": "disabled",
+                "previewStatus": "disabled",
+                "datasheetStatus": "disabled"
+            }
+        ]
+    }
+
+    function loadResults() {
+        progressController.resultsList = makeResults()
+        progressController.filteredPendingCount = 1
+        progressController.successCount = 1
+        progressController.failureCount = 1
+        wait(100)
+    }
+
+    function cardItem() {
+        verify(resultsCard.item !== null, "results loader should have an active item")
+        return resultsCard.item
+    }
+
+    function resultItem(componentId) {
+        var item = findByObjectName(cardItem(), "exportResultItem_" + componentId)
+        verify(item !== null, "result item should be discoverable: " + componentId)
+        return item
+    }
+
+    function filterButton(objectName) {
+        var button = findByObjectName(cardItem(), objectName)
+        verify(button !== null, "filter button should be discoverable: " + objectName)
+        return button
+    }
+
+    function test_hiddenWhenIdleWithNoResults() {
+        compare(resultsCard.active, false)
+        compare(resultsCard.visible, false)
+    }
+
+    function test_activeWhileExportingBeforeResultsArrive() {
+        progressController.isExporting = true
+        wait(0)
+
+        compare(resultsCard.active, true)
+        verify(resultsCard.item !== null)
+        compare(findByObjectName(cardItem(), "exportResultsList").visible, false)
+    }
+
+    function test_resultItemsRenderWhenResultsExist() {
+        loadResults()
+
+        compare(resultsCard.active, true)
+        verify(findByObjectName(cardItem(), "exportResultsFilterSegmentedControl").visible)
+        verify(findByObjectName(cardItem(), "exportResultsList").visible)
+        compare(resultItem("C100").status, "success")
+        compare(resultItem("C200").status, "failed")
+        compare(resultItem("C300").status, "in_progress")
+    }
+
+    function test_filterButtonsUpdateControllerMode() {
+        loadResults()
+
+        mouseClick(filterButton("exportResultsFilterFailedButton"))
+        compare(progressController.lastFilterMode, "failed")
+        compare(progressController.filterMode, "failed")
+
+        mouseClick(filterButton("exportResultsFilterSuccessButton"))
+        compare(progressController.lastFilterMode, "success")
+        compare(progressController.filterMode, "success")
+
+        mouseClick(filterButton("exportResultsFilterAllButton"))
+        compare(progressController.lastFilterMode, "all")
+        compare(progressController.filterMode, "all")
+    }
+
+    function test_disabledFilterDoesNotChangeControllerMode() {
+        progressController.resultsList = makeResults()
+        progressController.filteredPendingCount = 0
+        progressController.successCount = 1
+        progressController.failureCount = 1
+        wait(100)
+
+        mouseClick(filterButton("exportResultsFilterExportingButton"))
+
+        compare(progressController.lastFilterMode, "")
+        compare(progressController.filterMode, "all")
+    }
+
+    function test_retryAndDeleteFailedResultCallController() {
+        loadResults()
+
+        var failedItem = resultItem("C200")
+        failedItem.retryClicked()
+        compare(progressController.lastRetryComponentId, "C200")
+
+        failedItem.deleteClicked()
+        compare(progressController.lastRemovedComponentId, "C200")
+    }
+}

--- a/tests/ui/tst_MainDialogBindings.qml
+++ b/tests/ui/tst_MainDialogBindings.qml
@@ -1,0 +1,126 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import QtTest
+import "../../src/ui/qml/components"
+
+TestCase {
+    name: "MainDialogBindings"
+    width: 520
+    height: 360
+    visible: true
+    when: windowShown
+
+    ApplicationWindow {
+        id: testWindow
+        width: 360
+        height: 260
+        visible: false
+    }
+
+    QtObject {
+        id: exportProgressController
+        property bool isExporting: false
+        property int handleCloseRequestCount: 0
+
+        function handleCloseRequest() {
+            handleCloseRequestCount += 1
+        }
+    }
+
+    QtObject {
+        id: configService
+        property string exitPreference: ""
+
+        function getExitPreference() {
+            return exitPreference
+        }
+
+        function getWindowState() {
+            return {
+                "x": -9999,
+                "y": -9999,
+                "width": -1,
+                "height": -1,
+                "maximized": false
+            }
+        }
+    }
+
+    WindowController {
+        id: appWindowController
+        window: testWindow
+        configService: configService
+        exportProgressController: exportProgressController
+        closeConfirmDialog: closeConfirmDialog
+        exitOptionDialog: exitOptionDialog
+    }
+
+    ConfirmDialog {
+        id: closeConfirmDialog
+        title: qsTr("确认退出")
+        message: qsTr("转换正在进行中。退出将取消当前转换，已导出的文件会保留。确定要退出吗？")
+        confirmText: qsTr("强制退出")
+        cancelText: qsTr("继续转换")
+        onRejected: appWindowController.resumeExport()
+    }
+
+    ExitDialog {
+        id: exitOptionDialog
+        onCanceled: appWindowController.resumeExport()
+    }
+
+    function init() {
+        exportProgressController.isExporting = false
+        exportProgressController.handleCloseRequestCount = 0
+        configService.exitPreference = ""
+        appWindowController.forceExitRequested = false
+        closeConfirmDialog.close()
+        exitOptionDialog.close()
+        wait(0)
+    }
+
+    function test_exportingCloseRequestOpensRealConfirmDialog() {
+        exportProgressController.isExporting = true
+
+        appWindowController.processCloseRequest()
+
+        compare(closeConfirmDialog.visible, true)
+        compare(exitOptionDialog.visible, false)
+        compare(exportProgressController.handleCloseRequestCount, 0)
+    }
+
+    function test_rejectingConfirmDialogResumesExportAndClosesDialog() {
+        exportProgressController.isExporting = true
+        appWindowController.processCloseRequest()
+        compare(closeConfirmDialog.visible, true)
+
+        closeConfirmDialog.rejected()
+        wait(0)
+
+        compare(closeConfirmDialog.visible, false)
+        compare(appWindowController.forceExitRequested, false)
+        compare(exportProgressController.handleCloseRequestCount, 0)
+    }
+
+    function test_idleCloseRequestOpensRealExitOptionsDialog() {
+        exportProgressController.isExporting = false
+
+        appWindowController.processCloseRequest()
+
+        compare(exitOptionDialog.visible, true)
+        compare(closeConfirmDialog.visible, false)
+    }
+
+    function test_cancelingExitOptionsDialogReturnsToWindow() {
+        appWindowController.processCloseRequest()
+        compare(exitOptionDialog.visible, true)
+
+        exitOptionDialog.getButtonSpecByIndex(2).action()
+        wait(300)
+
+        compare(exitOptionDialog.visible, false)
+        compare(appWindowController.forceExitRequested, false)
+        compare(exportProgressController.handleCloseRequestCount, 0)
+    }
+}

--- a/tests/ui/tst_WindowControllerClosing.qml
+++ b/tests/ui/tst_WindowControllerClosing.qml
@@ -1,0 +1,167 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+import QtTest
+import "../../src/ui/qml/components"
+
+TestCase {
+    name: "WindowControllerClosing"
+    width: 480
+    height: 320
+    visible: true
+    when: windowShown
+
+    ApplicationWindow {
+        id: testWindow
+        width: 320
+        height: 240
+        visible: false
+    }
+
+    QtObject {
+        id: exportProgressController
+        property bool isExporting: false
+        property int handleCloseRequestCount: 0
+
+        function handleCloseRequest() {
+            handleCloseRequestCount += 1
+        }
+    }
+
+    QtObject {
+        id: configService
+        property string preference: ""
+        property int getExitPreferenceCount: 0
+
+        function getExitPreference() {
+            getExitPreferenceCount += 1
+            return preference
+        }
+    }
+
+    QtObject {
+        id: closeConfirmDialog
+        property bool visible: false
+        property int openCount: 0
+        property int closeCount: 0
+
+        function open() {
+            visible = true
+            openCount += 1
+        }
+
+        function close() {
+            visible = false
+            closeCount += 1
+        }
+    }
+
+    QtObject {
+        id: exitOptionDialog
+        property bool visible: false
+        property int openCount: 0
+        property int closeCount: 0
+
+        function open() {
+            visible = true
+            openCount += 1
+        }
+
+        function close() {
+            visible = false
+            closeCount += 1
+        }
+    }
+
+    WindowController {
+        id: controller
+        window: testWindow
+        configService: configService
+        exportProgressController: exportProgressController
+        closeConfirmDialog: closeConfirmDialog
+        exitOptionDialog: exitOptionDialog
+    }
+
+    function init() {
+        exportProgressController.isExporting = false
+        exportProgressController.handleCloseRequestCount = 0
+        configService.preference = ""
+        configService.getExitPreferenceCount = 0
+        closeConfirmDialog.visible = false
+        closeConfirmDialog.openCount = 0
+        closeConfirmDialog.closeCount = 0
+        exitOptionDialog.visible = false
+        exitOptionDialog.openCount = 0
+        exitOptionDialog.closeCount = 0
+        controller.forceExitRequested = false
+        wait(0)
+    }
+
+    function test_handleClosingWhileExportingRejectsCloseAndShowsConfirmDialog() {
+        exportProgressController.isExporting = true
+        var closeEvent = {
+            "accepted": true
+        }
+
+        controller.handleClosing(closeEvent)
+
+        compare(closeEvent.accepted, false)
+        compare(closeConfirmDialog.visible, true)
+        compare(closeConfirmDialog.openCount, 1)
+        compare(exitOptionDialog.openCount, 0)
+        compare(exportProgressController.handleCloseRequestCount, 0)
+    }
+
+    function test_handleClosingWithoutExportShowsExitOptions() {
+        var closeEvent = {
+            "accepted": true
+        }
+
+        controller.handleClosing(closeEvent)
+
+        compare(closeEvent.accepted, false)
+        compare(configService.getExitPreferenceCount, 1)
+        compare(exitOptionDialog.visible, true)
+        compare(exitOptionDialog.openCount, 1)
+        compare(closeConfirmDialog.openCount, 0)
+    }
+
+    function test_existingDialogPreventsDuplicateClosePrompt() {
+        exportProgressController.isExporting = true
+        closeConfirmDialog.visible = true
+
+        controller.processCloseRequest()
+
+        compare(closeConfirmDialog.openCount, 0)
+        compare(exitOptionDialog.openCount, 0)
+    }
+
+    function test_handleEscTogglesVisibleDialogsBeforeOpeningNewPrompt() {
+        closeConfirmDialog.visible = true
+
+        controller.handleEsc()
+
+        compare(closeConfirmDialog.visible, false)
+        compare(closeConfirmDialog.closeCount, 1)
+        compare(exitOptionDialog.openCount, 0)
+
+        exportProgressController.isExporting = false
+        controller.handleEsc()
+
+        compare(exitOptionDialog.visible, true)
+        compare(exitOptionDialog.openCount, 1)
+    }
+
+    function test_handleClosingAllowsCloseAfterForcedExitFlag() {
+        controller.forceExitRequested = true
+        var closeEvent = {
+            "accepted": false
+        }
+
+        controller.handleClosing(closeEvent)
+
+        compare(closeEvent.accepted, true)
+        compare(closeConfirmDialog.openCount, 0)
+        compare(exitOptionDialog.openCount, 0)
+    }
+}

--- a/tests/ui/tst_WindowControllerClosing.qml
+++ b/tests/ui/tst_WindowControllerClosing.qml
@@ -37,6 +37,16 @@ TestCase {
             getExitPreferenceCount += 1
             return preference
         }
+
+        function getWindowState() {
+            return {
+                "x": -9999,
+                "y": -9999,
+                "width": -1,
+                "height": -1,
+                "maximized": false
+            }
+        }
     }
 
     QtObject {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -486,5 +486,5 @@ set(EASYKICONVERTER_UNIT_TESTS
 
 set_tests_properties(${EASYKICONVERTER_UNIT_TESTS}
     PROPERTIES
-        LABELS "unit"
+        LABELS "unit;fast"
 )

--- a/tests/unit/test_export_progress_viewmodel.cpp
+++ b/tests/unit/test_export_progress_viewmodel.cpp
@@ -202,6 +202,104 @@ private slots:
             QCOMPARE(result.value("error").toString(), QStringLiteral("Export cancelled"));
         }
     }
+
+    void retryFailedComponentsResetsOnlyFailedItems() {
+        ParallelExportService service;
+        ExportProgressViewModel viewModel(&service, nullptr, nullptr);
+
+        viewModel.startExport({"C1", "C2", "C3"},
+                              "/tmp/easykiconverter-test",
+                              "testlib",
+                              true,
+                              true,
+                              false,
+                              0,
+                              0,
+                              false,
+                              false,
+                              false,
+                              false,
+                              false);
+
+        auto makeStatus = [](ExportItemStatus::Status state, const QString& error = QString()) {
+            ExportItemStatus status;
+            status.status = state;
+            status.errorMessage = error;
+            return status;
+        };
+
+        QVERIFY(QMetaObject::invokeMethod(&viewModel,
+                                          "handleItemStatusChanged",
+                                          Qt::DirectConnection,
+                                          Q_ARG(QString, QStringLiteral("C1")),
+                                          Q_ARG(QString, QStringLiteral("Symbol")),
+                                          Q_ARG(ExportItemStatus, makeStatus(ExportItemStatus::Status::Success))));
+        QVERIFY(QMetaObject::invokeMethod(&viewModel,
+                                          "handleItemStatusChanged",
+                                          Qt::DirectConnection,
+                                          Q_ARG(QString, QStringLiteral("C1")),
+                                          Q_ARG(QString, QStringLiteral("Footprint")),
+                                          Q_ARG(ExportItemStatus, makeStatus(ExportItemStatus::Status::Success))));
+        QVERIFY(QMetaObject::invokeMethod(
+            &viewModel,
+            "handleItemStatusChanged",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("C2")),
+            Q_ARG(QString, QStringLiteral("Symbol")),
+            Q_ARG(ExportItemStatus, makeStatus(ExportItemStatus::Status::Failed, QStringLiteral("symbol failed")))));
+        QVERIFY(QMetaObject::invokeMethod(&viewModel,
+                                          "handleItemStatusChanged",
+                                          Qt::DirectConnection,
+                                          Q_ARG(QString, QStringLiteral("C2")),
+                                          Q_ARG(QString, QStringLiteral("Footprint")),
+                                          Q_ARG(ExportItemStatus, makeStatus(ExportItemStatus::Status::Success))));
+        QVERIFY(QMetaObject::invokeMethod(&viewModel,
+                                          "handleItemStatusChanged",
+                                          Qt::DirectConnection,
+                                          Q_ARG(QString, QStringLiteral("C3")),
+                                          Q_ARG(QString, QStringLiteral("Symbol")),
+                                          Q_ARG(ExportItemStatus, makeStatus(ExportItemStatus::Status::Success))));
+        QVERIFY(QMetaObject::invokeMethod(
+            &viewModel,
+            "handleItemStatusChanged",
+            Qt::DirectConnection,
+            Q_ARG(QString, QStringLiteral("C3")),
+            Q_ARG(QString, QStringLiteral("Footprint")),
+            Q_ARG(ExportItemStatus, makeStatus(ExportItemStatus::Status::Failed, QStringLiteral("footprint failed")))));
+        QVERIFY(QMetaObject::invokeMethod(&viewModel, "flushPendingUpdates", Qt::DirectConnection));
+
+        QCOMPARE(viewModel.successCount(), 1);
+        QCOMPARE(viewModel.failureCount(), 2);
+
+        viewModel.retryFailedComponents();
+
+        QCOMPARE(viewModel.successCount(), 1);
+        QCOMPARE(viewModel.failureCount(), 0);
+        QCOMPARE(viewModel.filteredPendingCount(), 2);
+
+        const QVariantList results = viewModel.resultsList();
+        QCOMPARE(results.size(), 3);
+
+        const QVariantMap success = results.at(0).toMap();
+        QCOMPARE(success.value("componentId").toString(), QStringLiteral("C1"));
+        QCOMPARE(success.value("status").toString(), QStringLiteral("success"));
+        QCOMPARE(success.value("symbolStatus").toString(), QStringLiteral("success"));
+        QCOMPARE(success.value("footprintStatus").toString(), QStringLiteral("success"));
+
+        const QVariantMap retrySymbol = results.at(1).toMap();
+        QCOMPARE(retrySymbol.value("componentId").toString(), QStringLiteral("C2"));
+        QCOMPARE(retrySymbol.value("status").toString(), QStringLiteral("pending"));
+        QCOMPARE(retrySymbol.value("symbolStatus").toString(), QStringLiteral("pending"));
+        QCOMPARE(retrySymbol.value("footprintStatus").toString(), QStringLiteral("pending"));
+        QCOMPARE(retrySymbol.value("error").toString(), QString());
+
+        const QVariantMap retryFootprint = results.at(2).toMap();
+        QCOMPARE(retryFootprint.value("componentId").toString(), QStringLiteral("C3"));
+        QCOMPARE(retryFootprint.value("status").toString(), QStringLiteral("pending"));
+        QCOMPARE(retryFootprint.value("symbolStatus").toString(), QStringLiteral("pending"));
+        QCOMPARE(retryFootprint.value("footprintStatus").toString(), QStringLiteral("pending"));
+        QCOMPARE(retryFootprint.value("error").toString(), QString());
+    }
 };
 
 }  // namespace EasyKiConverter

--- a/tests/unit/test_export_progress_viewmodel.cpp
+++ b/tests/unit/test_export_progress_viewmodel.cpp
@@ -157,6 +157,51 @@ private slots:
         QCOMPARE(second.value("footprintStatus").toString(), QStringLiteral("failed"));
         QCOMPARE(second.value("error").toString(), QStringLiteral("broken"));
     }
+
+    void cancelExportMarksPendingItemsCancelledAndResetsState() {
+        ParallelExportService service;
+        ExportProgressViewModel viewModel(&service, nullptr, nullptr);
+        QSignalSpy stoppingSpy(&viewModel, &ExportProgressViewModel::isStoppingChanged);
+        QSignalSpy exportingSpy(&viewModel, &ExportProgressViewModel::isExportingChanged);
+
+        viewModel.startExport({"C1", "C2"},
+                              "/tmp/easykiconverter-test",
+                              "testlib",
+                              true,
+                              true,
+                              false,
+                              0,
+                              0,
+                              false,
+                              false,
+                              false,
+                              false,
+                              false);
+
+        QVERIFY(viewModel.isExporting());
+        QCOMPARE(viewModel.resultsList().size(), 2);
+
+        viewModel.cancelExport();
+
+        QCOMPARE(viewModel.isStopping(), false);
+        QCOMPARE(viewModel.isExporting(), false);
+        QCOMPARE(viewModel.hasCompletedExport(), false);
+        QCOMPARE(viewModel.progress(), 0);
+        QCOMPARE(viewModel.status(), QStringLiteral("Export cancelled"));
+        QVERIFY(stoppingSpy.count() >= 2);
+        QVERIFY(exportingSpy.count() >= 2);
+
+        const QVariantList results = viewModel.resultsList();
+        QCOMPARE(results.size(), 2);
+        for (const QVariant& resultVariant : results) {
+            const QVariantMap result = resultVariant.toMap();
+            QCOMPARE(result.value("status").toString(), QStringLiteral("failed"));
+            QCOMPARE(result.value("symbolStatus").toString(), QStringLiteral("failed"));
+            QCOMPARE(result.value("footprintStatus").toString(), QStringLiteral("failed"));
+            QCOMPARE(result.value("model3DStatus").toString(), QStringLiteral("disabled"));
+            QCOMPARE(result.value("error").toString(), QStringLiteral("Export cancelled"));
+        }
+    }
 };
 
 }  // namespace EasyKiConverter


### PR DESCRIPTION
描述：

  改动目的

  本分支围绕三个核心目标展开：(1) 大幅完善测试基础设施，将原本需要手动验证的 GUI 导出流程纳入自动化回归

  主要变更

  测试基础设施与自动化覆盖

  - 新增 tests/fixtures/ 和 tests/golden/ 目录，提供 EasyEDA 响应样例、BOM 文件和 KiCad 期望输出，支持离线
  golden-file 对比
  - 新增大量单元测试：原子写入、BOM 解析、缓存裁剪、CLI 转换器、命令行解析、核心工具、EasyEDA 导入器、导出进度/设置
  ViewModel、导出阶段、网络客户端、路径安全、SVG 解析、临时文件管理等
  - 新增集成测试：并行导出取消、fixture 到 KiCad 导出的离线路径验证
  - 新增 UI/QML 自动化测试：导出流程完整流程、导出进度卡、导出结果卡、导出设置卡、窗口关闭流程
  - 新增 KiCad golden 对比测试（符号库、封装、3D 模型路径、特殊字符处理）
  - 新增覆盖率报告生成工具 tools/python/generate_coverage.py
  - 新增测试路径辅助头文件 tests/common/TestPaths.hpp