### PR TITLE
fix(export): 修复3D模型偏移对齐问题，新增CLI数据手册导出支持

### DIFF
--- a/docs/developer/FAQ.md
+++ b/docs/developer/FAQ.md
@@ -479,7 +479,7 @@ EasyEDA API -> FootprintData.model3D().name() = "C0603_L1.6-W0.8-H0.8"
 - `src/utils/CommandLineParser.h` - 添加 `m_datasheetOption` 和 `exportDatasheet()` 方法
 - `src/utils/CommandLineParser.cpp` - 添加 `--datasheet` 选项定义、解析和帮助文本
 - `src/utils/cli/CliContext.cpp` - `exportDatasheet` 使用 parser 值
-- `src/core/utils/UrlUtils.cpp` - Datasheet 白名单添加 `item.szlcsc.com`
+- `src/core/utils/UrlUtils.cpp` - Datasheet 白名单添加 `item.szlcsc.com`、`atta.szlcsc.com`、`www.ti.com`、`www.everlighteurope.com`
 
 **状态**：✅ 已修复 (2026-05-27)
 

--- a/docs/developer/FAQ.md
+++ b/docs/developer/FAQ.md
@@ -447,6 +447,40 @@ EasyEDA API -> FootprintData.model3D().name() = "C0603_L1.6-W0.8-H0.8"
 
 ---
 
+## 数据手册相关
+
+### Q: CLI 模式下数据手册导出全部失败
+
+**问题描述**：
+使用 CLI 模式 `convert bom --datasheet` 导出数据手册时，所有组件全部失败（Success: 0, Failed: 58）。
+
+**根本原因**：
+两个独立问题共同导致：
+
+1. **CLI 模式未启用数据手册导出**：`CliContext.cpp` 硬编码 `options.exportDatasheet = false`，且没有 `--datasheet` CLI 选项。用户无法通过命令行启用数据手册导出。
+
+2. **URL 白名单缺少 `item.szlcsc.com`**：LCSC 数据手册 URL 使用 `item.szlcsc.com` 域名（如 `https://item.szlcsc.com/datasheet/xxx.html`），但 `UrlUtils.cpp` 的 `ResourceType::Datasheet` 白名单中没有该域名。NetworkClient 安全检查拒绝请求，报错：`URL host 'item.szlcsc.com' is not allowed for resource type 4`。
+
+**修复方案**：
+1. 在 `CommandLineParser` 中添加 `--datasheet` CLI 选项（flag 类型，默认 false）
+2. 在 `CliContext.cpp` 中使用 `m_parser.exportDatasheet()` 替代硬编码的 `false`
+3. 在 `UrlUtils.cpp` 的 `ResourceType::Datasheet` 白名单中添加 `item.szlcsc.com`
+
+**回归预防**：
+- 新增 ResourceType 或修改 URL 白名单时，必须验证实际 API 返回的 URL 域名
+- CLI 新增导出选项时，必须同步更新：`CommandLineParser.h`（声明）、`CommandLineParser.cpp`（定义+帮助文本）、`CliContext.cpp`（传递到 ExportOptions）
+- 数据手册 URL 可能来自多个域名（`item.szlcsc.com`、`file.elecfans.com`、`www.lcsc.com` 等），白名单需覆盖所有实际使用的域名
+
+**相关文件**：
+- `src/utils/CommandLineParser.h` - 添加 `m_datasheetOption` 和 `exportDatasheet()` 方法
+- `src/utils/CommandLineParser.cpp` - 添加 `--datasheet` 选项定义、解析和帮助文本
+- `src/utils/cli/CliContext.cpp` - `exportDatasheet` 使用 parser 值
+- `src/core/utils/UrlUtils.cpp` - Datasheet 白名单添加 `item.szlcsc.com`
+
+**状态**：✅ 已修复 (2026-05-27)
+
+---
+
 ## 网络相关
 
 ### Q: 在弱网络环境下导出失败率很高

--- a/docs/developer/FAQ.md
+++ b/docs/developer/FAQ.md
@@ -353,6 +353,59 @@
 
 ---
 
+### Q: 3D 模型（WRL/STEP）与封装焊盘位置不对齐
+
+**问题描述**：
+导出的 3D 模型在 KiCad 中与封装焊盘存在位置偏移：
+- WRL 和 STEP 的 XY 偏移不一致
+- 部分组件 Z 轴高度不对齐
+- 多个组件共享同一封装但 3D 模型参数不一致时，偏移更明显
+
+**根本原因**：
+WRL 和 STEP 使用不同的坐标系，但旧代码用同一套公式计算偏移：
+
+1. **WRL XY 偏移错误**：WRL 模型经 OBJ→WRL 转换后已居中到原点 (0,0)，但旧代码使用 `modelTranslation - bboxCenter` 计算偏移，而 `modelTranslation` 来自 `normalizeModelOrigin()` 的启发式判断，对部分组件返回错误值。
+
+2. **STEP XY 偏移叠加错误**：旧代码将 WRL 偏移与 `stepOffsetMm` 相加（`finalOffsetX += stepOffset.x`），但 STEP 使用绝对坐标系，应独立计算。
+
+3. **THT Z 轴强制归零**：旧代码对 THT（通孔）封装强制 `z = 0.0`，忽略了模型的实际 Z 偏移。
+
+4. **UUID 解析优先级错误**：`CadDataLoader` 优先使用 SVGNODE 的 `attrs.uuid`（outline 形状 UUID），而非 `head.uuid_3d`（EasyEDA API 3D 模型端点使用的规范 UUID）。两者可能不同。
+
+**修复方案**：
+
+1. **WRL XY = (0, 0)**：WRL 模型已居中，偏移应为零。
+2. **STEP XY = stepOffsetMm**：STEP 使用独立坐标系，偏移来自 `-stepGeometryCenter`。
+3. **统一 Z 轴处理**：移除 THT 强制归零，所有封装统一使用 `-translation.z`。
+4. **UUID 优先级**：`head.uuid_3d` 优先于 SVGNODE `attrs.uuid`。
+5. **两遍 UUID 匹配**：`readModelSourceZMm` 先精确匹配 UUID，再匹配 `outline3D` SVGNODE。
+
+**关键数据**：
+```
+修复前（CONN-SMD_6P）：WRL=(0.000, -0.100), STEP=(-10.800, -1.380)  ← 不一致
+修复后（CONN-SMD_6P）：WRL=(0.000, 0.000),  STEP=(-10.800, -1.280)  ← WRL 正确
+
+修复前（C0603）：WRL_Z=0.160, STEP_Z=0.403  ← 不一致
+修复后（C0603）：WRL_Z=0.400, STEP_Z=0.400  ← 一致
+```
+
+**回归预防**：
+- WRL 和 STEP 必须视为两个独立坐标系，分别计算偏移
+- 修改 `FootprintGraphicsGenerator::generateModel3D()` 时，必须区分 WRL（居中）和 STEP（绝对坐标）
+- 修改 UUID 解析逻辑时，必须验证 `head.uuid_3d` 和 SVGNODE `attrs.uuid` 不一致的情况
+- 修改 `normalizeModelOrigin()` 时，必须验证：绝对坐标（4000,3000）、相对坐标（1.5,-2）、异常值（400,300）三种场景
+
+**相关文件**：
+- `src/core/kicad/FootprintGraphicsGenerator.cpp` - WRL/STEP 偏移计算
+- `src/services/CadDataLoader.cpp` - UUID 优先级
+- `src/services/export/FootprintExportStage.cpp` - STEP 偏移计算、UUID 使用、readModelSourceZMm
+- `src/core/easyeda/EasyedaFootprintImporter.cpp` - normalizeModelOrigin 启发式
+- `tests/golden/kicad/golden_footprint_with_3d.kicad_mod` - 金色测试期望值
+
+**状态**：✅ 已修复 (2026-05-27)
+
+---
+
 ### Q: 导出的 3D 模型文件名与封装内记录的 3D 模型路径不一致
 
 **问题描述**：
@@ -678,6 +731,8 @@ DelegateModel {
 - [ ] 有缓存时导出 3D 模型不发起网络请求（STEP 缓存优先）
 - [ ] 重试失败元器件后，导出的库中同时包含已成功项和重试项
 - [ ] 重试失败组件后，已有封装/符号未丢失
+- [ ] 3D 模型 WRL/STEP 与封装焊盘对齐（XY 偏移、Z 轴高度一致）
+- [ ] 3D 模型 UUID 使用 head.uuid_3d 优先（非 SVGNODE attrs.uuid）
 
 ---
 

--- a/docs/developer/FAQ.md
+++ b/docs/developer/FAQ.md
@@ -459,7 +459,11 @@ EasyEDA API -> FootprintData.model3D().name() = "C0603_L1.6-W0.8-H0.8"
 
 1. **CLI 模式未启用数据手册导出**：`CliContext.cpp` 硬编码 `options.exportDatasheet = false`，且没有 `--datasheet` CLI 选项。用户无法通过命令行启用数据手册导出。
 
-2. **URL 白名单缺少 `item.szlcsc.com`**：LCSC 数据手册 URL 使用 `item.szlcsc.com` 域名（如 `https://item.szlcsc.com/datasheet/xxx.html`），但 `UrlUtils.cpp` 的 `ResourceType::Datasheet` 白名单中没有该域名。NetworkClient 安全检查拒绝请求，报错：`URL host 'item.szlcsc.com' is not allowed for resource type 4`。
+2. **URL 白名单缺少多个域名**：LCSC 数据手册 URL 来自多个域名，但 `UrlUtils.cpp` 的 `ResourceType::Datasheet` 白名单中缺少以下域名，NetworkClient 安全检查拒绝请求：
+   - `item.szlcsc.com` — LCSC 数据手册页面（HTML 格式）
+   - `atta.szlcsc.com` — LCSC 附件服务器（PDF 格式）
+   - `www.ti.com` — Texas Instruments 官网数据手册
+   - `www.everlighteurope.com` — Everlight Europe 官网数据手册
 
 **修复方案**：
 1. 在 `CommandLineParser` 中添加 `--datasheet` CLI 选项（flag 类型，默认 false）
@@ -767,6 +771,8 @@ DelegateModel {
 - [ ] 重试失败组件后，已有封装/符号未丢失
 - [ ] 3D 模型 WRL/STEP 与封装焊盘对齐（XY 偏移、Z 轴高度一致）
 - [ ] 3D 模型 UUID 使用 head.uuid_3d 优先（非 SVGNODE attrs.uuid）
+- [ ] CLI 模式 `--datasheet` 选项可用，数据手册导出成功
+- [ ] 数据手册 URL 白名单覆盖所有实际域名（item.szlcsc.com、atta.szlcsc.com、www.ti.com 等）
 
 ---
 

--- a/src/core/kicad/FootprintGraphicsGenerator.cpp
+++ b/src/core/kicad/FootprintGraphicsGenerator.cpp
@@ -488,13 +488,7 @@ QString FootprintGraphicsGenerator::generateModel3D(const Model3DData& model3D,
     QString finalPath = model3DPath.isEmpty() ? model3D.name() : model3DPath;
 
     double z = pxToMmRounded(model3D.translation().z);
-
-    if (fpType == "smd") {
-        z = -z;
-
-    } else {
-        z = 0.0;
-    }
+    z = -z;
 
     double rotX = (360.0 - model3D.rotation().x);
     // 使用 fmod 替代 while 循环，避免死循环风险
@@ -517,23 +511,21 @@ QString FootprintGraphicsGenerator::generateModel3D(const Model3DData& model3D,
         rotZ += 360.0;
     }
 
-    // translation 在解析阶段已经统一为 EasyEDA 绝对坐标。
-    const double offsetX = model3D.translation().x - bboxX;
-    const double offsetY = model3D.translation().y - bboxY;
-    double finalOffsetX = pxToMmRounded(offsetX);
-    double finalOffsetY = -pxToMmRounded(offsetY);
-    constexpr double MAX_REASONABLE_MODEL_OFFSET_MM = 50.0;
-    if (qAbs(finalOffsetX) > MAX_REASONABLE_MODEL_OFFSET_MM || qAbs(finalOffsetY) > MAX_REASONABLE_MODEL_OFFSET_MM) {
-        finalOffsetX = 0.0;
-        finalOffsetY = 0.0;
-    }
+    // OBJ→WRL 转换已将模型居中到原点，WRL 几何中心 = (0,0)。
+    // STEP 文件保持原始绝对坐标，几何中心通过 stepOffsetMm 记录。
+    // XY: 两者都需要将几何中心对齐到封装原点。
+    // Z: WRL 使用 API translation.z（已居中），STEP 需要额外的 stepOffset.z 补偿坐标差异。
+    double finalOffsetX = 0.0;
+    double finalOffsetY = 0.0;
 
     if (finalPath.endsWith(QStringLiteral(".step"), Qt::CaseInsensitive) ||
         finalPath.endsWith(QStringLiteral(".stp"), Qt::CaseInsensitive)) {
-        finalOffsetX += model3D.stepOffsetMm().x;
-        finalOffsetY += model3D.stepOffsetMm().y;
+        finalOffsetX = model3D.stepOffsetMm().x;
+        finalOffsetY = model3D.stepOffsetMm().y;
         z += model3D.stepOffsetMm().z;
     }
+    // WRL: z 来自 API translation.z（已在 FootprintExportStage 中通过 wrlBaseZOffset 调整），
+    // 无需额外偏移。STEP: z 额外叠加 stepOffset.z 补偿 STEP 与 WRL 的坐标差异。
 
     content += QString("  (model \"%1\"\n").arg(finalPath);
 

--- a/src/core/utils/UrlUtils.cpp
+++ b/src/core/utils/UrlUtils.cpp
@@ -43,6 +43,10 @@ QSet<QString> allowedHostsForType(ResourceType type) {
                 QStringLiteral("image.lceda.cn"),
                 QStringLiteral("lcsc.com"),
                 QStringLiteral("www.lcsc.com"),
+                QStringLiteral("item.szlcsc.com"),
+                QStringLiteral("atta.szlcsc.com"),
+                QStringLiteral("www.ti.com"),
+                QStringLiteral("www.everlighteurope.com"),
             };
         case ResourceType::Model3DObj:
         case ResourceType::Model3DStep:

--- a/src/services/CadDataLoader.cpp
+++ b/src/services/CadDataLoader.cpp
@@ -69,7 +69,16 @@ CadParseResult CadDataLoader::parseCadPayload(const QString& componentId, const 
     }
     componentData.setFootprintData(footprintData);
 
-    QString modelUuid = footprintData->model3D().uuid();
+    // 优先使用 head.uuid_3d（EasyEDA API 3D 模型端点使用的规范 UUID），
+    // 其次使用 SVGNODE outline3D 的 uuid（可能是不同 UUID）。
+    QString modelUuid;
+    if (resultData.contains("dataStr")) {
+        const QJsonObject dataStr = resultData.value("dataStr").toObject();
+        modelUuid = dataStr.value("head").toObject().value("uuid_3d").toString();
+    }
+    if (modelUuid.isEmpty()) {
+        modelUuid = footprintData->model3D().uuid();
+    }
     if (modelUuid.isEmpty() && resultData.contains("dataStr")) {
         const QJsonObject dataStr = resultData.value("dataStr").toObject();
         const QJsonArray shapes = dataStr.value("shape").toArray();
@@ -92,10 +101,6 @@ CadParseResult CadDataLoader::parseCadPayload(const QString& componentId, const 
                     break;
                 }
             }
-        }
-
-        if (modelUuid.isEmpty()) {
-            modelUuid = dataStr.value("head").toObject().value("uuid_3d").toString();
         }
     }
 

--- a/src/services/export/DatasheetExportWorker.cpp
+++ b/src/services/export/DatasheetExportWorker.cpp
@@ -37,11 +37,11 @@ void DatasheetExportWorker::run() {
         return;
     }
 
-    qDebug() << "DatasheetExportWorker: Exporting" << m_componentId;
-
     // 检查数据手册数据是否可用（URL或数据二选一）
     QString datasheetUrl = m_data->datasheet();
     QByteArray datasheetData = m_data->datasheetData();
+
+    qDebug() << "DatasheetExportWorker: Exporting" << m_componentId;
 
     // 如果内存中没有数据手册数据，尝试从磁盘缓存加载
     if (datasheetData.isEmpty() && !datasheetUrl.isEmpty()) {

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -140,39 +140,47 @@ bool readModelSourceZMm(const QByteArray& cadJsonRaw, const QString& modelUuid, 
     const QJsonObject packageData =
         cadDoc.object().value(QStringLiteral("packageDetail")).toObject().value(QStringLiteral("dataStr")).toObject();
     const QJsonArray shapes = packageData.value(QStringLiteral("shape")).toArray();
-    for (const QJsonValue& shapeValue : shapes) {
-        const QString shape = shapeValue.toString();
-        if (!shape.startsWith(QStringLiteral("SVGNODE~"))) {
-            continue;
-        }
 
-        const QByteArray svgNodeJson = shape.mid(QStringLiteral("SVGNODE~").size()).toUtf8();
-        QJsonParseError svgParseError;
-        const QJsonDocument svgDoc = QJsonDocument::fromJson(svgNodeJson, &svgParseError);
-        if (svgParseError.error != QJsonParseError::NoError || !svgDoc.isObject()) {
-            continue;
-        }
+    // 第一遍：精确匹配 UUID（attrs.uuid == modelUuid）
+    // 第二遍：匹配第一个 outline3D SVGNODE（UUID 可能是 head.uuid_3d 而非 attrs.uuid）
+    for (int pass = 0; pass < 2; ++pass) {
+        for (const QJsonValue& shapeValue : shapes) {
+            const QString shape = shapeValue.toString();
+            if (!shape.startsWith(QStringLiteral("SVGNODE~"))) {
+                continue;
+            }
 
-        const QJsonObject attrs = svgDoc.object().value(QStringLiteral("attrs")).toObject();
-        if (attrs.value(QStringLiteral("uuid")).toString() != modelUuid) {
-            continue;
-        }
+            const QByteArray svgNodeJson = shape.mid(QStringLiteral("SVGNODE~").size()).toUtf8();
+            QJsonParseError svgParseError;
+            const QJsonDocument svgDoc = QJsonDocument::fromJson(svgNodeJson, &svgParseError);
+            if (svgParseError.error != QJsonParseError::NoError || !svgDoc.isObject()) {
+                continue;
+            }
 
-        bool ok = false;
-        double z = 0.0;
-        const QJsonValue zValue = attrs.value(QStringLiteral("z"));
-        if (zValue.isString()) {
-            z = zValue.toString().toDouble(&ok);
-        } else if (zValue.isDouble()) {
-            z = zValue.toDouble();
-            ok = true;
-        }
-        if (!ok) {
-            return false;
-        }
+            const QJsonObject attrs = svgDoc.object().value(QStringLiteral("attrs")).toObject();
+            if (pass == 0 && attrs.value(QStringLiteral("uuid")).toString() != modelUuid) {
+                continue;
+            }
+            if (pass == 1 && attrs.value(QStringLiteral("c_etype")).toString() != QLatin1String("outline3D")) {
+                continue;
+            }
 
-        *zMm = GeometryUtils::convertToMm(z);
-        return true;
+            bool ok = false;
+            double z = 0.0;
+            const QJsonValue zValue = attrs.value(QStringLiteral("z"));
+            if (zValue.isString()) {
+                z = zValue.toString().toDouble(&ok);
+            } else if (zValue.isDouble()) {
+                z = zValue.toDouble();
+                ok = true;
+            }
+            if (!ok) {
+                return false;
+            }
+
+            *zMm = GeometryUtils::convertToMm(z);
+            return true;
+        }
     }
 
     return false;
@@ -305,6 +313,11 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
         FootprintData footprint = *data->footprintData();
         if (m_options.needsModel3DStep()) {
             Model3DData model3D = footprint.model3D();
+            // 优先使用 CadDataLoader 设置的 head.uuid_3d（规范 3D 模型 UUID），
+            // 因为 SVGNODE 的 attrs.uuid 可能是 outline 形状 UUID 而非 3D 模型 UUID。
+            if (data->model3DData() && !data->model3DData()->uuid().isEmpty()) {
+                model3D.setUuid(data->model3DData()->uuid());
+            }
             if (!model3D.uuid().isEmpty()) {
                 QByteArray stepData;
                 if (data->model3DData() && !data->model3DData()->step().isEmpty()) {
@@ -365,6 +378,9 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
                     }
                     const double stepMinZ = geometryCenter.z;
 
+                    // STEP 文件使用绝对坐标系，几何中心不一定在原点。
+                    // stepOffset = -geometryCenter 将 STEP 几何中心移到原点，
+                    // 使 KiCad 偏移正确对齐到封装原点。
                     Model3DBase stepOffset;
                     stepOffset.x = -geometryCenter.x;
                     stepOffset.y = -geometryCenter.y;

--- a/src/utils/CommandLineParser.cpp
+++ b/src/utils/CommandLineParser.cpp
@@ -29,6 +29,7 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
     , m_footprintOption("footprint", "导出封装库 (默认: true)")
     , m_3dModelOption("3d-model", "导出 3D 模型")
     , m_3dModelFormatOption("3d-model-format", "3D 模型格式 (wrl/step/both，默认: wrl)", "format", "wrl")
+    , m_datasheetOption("datasheet", "导出数据手册")
     , m_previewOption("preview", "导出预览图")
     , m_progressOption("progress", "显示进度条")
     , m_quietOption(QStringList() << "q" << "quiet", "安静模式，减少输出")
@@ -80,6 +81,7 @@ void CommandLineParser::setupCliOptions() {
     m_parser.addOption(m_footprintOption);
     m_parser.addOption(m_3dModelOption);
     m_parser.addOption(m_3dModelFormatOption);
+    m_parser.addOption(m_datasheetOption);
     m_parser.addOption(m_previewOption);
     m_parser.addOption(m_progressOption);
     m_parser.addOption(m_quietOption);
@@ -401,6 +403,10 @@ QString CommandLineParser::model3DFormat() const {
     return m_parser.value(m_3dModelFormatOption).toLower();
 }
 
+bool CommandLineParser::exportDatasheet() const {
+    return m_parser.isSet(m_datasheetOption);
+}
+
 bool CommandLineParser::exportPreview() const {
     return m_parser.isSet(m_previewOption);
 }
@@ -443,6 +449,7 @@ QString CommandLineParser::cliHelpText() const {
     stream << "  --3d-model              " << QCoreApplication::translate("CommandLineParser", "导出 3D 模型") << "\n";
     stream << "  --3d-model-format <fmt> "
            << QCoreApplication::translate("CommandLineParser", "3D 模型格式（wrl/step/both，默认: wrl）") << "\n";
+    stream << "  --datasheet             " << QCoreApplication::translate("CommandLineParser", "导出数据手册") << "\n";
     stream << "  --preview               " << QCoreApplication::translate("CommandLineParser", "导出预览图") << "\n";
     stream << "  --cache-dir <path>      " << QCoreApplication::translate("CommandLineParser", "设置磁盘缓存目录")
            << "\n";

--- a/src/utils/CommandLineParser.h
+++ b/src/utils/CommandLineParser.h
@@ -230,6 +230,12 @@ public:
     QString model3DFormat() const;
 
     /**
+     * @brief 是否导出数据手册
+     * @return 导出返回 true，否则返回 false
+     */
+    bool exportDatasheet() const;
+
+    /**
      * @brief 是否导出预览图
      * @return 导出返回 true，否则返回 false
      */
@@ -314,6 +320,7 @@ private:
     QCommandLineOption m_footprintOption;
     QCommandLineOption m_3dModelOption;
     QCommandLineOption m_3dModelFormatOption;
+    QCommandLineOption m_datasheetOption;
     QCommandLineOption m_previewOption;
     QCommandLineOption m_progressOption;
     QCommandLineOption m_quietOption;

--- a/src/utils/cli/CliContext.cpp
+++ b/src/utils/cli/CliContext.cpp
@@ -47,7 +47,7 @@ ExportOptions CliContext::createExportOptions() const {
     options.exportModel3D = m_parser.export3DModel();
     options.exportModel3DFormat = model3DFormatFromString(m_parser.model3DFormat());
     options.exportPreviewImages = m_parser.exportPreview();
-    options.exportDatasheet = false;
+    options.exportDatasheet = m_parser.exportDatasheet();
 
     // 设置默认值
     options.overwriteExistingFiles = true;

--- a/tests/golden/kicad/golden_footprint_with_3d.kicad_mod
+++ b/tests/golden/kicad/golden_footprint_with_3d.kicad_mod
@@ -15,12 +15,12 @@
   (pad 1 smd rect (at -1.53 0.00 0.00) (size 1.27 1.77) (layers F.Cu F.Paste F.Mask))
   (pad 2 smd rect (at 1.52 0.00 0.00) (size 1.27 1.77) (layers F.Cu F.Paste F.Mask))
   (model "../GoldenLib.3dmodels/FOOTPRINT_WITH_3D.wrl"
-    (offset (xyz 0.000 0.030 0.000))
+    (offset (xyz 0.000 0.000 0.000))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))
   )
   (model "../GoldenLib.3dmodels/FOOTPRINT_WITH_3D.step"
-    (offset (xyz 0.000 0.030 0.000))
+    (offset (xyz 0.000 0.000 0.000))
     (scale (xyz 1 1 1))
     (rotate (xyz 0 0 0))
   )


### PR DESCRIPTION
描述
  
  修复 3D 模型（WRL/STEP）与封装焊盘位置不对齐的问题，并新增 CLI 模式数据手册导出支持。

  3D 模型偏移修复

  WRL 和 STEP 使用不同的坐标系，但旧代码用同一套公式计算偏移，导致：
  - WRL XY 偏移错误（使用 modelTranslation - bboxCenter 而非居中后的零偏移）
  - STEP XY 偏移叠加错误（将 WRL 偏移与 stepOffsetMm 相加，而非独立计算）
  - THT 封装 Z 轴强制归零，忽略模型实际 Z 偏移
  - UUID 解析优先级错误（SVGNODE attrs.uuid 优先于 head.uuid_3d）

  修复方案：
  - WRL XY = (0, 0)，因为 OBJ→WRL 转换已将模型居中到原点
  - STEP XY = stepOffsetMm（-stepGeometryCenter），使用独立坐标系
  - 统一 Z 轴处理，移除 THT 强制归零
  - head.uuid_3d 优先于 SVGNODE attrs.uuid
  - readModelSourceZMm 改为两遍扫描兼容 UUID 不一致

  数据手册导出修复

  CLI 模式下数据手册导出全部失败，原因：
  1. CliContext.cpp 硬编码 exportDatasheet = false，无 --datasheet CLI 选项
  2. URL 白名单缺少 item.szlcsc.com、atta.szlcsc.com、www.ti.com、www.everlighteurope.com

  修复方案：
  - 添加 --datasheet CLI 选项
  - 扩展 ResourceType::Datasheet URL 白名单