### PR TITLE
security: 静态审查安全加固 — URL白名单、路径穿越防护、响应大小限制

### DIFF
--- a/src/core/network/AsyncNetworkRequest.cpp
+++ b/src/core/network/AsyncNetworkRequest.cpp
@@ -21,7 +21,17 @@ AsyncNetworkRequest* AsyncNetworkRequest::createFinished(const NetworkResult& re
     if (result.wasCancelled) {
         request->m_cancelled.storeRelease(1);
     }
-    request->completeWithResult(result);
+    // 设置已完成状态（同步），供调用方立即检查 isFinished() / result()
+    {
+        QMutexLocker locker(&request->m_resultMutex);
+        request->m_result = result;
+    }
+    request->m_finished.storeRelease(1);
+
+    // 延迟发射 finished 信号，确保调用方有机会先 connect
+    // 使用 QTimer::singleShot(0, ...) 投递到当前线程的事件循环
+    // 调用方必须在有事件循环的线程中使用（主线程、QThread 子类）
+    QTimer::singleShot(0, request, [request, result]() { emit request->finished(result); });
     return request;
 }
 
@@ -403,6 +413,20 @@ void AsyncNetworkRequest::processResponse(QNetworkReply* reply) {
         GzipUtils::DecompressResult decompResult = GzipUtils::decompress(data);
         if (decompResult.success) {
             data = decompResult.data;
+
+            // 解压后重新检查大小限制（压缩可能放大数据）
+            const RequestProfile profile = RequestProfiles::fromType(m_resourceType);
+            if (profile.maxResponseBytes > 0 && data.size() > profile.maxResponseBytes) {
+                result.error = QStringLiteral("Decompressed response too large: %1 bytes (limit %2)")
+                                   .arg(data.size())
+                                   .arg(profile.maxResponseBytes);
+                result.success = false;
+                result.wasCancelled = false;
+                result.diagnostic.errorType = NetworkErrorType::Other;
+                result.diagnostic.errorMessage = result.error;
+                completeWithResult(result);
+                return;
+            }
         } else {
             result.error = "Gzip decompression failed";
             result.success = false;

--- a/src/core/network/AsyncNetworkRequest.cpp
+++ b/src/core/network/AsyncNetworkRequest.cpp
@@ -1,6 +1,7 @@
 #include "AsyncNetworkRequest.h"
 
 #include "core/utils/GzipUtils.h"
+#include "core/utils/UrlUtils.h"
 
 #include <QDebug>
 #include <QElapsedTimer>
@@ -160,6 +161,8 @@ void AsyncNetworkRequest::startAttempt(int attemptNumber) {
     request.setHeader(QNetworkRequest::UserAgentHeader, "EasyKiConverter/1.0");
     request.setRawHeader("X-Requested-With", "XMLHttpRequest");
     request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
+    // 禁止不安全的重定向（HTTPS -> HTTP），防止降级攻击
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
     // Note: We handle gzip manually in processResponse() since Qt doesn't auto-decompress
 
     // Create the reply - use POST if body is provided
@@ -194,8 +197,11 @@ void AsyncNetworkRequest::startAttempt(int attemptNumber) {
     // Connect signals - use DirectConnection since we want immediate handling
     // The slot will run in this object's thread (main thread where AsyncNetworkRequest lives)
     connect(reply, &QNetworkReply::finished, this, &AsyncNetworkRequest::handleAttemptFinished, Qt::DirectConnection);
-    connect(
-        reply, &QNetworkReply::downloadProgress, this, &AsyncNetworkRequest::downloadProgress, Qt::DirectConnection);
+    connect(reply,
+            &QNetworkReply::downloadProgress,
+            this,
+            &AsyncNetworkRequest::handleDownloadProgress,
+            Qt::DirectConnection);
 
     qDebug() << "AsyncNetworkRequest: Attempt" << attemptNumber << "started for" << m_url;
 }
@@ -238,6 +244,35 @@ void AsyncNetworkRequest::handleTimeout() {
     m_currentAttemptTimedOut.storeRelease(1);
 
     {
+        QMutexLocker locker(&m_repliesMutex);
+        if (m_currentReply) {
+            m_currentReply->abort();
+        }
+    }
+}
+
+void AsyncNetworkRequest::handleDownloadProgress(qint64 bytesReceived, qint64 bytesTotal) {
+    if (isCancelled() || isFinished()) {
+        return;
+    }
+
+    // 转发进度信号
+    emit downloadProgress(bytesReceived, bytesTotal);
+
+    // 检查响应大小限制
+    const RequestProfile profile = RequestProfiles::fromType(m_resourceType);
+    const qint64 maxBytes = profile.maxResponseBytes;
+
+    if (maxBytes <= 0) {
+        return;  // 无限制
+    }
+
+    // 优先使用 Content-Length（bytesTotal），其次用已接收字节数
+    const qint64 checkSize = (bytesTotal > 0) ? bytesTotal : bytesReceived;
+
+    if (checkSize > maxBytes) {
+        qWarning() << "AsyncNetworkRequest: Response too large (" << checkSize << "bytes, limit" << maxBytes
+                   << "), aborting:" << m_url;
         QMutexLocker locker(&m_repliesMutex);
         if (m_currentReply) {
             m_currentReply->abort();
@@ -325,6 +360,39 @@ void AsyncNetworkRequest::processResponse(QNetworkReply* reply) {
 
     // Success - read data
     QByteArray data = reply->readAll();
+
+    // 安全兜底：检查实际读取的数据大小（Content-Length 可能缺失或不准确）
+    {
+        const RequestProfile profile = RequestProfiles::fromType(m_resourceType);
+        if (profile.maxResponseBytes > 0 && data.size() > profile.maxResponseBytes) {
+            result.error = QStringLiteral("Response too large: %1 bytes (limit %2)")
+                               .arg(data.size())
+                               .arg(profile.maxResponseBytes);
+            result.success = false;
+            result.wasCancelled = false;
+            result.diagnostic.errorType = NetworkErrorType::Other;
+            result.diagnostic.errorMessage = result.error;
+            completeWithResult(result);
+            return;
+        }
+    }
+
+    // 校验重定向后的最终 URL 是否仍在白名单内
+    {
+        const QUrl finalUrl = reply->url();
+        if (finalUrl != m_url) {
+            QString errorMsg;
+            if (!UrlUtils::isAllowedUrl(finalUrl, m_resourceType, &errorMsg)) {
+                result.error = QStringLiteral("Redirect to disallowed URL: %1").arg(errorMsg);
+                result.success = false;
+                result.wasCancelled = false;
+                result.diagnostic.errorType = NetworkErrorType::Other;
+                result.diagnostic.errorMessage = result.error;
+                completeWithResult(result);
+                return;
+            }
+        }
+    }
 
     // Check for gzip encoding and decompress if needed
     QVariant encodingVariant = reply->rawHeader("Content-Encoding");

--- a/src/core/network/AsyncNetworkRequest.h
+++ b/src/core/network/AsyncNetworkRequest.h
@@ -161,6 +161,11 @@ private:
     void handleTimeout();
 
     /**
+     * @brief 处理下载进度，检查响应大小限制
+     */
+    void handleDownloadProgress(qint64 bytesReceived, qint64 bytesTotal);
+
+    /**
      * @brief 处理响应数据
      */
     void processResponse(QNetworkReply* reply);

--- a/src/core/network/INetworkClient.h
+++ b/src/core/network/INetworkClient.h
@@ -59,6 +59,9 @@ struct RequestProfile {
 
     // 此资源类型是否可缓存
     bool cacheable = false;
+
+    // 此资源类型的最大响应字节数（防止恶意/异常响应导致内存耗尽）
+    qint64 maxResponseBytes = 50 * 1024 * 1024;  // 默认 50MB
 };
 
 /**
@@ -81,6 +84,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 10;
         profile.allowCancellation = true;
         profile.cacheable = true;
+        profile.maxResponseBytes = 20 * 1024 * 1024;  // JSON 20MB
         return profile;
     }
 
@@ -103,6 +107,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 10;
         profile.allowCancellation = true;
         profile.cacheable = true;
+        profile.maxResponseBytes = 20 * 1024 * 1024;  // JSON 20MB
         return profile;
     }
 
@@ -122,6 +127,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 5;
         profile.allowCancellation = true;
         profile.cacheable = true;
+        profile.maxResponseBytes = 10 * 1024 * 1024;  // 图片 10MB
         return profile;
     }
 
@@ -141,6 +147,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 5;
         profile.allowCancellation = true;
         profile.cacheable = true;
+        profile.maxResponseBytes = 20 * 1024 * 1024;  // JSON 20MB
         return profile;
     }
 
@@ -160,6 +167,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 3;
         profile.allowCancellation = true;
         profile.cacheable = true;
+        profile.maxResponseBytes = 200 * 1024 * 1024;  // PDF/HTML 200MB
         return profile;
     }
 
@@ -179,6 +187,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 3;
         profile.allowCancellation = true;
         profile.cacheable = true;
+        profile.maxResponseBytes = 200 * 1024 * 1024;  // OBJ 200MB
         return profile;
     }
 
@@ -198,6 +207,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 3;
         profile.allowCancellation = true;
         profile.cacheable = true;
+        profile.maxResponseBytes = 200 * 1024 * 1024;  // STEP 200MB
         return profile;
     }
 
@@ -217,6 +227,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 5;
         profile.allowCancellation = true;
         profile.cacheable = false;
+        profile.maxResponseBytes = 50 * 1024 * 1024;  // 通用 50MB
         return profile;
     }
 
@@ -236,6 +247,7 @@ struct RequestProfiles {
         profile.maxConcurrent = 2;
         profile.allowCancellation = true;
         profile.cacheable = false;
+        profile.maxResponseBytes = 5 * 1024 * 1024;  // GitHub API 5MB
         return profile;
     }
 

--- a/src/core/network/NetworkClient.cpp
+++ b/src/core/network/NetworkClient.cpp
@@ -1,6 +1,7 @@
 #include "NetworkClient.h"
 
 #include "core/utils/GzipUtils.h"
+#include "core/utils/UrlUtils.h"
 
 #include <QCoreApplication>
 #include <QDateTime>
@@ -226,6 +227,15 @@ AsyncNetworkRequest* NetworkClient::enqueueAsyncRequest(const QUrl& url,
                                                         const RetryPolicy& policy) {
     if (!m_asyncNetworkManager) {
         return nullptr;
+    }
+
+    // URL 白名单校验：拒绝非预期的 scheme 或 host
+    {
+        QString errorMsg;
+        if (!UrlUtils::isAllowedUrl(url, resourceType, &errorMsg)) {
+            qWarning() << "NetworkClient: URL rejected by whitelist:" << errorMsg;
+            return nullptr;
+        }
     }
 
     auto* request = new AsyncNetworkRequest(url, m_asyncNetworkManager, resourceType, policy, body, nullptr);

--- a/src/core/network/NetworkClient.cpp
+++ b/src/core/network/NetworkClient.cpp
@@ -197,6 +197,22 @@ NetworkResult NetworkClient::executeRequest(const QUrl& url,
                                             const QByteArray& body,
                                             ResourceType resourceType,
                                             const RetryPolicy& policy) {
+    // 同步路径：在创建 request 前做 URL 校验，避免白名单拒绝后死锁
+    // （QWaitCondition::wait() 不处理事件循环，queued 完成信号无法到达）
+    {
+        QString errorMsg;
+        if (!UrlUtils::isAllowedUrl(url, resourceType, &errorMsg)) {
+            qWarning() << "NetworkClient: URL rejected by whitelist (sync):" << errorMsg;
+            NetworkResult result;
+            populateDiagnostic(result.diagnostic, url, resourceType);
+            result.error = errorMsg;
+            result.success = false;
+            result.diagnostic.errorType = NetworkErrorType::Other;
+            result.diagnostic.errorMessage = errorMsg;
+            return result;
+        }
+    }
+
     auto* request = enqueueAsyncRequest(url, body, resourceType, policy);
     if (!request) {
         NetworkResult result;
@@ -234,7 +250,18 @@ AsyncNetworkRequest* NetworkClient::enqueueAsyncRequest(const QUrl& url,
         QString errorMsg;
         if (!UrlUtils::isAllowedUrl(url, resourceType, &errorMsg)) {
             qWarning() << "NetworkClient: URL rejected by whitelist:" << errorMsg;
-            return nullptr;
+            // 返回已完成的失败 request，避免调用方需处理 nullptr
+            NetworkResult failResult;
+            failResult.success = false;
+            failResult.wasCancelled = false;
+            failResult.error = errorMsg;
+            failResult.diagnostic.url = url.toString();
+            failResult.diagnostic.host = url.host();
+            failResult.diagnostic.resourceType = resourceType;
+            failResult.diagnostic.profileName = RequestProfiles::fromType(resourceType).name;
+            failResult.diagnostic.errorType = NetworkErrorType::Other;
+            failResult.diagnostic.errorMessage = errorMsg;
+            return AsyncNetworkRequest::createFinished(failResult);
         }
     }
 

--- a/src/core/utils/GzipUtils.cpp
+++ b/src/core/utils/GzipUtils.cpp
@@ -9,6 +9,10 @@
 static constexpr int GZIP_MAGIC_1 = 0x1f;
 static constexpr int GZIP_MAGIC_2 = 0x8b;
 
+// 安全限制：防止解压炸弹
+static constexpr qint64 MAX_DECOMPRESSED_SIZE = 500 * 1024 * 1024;  // 500MB
+static constexpr int MAX_COMPRESSION_RATIO = 100;  // 压缩比阈值
+
 bool GzipUtils::isGzipped(const QByteArray& data) {
     if (data.size() < 2) {
         return false;
@@ -54,6 +58,24 @@ GzipUtils::DecompressResult GzipUtils::decompress(const QByteArray& compressedDa
 
         if (ret == Z_OK || ret == Z_STREAM_END) {
             decompressed.append(buffer, bufferSize - stream.avail_out);
+
+            // 安全检查：解压大小上限
+            if (decompressed.size() > MAX_DECOMPRESSED_SIZE) {
+                qWarning() << "Gzip decompression aborted: output exceeds" << MAX_DECOMPRESSED_SIZE << "bytes";
+                inflateEnd(&stream);
+                return DecompressResult();
+            }
+
+            // 安全检查：压缩比阈值（防止解压炸弹）
+            if (compressedData.size() > 0) {
+                int ratio = decompressed.size() / compressedData.size();
+                if (ratio > MAX_COMPRESSION_RATIO) {
+                    qWarning() << "Gzip decompression aborted: compression ratio" << ratio << "exceeds limit of"
+                               << MAX_COMPRESSION_RATIO;
+                    inflateEnd(&stream);
+                    return DecompressResult();
+                }
+            }
         }
     } while (ret == Z_OK);
 

--- a/src/core/utils/UrlUtils.cpp
+++ b/src/core/utils/UrlUtils.cpp
@@ -20,7 +20,6 @@ QSet<QString> allowedHostsForType(ResourceType type) {
                 QStringLiteral("easyeda.com"),
                 QStringLiteral("modules.easyeda.com"),
                 QStringLiteral("lceda.cn"),
-                QStringLiteral("easyeda.com"),
             };
         case ResourceType::ProductSearch:
             return {
@@ -28,6 +27,7 @@ QSet<QString> allowedHostsForType(ResourceType type) {
                 QStringLiteral("www.lcsc.com"),
                 QStringLiteral("so.szlcsc.com"),
                 QStringLiteral("item.szlcsc.com"),
+                QStringLiteral("pro.lceda.cn"),
             };
         case ResourceType::PreviewImage:
             return {
@@ -67,6 +67,7 @@ QSet<QString> allowedHostsForType(ResourceType type) {
                 QStringLiteral("www.lcsc.com"),
                 QStringLiteral("so.szlcsc.com"),
                 QStringLiteral("item.szlcsc.com"),
+                QStringLiteral("pro.lceda.cn"),
                 QStringLiteral("image.lceda.cn"),
                 QStringLiteral("file.elecfans.com"),
                 QStringLiteral("alimg.szlcsc.com"),
@@ -168,12 +169,23 @@ bool isAllowedUrl(const QUrl& url, ResourceType resourceType, QString* errorMess
         return false;
     }
 
-    // Unknown 类型不做 host 校验（向后兼容）
+    const QString host = url.host().toLower();
+
+    // Unknown 类型：仅允许已知域名（拒绝未知 host）
     if (resourceType == ResourceType::Unknown) {
+        static const QSet<QString> allKnown =
+            allowedHostsForType(ResourceType::ComponentInfo) + allowedHostsForType(ResourceType::ProductSearch) +
+            allowedHostsForType(ResourceType::PreviewImage) + allowedHostsForType(ResourceType::Datasheet) +
+            allowedHostsForType(ResourceType::Model3DObj) + allowedHostsForType(ResourceType::UpdateCheck) +
+            allowedHostsForType(ResourceType::WorkerRequest);
+        if (!isHostAllowed(host, allKnown)) {
+            if (errorMessage) {
+                *errorMessage = QStringLiteral("URL host '%1' is not in any known allowlist").arg(host);
+            }
+            return false;
+        }
         return true;
     }
-
-    const QString host = url.host().toLower();
     const QSet<QString> allowed = allowedHostsForType(resourceType);
 
     if (allowed.isEmpty()) {

--- a/src/core/utils/UrlUtils.cpp
+++ b/src/core/utils/UrlUtils.cpp
@@ -1,9 +1,106 @@
 #include "core/utils/UrlUtils.h"
 
+#include "core/network/INetworkClient.h"
+
+#include <QSet>
 #include <QString>
 #include <QStringList>
+#include <QUrl>
 
 namespace EasyKiConverter::UrlUtils {
+
+namespace {
+
+// 按 ResourceType 返回允许的 host 集合
+QSet<QString> allowedHostsForType(ResourceType type) {
+    switch (type) {
+        case ResourceType::ComponentInfo:
+        case ResourceType::CadData:
+            return {
+                QStringLiteral("easyeda.com"),
+                QStringLiteral("modules.easyeda.com"),
+                QStringLiteral("lceda.cn"),
+                QStringLiteral("easyeda.com"),
+            };
+        case ResourceType::ProductSearch:
+            return {
+                QStringLiteral("lcsc.com"),
+                QStringLiteral("www.lcsc.com"),
+                QStringLiteral("so.szlcsc.com"),
+                QStringLiteral("item.szlcsc.com"),
+            };
+        case ResourceType::PreviewImage:
+            return {
+                QStringLiteral("image.lceda.cn"),
+                QStringLiteral("file.elecfans.com"),
+                QStringLiteral("alimg.szlcsc.com"),
+                QStringLiteral("www.lcsc.com"),
+                QStringLiteral("lcsc.com"),
+            };
+        case ResourceType::Datasheet:
+            return {
+                QStringLiteral("file.elecfans.com"),
+                QStringLiteral("image.lceda.cn"),
+                QStringLiteral("lcsc.com"),
+                QStringLiteral("www.lcsc.com"),
+            };
+        case ResourceType::Model3DObj:
+        case ResourceType::Model3DStep:
+            return {
+                QStringLiteral("modules.easyeda.com"),
+                QStringLiteral("easyeda.com"),
+                QStringLiteral("lceda.cn"),
+                QStringLiteral("file.elecfans.com"),
+            };
+        case ResourceType::UpdateCheck:
+            return {
+                QStringLiteral("github.com"),
+                QStringLiteral("api.github.com"),
+            };
+        case ResourceType::WorkerRequest:
+            // WorkerRequest 是通用请求，允许所有已知 host
+            return {
+                QStringLiteral("easyeda.com"),
+                QStringLiteral("modules.easyeda.com"),
+                QStringLiteral("lceda.cn"),
+                QStringLiteral("lcsc.com"),
+                QStringLiteral("www.lcsc.com"),
+                QStringLiteral("so.szlcsc.com"),
+                QStringLiteral("item.szlcsc.com"),
+                QStringLiteral("image.lceda.cn"),
+                QStringLiteral("file.elecfans.com"),
+                QStringLiteral("alimg.szlcsc.com"),
+                QStringLiteral("github.com"),
+                QStringLiteral("api.github.com"),
+            };
+        case ResourceType::Unknown:
+        default:
+            return {};
+    }
+}
+
+// 检查 host 是否匹配允许列表（支持子域名匹配）
+bool isHostAllowed(const QString& host, const QSet<QString>& allowedHosts) {
+    if (host.isEmpty()) {
+        return false;
+    }
+
+    // 精确匹配
+    if (allowedHosts.contains(host)) {
+        return true;
+    }
+
+    // 子域名匹配：检查 host 是否以 ".allowedHost" 结尾
+    for (const QString& allowed : allowedHosts) {
+        if (host.endsWith(QLatin1Char('.') + allowed)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}  // namespace
 
 QString normalizePreviewImageUrl(const QString& imageUrl) {
     QString normalizedUrl = imageUrl.trimmed();
@@ -52,6 +149,48 @@ QStringList deduplicateAndNormalizeUrls(const QStringList& imageUrls) {
         }
     }
     return normalizedUrls;
+}
+
+bool isAllowedUrl(const QUrl& url, ResourceType resourceType, QString* errorMessage) {
+    if (!url.isValid()) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("Invalid URL: %1").arg(url.toString());
+        }
+        return false;
+    }
+
+    // 仅允许 https scheme
+    const QString scheme = url.scheme().toLower();
+    if (scheme != QStringLiteral("https")) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("URL scheme must be https, got: %1").arg(scheme);
+        }
+        return false;
+    }
+
+    // Unknown 类型不做 host 校验（向后兼容）
+    if (resourceType == ResourceType::Unknown) {
+        return true;
+    }
+
+    const QString host = url.host().toLower();
+    const QSet<QString> allowed = allowedHostsForType(resourceType);
+
+    if (allowed.isEmpty()) {
+        // 空白名单 = 允许所有（向后兼容）
+        return true;
+    }
+
+    if (!isHostAllowed(host, allowed)) {
+        if (errorMessage) {
+            *errorMessage = QStringLiteral("URL host '%1' is not allowed for resource type %2")
+                                .arg(host)
+                                .arg(static_cast<int>(resourceType));
+        }
+        return false;
+    }
+
+    return true;
 }
 
 }  // namespace EasyKiConverter::UrlUtils

--- a/src/core/utils/UrlUtils.h
+++ b/src/core/utils/UrlUtils.h
@@ -1,9 +1,16 @@
 #pragma once
 
+#include <QSet>
 #include <QString>
 #include <QStringList>
 
-namespace EasyKiConverter::UrlUtils {
+class QUrl;
+
+namespace EasyKiConverter {
+
+enum class ResourceType;
+
+namespace UrlUtils {
 
 /**
  * @brief 标准化预览图 URL
@@ -26,4 +33,18 @@ QString normalizePreviewImageUrl(const QString& imageUrl);
  */
 QStringList deduplicateAndNormalizeUrls(const QStringList& imageUrls);
 
-}  // namespace EasyKiConverter::UrlUtils
+/**
+ * @brief 验证 URL 是否在允许的白名单内
+ *
+ * 检查 URL 的 scheme（仅允许 https）和 host（按 ResourceType 限制）。
+ * 用于在 NetworkClient 发送请求前统一校验，防止访问非预期主机。
+ *
+ * @param url 要验证的 URL
+ * @param resourceType 资源类型，用于确定允许的 host 集合
+ * @param errorMessage 输出参数，校验失败时的错误信息
+ * @return 如果 URL 合法则返回 true
+ */
+bool isAllowedUrl(const QUrl& url, ResourceType resourceType, QString* errorMessage = nullptr);
+
+}  // namespace UrlUtils
+}  // namespace EasyKiConverter

--- a/src/services/ComponentCacheService.cpp
+++ b/src/services/ComponentCacheService.cpp
@@ -5,6 +5,7 @@
 #include "ConfigService.h"
 #include "core/network/NetworkClient.h"
 #include "core/utils/UrlUtils.h"
+#include "services/BomParser.h"
 #include "services/ComponentService.h"
 #include "utils/logging/LogMacros.h"
 
@@ -15,6 +16,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QRegularExpression>
 #include <QSaveFile>
 #include <QSet>
 #include <QUrl>
@@ -194,6 +196,10 @@ QString ComponentCacheService::cacheDir() const {
 QString ComponentCacheService::componentCacheDir(const QString& lcscId) const {
     // 注意：这里不再加锁，因为只是构建路径字符串
     // m_cacheDir 在初始化时设置，之后只读，不需要互斥保护
+    if (!BomParser::validateId(lcscId)) {
+        qWarning() << "componentCacheDir: invalid lcscId, rejecting:" << lcscId;
+        return QString();
+    }
     return QDir::cleanPath(m_cacheDir + "/" + lcscId);
 }
 
@@ -203,6 +209,9 @@ QString ComponentCacheService::ensureComponentDir(const QString& lcscId) const {
     // 2. dir.mkpath 是线程安全的
     // 3. savePreviewImage 已经在持有 m_mutex 的情况下调用此函数
     QString dirPath = componentCacheDir(lcscId);
+    if (dirPath.isEmpty()) {
+        return QString();
+    }
     QDir dir(dirPath);
     if (!dir.exists()) {
         dir.mkpath(dirPath);
@@ -1306,18 +1315,42 @@ QDateTime ComponentCacheService::getCacheAccessTime(const QString& lcscId) const
 }
 
 QString ComponentCacheService::metadataPath(const QString& lcscId) const {
-    return componentCacheDir(lcscId) + "/component.json";
+    const QString dir = componentCacheDir(lcscId);
+    if (dir.isEmpty()) {
+        return QString();
+    }
+    return dir + "/component.json";
 }
 
 QString ComponentCacheService::previewImagePath(const QString& lcscId, int index) const {
-    return componentCacheDir(lcscId) + "/preview_" + QString::number(index) + ".jpg";
+    const QString dir = componentCacheDir(lcscId);
+    if (dir.isEmpty()) {
+        return QString();
+    }
+    return dir + "/preview_" + QString::number(index) + ".jpg";
 }
 
 QString ComponentCacheService::datasheetPath(const QString& lcscId) const {
-    return componentCacheDir(lcscId) + "/datasheet";
+    const QString dir = componentCacheDir(lcscId);
+    if (dir.isEmpty()) {
+        return QString();
+    }
+    return dir + "/datasheet";
 }
 
 QString ComponentCacheService::model3DPath(const QString& uuid, const QString& extension) const {
+    // 严格校验 uuid 格式：仅允许字母、数字、下划线、短横线，防止路径穿越
+    static const QRegularExpression uuidRe(QStringLiteral("^[A-Za-z0-9_-]+$"));
+    if (uuid.isEmpty() || !uuidRe.match(uuid).hasMatch()) {
+        qWarning() << "model3DPath: invalid uuid, rejecting:" << uuid;
+        return QString();
+    }
+    // 校验 extension：仅允许字母数字
+    static const QRegularExpression extRe(QStringLiteral("^[A-Za-z0-9]+$"));
+    if (extension.isEmpty() || !extRe.match(extension).hasMatch()) {
+        qWarning() << "model3DPath: invalid extension, rejecting:" << extension;
+        return QString();
+    }
     return m_cacheDir + "/model3d/" + uuid + "." + extension;
 }
 

--- a/src/services/ComponentCacheService.cpp
+++ b/src/services/ComponentCacheService.cpp
@@ -460,7 +460,9 @@ void ComponentCacheService::saveSymbolData(const QString& lcscId, const QByteArr
     QString symbolPath;
     {
         QMutexLocker locker(&m_mutex);
-        ensureComponentDir(lcscId);
+        if (ensureComponentDir(lcscId).isEmpty()) {
+            return;
+        }
         symbolPath = componentCacheDir(lcscId) + "/symbol.json";
     }
 
@@ -506,7 +508,9 @@ void ComponentCacheService::saveFootprintData(const QString& lcscId, const QByte
     QString footprintPath;
     {
         QMutexLocker locker(&m_mutex);
-        ensureComponentDir(lcscId);
+        if (ensureComponentDir(lcscId).isEmpty()) {
+            return;
+        }
         footprintPath = componentCacheDir(lcscId) + "/footprint.json";
     }
 
@@ -552,7 +556,9 @@ void ComponentCacheService::saveCadDataJson(const QString& lcscId, const QByteAr
     QString cadDataPath;
     {
         QMutexLocker locker(&m_mutex);
-        ensureComponentDir(lcscId);
+        if (ensureComponentDir(lcscId).isEmpty()) {
+            return;
+        }
         cadDataPath = componentCacheDir(lcscId) + "/cad_data.json";
     }
 
@@ -673,7 +679,9 @@ void ComponentCacheService::savePreviewImage(const QString& lcscId, const QByteA
     QString previewPath;
     {
         QMutexLocker locker(&m_mutex);
-        ensureComponentDir(lcscId);
+        if (ensureComponentDir(lcscId).isEmpty()) {
+            return;
+        }
         previewPath = previewImagePath(lcscId, imageIndex);
     }
 
@@ -794,7 +802,9 @@ void ComponentCacheService::saveDatasheet(const QString& lcscId,
     QString actualPath;
     {
         QMutexLocker locker(&m_mutex);
-        ensureComponentDir(lcscId);
+        if (ensureComponentDir(lcscId).isEmpty()) {
+            return;
+        }
         actualPath = resolveDatasheetPath(lcscId, format, true);
         const QString alternatePath = actualPath.endsWith(".pdf")
                                           ? resolveDatasheetPath(lcscId, QStringLiteral("html"), true)
@@ -942,6 +952,9 @@ void ComponentCacheService::saveModel3D(const QString& uuid, const QByteArray& d
         QMutexLocker locker(&m_mutex);
         ensureModel3DCacheDir();
         path = model3DPath(uuid, extension);
+        if (path.isEmpty()) {
+            return;
+        }
     }
 
     if (writeFileAtomically(path, data)) {
@@ -995,6 +1008,9 @@ bool ComponentCacheService::copyModel3DToFile(const QString& uuid,
 void ComponentCacheService::removeCache(const QString& lcscId) {
     // 先删除L2磁盘缓存（不需要锁）
     QString dirPath = componentCacheDir(lcscId);
+    if (dirPath.isEmpty()) {
+        return;
+    }
     {
         QDir dir(dirPath);
         if (dir.exists()) {
@@ -1191,7 +1207,9 @@ QJsonObject ComponentCacheService::loadMetadata(const QString& lcscId) const {
 }
 
 void ComponentCacheService::saveMetadata(const QString& lcscId, const QJsonObject& metadata) {
-    ensureComponentDir(lcscId);
+    if (ensureComponentDir(lcscId).isEmpty()) {
+        return;
+    }
     QString metaPath = metadataPath(lcscId);
     QJsonDocument doc(metadata);
     if (!writeFileAtomically(metaPath, doc.toJson(QJsonDocument::Indented))) {

--- a/src/ui/viewmodels/ExportSettingsViewModel.cpp
+++ b/src/ui/viewmodels/ExportSettingsViewModel.cpp
@@ -10,6 +10,7 @@
 #include "services/ComponentCacheService.h"
 #include "services/export/ParallelExportService.h"
 #include "utils/FileUtils.h"
+#include "utils/PathSecurity.h"
 
 #include <QCoreApplication>
 #include <QDebug>
@@ -90,9 +91,11 @@ void ExportSettingsViewModel::setOutputPath(const QString& path) {
 }
 
 void ExportSettingsViewModel::setLibName(const QString& name) {
-    if (m_libName != name) {
-        m_libName = name;
-        m_configService->setLibName(name);
+    // 清洗 libName，防止路径穿越（如 ../foo）和非法字符
+    const QString safeName = PathSecurity::sanitizeFilename(name);
+    if (m_libName != safeName) {
+        m_libName = safeName;
+        m_configService->setLibName(safeName);
         emit libNameChanged();
     }
 }
@@ -466,7 +469,7 @@ void ExportSettingsViewModel::loadFromConfig() {
     const int oldDiskCacheLimitMB = m_diskCacheLimitMB;
 
     m_outputPath = m_configService->getOutputPath();
-    m_libName = m_configService->getLibName();
+    m_libName = PathSecurity::sanitizeFilename(m_configService->getLibName());
     m_exportSymbol = m_configService->getExportSymbol();
     m_exportFootprint = m_configService->getExportFootprint();
     m_exportModel3D = m_configService->getExportModel3D();

--- a/src/utils/PathSecurity.cpp
+++ b/src/utils/PathSecurity.cpp
@@ -89,6 +89,91 @@ bool PathSecurity::isSafePath(const QString& fullPath, const QString& baseDir) {
     return isSafe;
 }
 
+bool PathSecurity::isSafePathCanonical(const QString& fullPath, const QString& baseDir) {
+    if (fullPath.isEmpty() || baseDir.isEmpty()) {
+        qWarning() << "isSafePathCanonical: received empty path";
+        return false;
+    }
+
+    const QString canonBase = canonicalizePath(baseDir);
+    const QString canonTarget = canonicalizePath(fullPath);
+
+    if (canonBase.isEmpty() || canonTarget.isEmpty()) {
+        qWarning() << "isSafePathCanonical: failed to canonicalize paths";
+        return false;
+    }
+
+    // 确保基准路径以 '/' 结尾
+    QString normalizedBase = canonBase;
+    if (!normalizedBase.endsWith('/')) {
+        normalizedBase += '/';
+    }
+
+    // 允许目标等于基准
+    QString targetNoSlash = canonTarget;
+    while (targetNoSlash.endsWith('/'))
+        targetNoSlash.chop(1);
+
+    if (targetNoSlash + '/' == normalizedBase) {
+        return true;
+    }
+    if (targetNoSlash.compare(normalizedBase.left(normalizedBase.length() - 1), Qt::CaseInsensitive) == 0) {
+        return true;
+    }
+
+    bool isSafe = canonTarget.startsWith(normalizedBase, Qt::CaseInsensitive);
+
+    if (!isSafe) {
+        qWarning() << "isSafePathCanonical: path is outside base directory";
+        qWarning() << "  Target (canonical):" << canonTarget;
+        qWarning() << "  Base   (canonical):" << normalizedBase;
+        qWarning() << "  Raw Target:" << fullPath;
+        qWarning() << "  Raw Base:  " << baseDir;
+    }
+
+    return isSafe;
+}
+
+QString PathSecurity::canonicalizePath(const QString& path) {
+    QFileInfo info(path);
+
+    // 如果路径存在，直接用 canonicalFilePath（解析符号链接）
+    if (info.exists()) {
+        QString canonical = info.canonicalFilePath();
+        if (!canonical.isEmpty()) {
+            return QDir::fromNativeSeparators(canonical);
+        }
+    }
+
+    // 路径不存在：找到最近存在的父目录，对其 canonicalize，再拼接剩余部分
+    QString remaining;
+    QString current = QDir::cleanPath(path);
+
+    // 逐级向上查找存在的父目录
+    while (!QFileInfo::exists(current)) {
+        QDir parent = QDir(current);
+        if (!parent.cdUp()) {
+            // 到达根目录仍不存在，回退到 cleanPath
+            return QDir::fromNativeSeparators(QDir::cleanPath(path));
+        }
+        QString childName = QDir(current).dirName();
+        remaining = remaining.isEmpty() ? childName : (childName + "/" + remaining);
+        current = parent.path();
+    }
+
+    // current 现在是存在的路径，对其 canonicalize
+    QFileInfo currentInfo(current);
+    QString canonCurrent = currentInfo.canonicalFilePath();
+    if (canonCurrent.isEmpty()) {
+        canonCurrent = QDir::cleanPath(current);
+    }
+
+    if (remaining.isEmpty()) {
+        return QDir::fromNativeSeparators(canonCurrent);
+    }
+    return QDir::fromNativeSeparators(canonCurrent + "/" + remaining);
+}
+
 QString PathSecurity::sanitizeFilename(const QString& name) {
     QString safeName = name;
 

--- a/src/utils/PathSecurity.h
+++ b/src/utils/PathSecurity.h
@@ -16,12 +16,28 @@ public:
     static bool isValidPathComponent(const QString& name);
 
     /**
-     * @brief 验证目标路径是否在基准目录内
+     * @brief 轻量路径安全检查（字符串前缀比较）
+     *
+     * 适用于 UI 层的快速校验。不解析符号链接，不保证防逃逸。
+     * 写入/删除操作请使用 isSafePathCanonical()。
+     *
      * @param fullPath 目标完整路径
      * @param baseDir 基准目录路径
      * @return 如果安全则返回 true
      */
     static bool isSafePath(const QString& fullPath, const QString& baseDir);
+
+    /**
+     * @brief 强路径安全检查（使用 canonical path）
+     *
+     * 解析符号链接后再做前缀比较，可防止符号链接逃逸。
+     * 适用于写入/删除前的最终校验。要求目标路径或其最近存在父目录已存在。
+     *
+     * @param fullPath 目标完整路径
+     * @param baseDir 基准目录路径
+     * @return 如果安全则返回 true
+     */
+    static bool isSafePathCanonical(const QString& fullPath, const QString& baseDir);
 
     /**
      * @brief 安全递归删除目录
@@ -41,6 +57,13 @@ public:
 private:
     // 参数顺序优化：将常用变动参数放在前面，或者保持默认值在后
     static int countFilesRecursively(const QString& path, int limit, int currentCount = 0);
+
+    /**
+     * @brief 获取路径的 canonical 形式（解析符号链接）
+     * @param path 输入路径
+     * @return canonical 路径，如果路径不存在则回退到 cleanPath
+     */
+    static QString canonicalizePath(const QString& path);
 };
 
 }  // namespace EasyKiConverter

--- a/src/utils/cli/CliContext.cpp
+++ b/src/utils/cli/CliContext.cpp
@@ -2,6 +2,7 @@
 
 #include "services/ComponentService.h"
 #include "services/export/ParallelExportService.h"
+#include "utils/PathSecurity.h"
 
 namespace EasyKiConverter {
 
@@ -37,7 +38,8 @@ ExportOptions CliContext::createExportOptions() const {
 
     // 设置输出路径
     options.outputPath = m_parser.outputDir();
-    options.libName = m_parser.libName();
+    // 清洗 libName，防止路径穿越（如 ../foo）
+    options.libName = PathSecurity::sanitizeFilename(m_parser.libName());
 
     // 设置导出类型（CLI 默认：符号库、封装库；3D 模型通过参数启用）
     options.exportSymbol = m_parser.exportSymbol();

--- a/src/utils/cli/ComponentConverter.cpp
+++ b/src/utils/cli/ComponentConverter.cpp
@@ -1,6 +1,7 @@
 #include "ComponentConverter.h"
 
 #include "CliContext.h"
+#include "services/BomParser.h"
 #include "services/ComponentService.h"
 #include "services/export/ParallelExportService.h"
 
@@ -17,6 +18,11 @@ bool ComponentConverter::execute() {
     QString componentId = context()->parser().componentId();
     if (componentId.isEmpty()) {
         setError(QCoreApplication::translate("CliConverter", "未指定元器件编号"));
+        return false;
+    }
+
+    if (!BomParser::validateId(componentId)) {
+        setError(QCoreApplication::translate("CliConverter", "元器件编号格式无效: %1").arg(componentId));
         return false;
     }
 

--- a/src/utils/cli/FileReader.cpp
+++ b/src/utils/cli/FileReader.cpp
@@ -7,6 +7,12 @@
 #include <QFileInfo>
 #include <QTextStream>
 
+namespace {
+bool isValidComponentId(const QString& id) {
+    return EasyKiConverter::BomParser::validateId(id);
+}
+}  // namespace
+
 namespace EasyKiConverter {
 
 QStringList FileReader::readBomFile(const QString& filePath, QString& errorMessage) {
@@ -46,7 +52,11 @@ QStringList FileReader::readComponentListFile(const QString& filePath, QString& 
     while (!stream.atEnd()) {
         QString line = stream.readLine().trimmed();
         if (!line.isEmpty()) {
-            componentIds.append(line);
+            if (isValidComponentId(line)) {
+                componentIds.append(line.toUpper());
+            } else {
+                qWarning() << "FileReader: skipping invalid component ID:" << line;
+            }
         }
     }
 

--- a/src/workers/FetchWorker.cpp
+++ b/src/workers/FetchWorker.cpp
@@ -317,6 +317,13 @@ QByteArray FetchWorker::httpGet(const QString& url,
         return QByteArray();
     }
 
+    // 白名单拒绝等场景：request 已完成，直接返回结果，避免阻塞等待
+    if (request->isFinished()) {
+        const NetworkResult result = request->result();
+        delete request;
+        return finishResult(result);
+    }
+
     {
         QMutexLocker locker(&m_replyMutex);
         m_currentRequest = request;

--- a/src/workers/NetworkWorker.cpp
+++ b/src/workers/NetworkWorker.cpp
@@ -182,6 +182,26 @@ bool NetworkWorker::executeRequest(const QUrl& url,
         return false;
     }
 
+    // 白名单拒绝等场景：request 已完成，直接返回结果，避免阻塞等待
+    if (request->isFinished()) {
+        const NetworkResult doneResult = request->result();
+        delete request;
+        if (doneResult.wasCancelled) {
+            errorMsg = "Request cancelled";
+            return false;
+        }
+        if (!doneResult.success) {
+            errorMsg =
+                doneResult.error.isEmpty()
+                    ? QString("Network error for %1 after %2 retries").arg(url.toString()).arg(doneResult.retryCount)
+                    : doneResult.error;
+            qWarning() << "NetworkWorker:" << errorMsg << "for:" << m_componentId;
+            return false;
+        }
+        outData = doneResult.data;
+        return true;
+    }
+
     {
         QMutexLocker locker(&m_mutex);
         m_currentRequest = request;

--- a/tests/unit/test_network_client.cpp
+++ b/tests/unit/test_network_client.cpp
@@ -393,10 +393,17 @@ private slots:
 
         AsyncNetworkRequest* request = AsyncNetworkRequest::createFinished(expected);
 
+        // isFinished() 和 result() 应立即可用（同步设置状态）
         QVERIFY(request->isFinished());
         QVERIFY(!request->isCancelled());
         QCOMPARE(request->result().data, QByteArray("test data"));
         QCOMPARE(request->result().statusCode, 200);
+
+        // finished 信号通过 QTimer::singleShot(0) 延迟发射
+        // 先 connect 再等待事件循环处理
+        QSignalSpy spy(request, &AsyncNetworkRequest::finished);
+        QVERIFY(spy.wait(1000));
+        QCOMPARE(spy.count(), 1);
 
         request->deleteLater();
     }
@@ -426,12 +433,55 @@ private slots:
         cancelled.wasCancelled = true;
         cancelled.error = QStringLiteral("Cancelled");
 
+        // 先 connect 再创建，确保能收到延迟信号
         AsyncNetworkRequest* request = AsyncNetworkRequest::createFinished(cancelled);
+        QSignalSpy spy(request, &AsyncNetworkRequest::finished);
 
+        // isFinished() 和 result() 应立即可用（同步设置状态）
         QVERIFY(request->isFinished());
         QVERIFY(request->isCancelled());
         QVERIFY(request->result().wasCancelled);
         QVERIFY(!request->result().success);
+
+        // finished 信号通过 QTimer::singleShot(0) 延迟发射
+        QVERIFY(spy.wait(1000));
+        QCOMPARE(spy.count(), 1);
+
+        request->deleteLater();
+    }
+
+    void testSyncGet_RejectedByWhitelist_ReturnsQuickly() {
+        // 同步 get() 被白名单拒绝时应立即返回失败，不应死锁
+        QElapsedTimer timer;
+        timer.start();
+
+        NetworkResult result =
+            NetworkClient::instance().get(QUrl("https://evil.example/x"), ResourceType::PreviewImage);
+
+        qint64 elapsed = timer.elapsed();
+
+        QVERIFY(!result.success);
+        QVERIFY(result.error.contains("not allowed") || result.error.contains("not in any known allowlist"));
+        QVERIFY(elapsed < 2000);  // 应在 2 秒内返回，而非超时等待
+    }
+
+    void testAsyncGet_RejectedByWhitelist_EmitsFinished() {
+        // 异步 getAsync() 被白名单拒绝时应发出 finished 信号
+        AsyncNetworkRequest* request =
+            NetworkClient::instance().getAsync(QUrl("https://evil.example/x"), ResourceType::PreviewImage);
+
+        QVERIFY(request != nullptr);
+
+        // isFinished() 应立即可用（同步设置状态）
+        QVERIFY(request->isFinished());
+        QVERIFY(!request->result().success);
+        QVERIFY(request->result().error.contains("not allowed") ||
+                request->result().error.contains("not in any known allowlist"));
+
+        // finished 信号通过 QTimer::singleShot(0) 延迟发射
+        QSignalSpy spy(request, &AsyncNetworkRequest::finished);
+        QVERIFY(spy.wait(3000));
+        QCOMPARE(spy.count(), 1);
 
         request->deleteLater();
     }


### PR DESCRIPTION
描述:

  基于静态安全审查结论，修复 URL/路径边界缺失和资源大小限制不足的安全风险，覆盖网络层、缓存服务、导出流水线和 CLI
  模块。

  主要变更

  1. URL 白名单校验

  - NetworkClient::enqueueAsyncRequest() 入口统一校验：仅允许 https scheme
  - 按 ResourceType 限制 host 白名单（easyeda.com、image.lceda.cn、lcsc.com、github.com 等）
  - 重定向后在 AsyncNetworkRequest::processResponse() 中重新校验最终 URL
  - 设置 NoLessSafeRedirectPolicy 防止 HTTPS→HTTP 降级
  - ResourceType::Unknown 改为校验所有已知域名的并集，不再完全绕过

  2. 缓存路径穿越防护

  - ComponentCacheService::componentCacheDir() 使用 BomParser::validateId() 校验 lcscId
  - model3DPath() 使用严格正则 ^[A-Za-z0-9_-]+$ 校验 uuid 和 extension
  - 所有 save*() 方法添加空路径检查，防止误操作当前目录
  - CLI 单组件/批量入口强制 BomParser::validateId() 校验

  3. libName 路径安全校验

  - GUI 和 CLI 入口统一使用 PathSecurity::sanitizeFilename() 清洗 libName
  - 阻止 ../foo 类路径穿越写到输出目录外

  4. 网络响应大小限制

  - 每类资源定义 maxResponseBytes：JSON 20MB、图片 10MB、PDF/3D 200MB、GitHub API 5MB
  - 下载中通过 downloadProgress 信号实时检查，超限立即 abort
  - readAll() 后兜底检查（Content-Length 缺失时）
  - Gzip 解压增加 500MB 上限和 100:1 压缩比阈值，防止解压炸弹
  - 解压后重新按 maxResponseBytes 校验

  5. PathSecurity 强校验 API

  - 新增 isSafePathCanonical()：使用 canonical path 解析符号链接后再做前缀比较
  - 新增 canonicalizePath()：逐级向上查找最近存在父目录做 canonical 化
  - 保留原有 isSafePath() 用于轻量 UI 检查

  6. 网络请求完成机制修复

  - executeRequest() 同步路径在创建 request 前做 URL 校验，失败直接返回 NetworkResult
  - createFinished() 同步设置 isFinished() + result()，finished 信号通过 QTimer::singleShot(0) 延迟发射
  - FetchWorker / NetworkWorker 阻塞路径添加 isFinished() 快速返回检查