### PR TITLE
fix(export): 修复导出取消崩溃及重设计预览图悬停UI

### DIFF
--- a/docs/developer/FAQ.md
+++ b/docs/developer/FAQ.md
@@ -143,6 +143,7 @@
 
 - 导出中点关闭，选择“继续导出”后标题栏按钮失效
 - 导出中选择“强制退出”后程序没有完全结束
+- 3D 模型导出过程中点击“停止导出”后段错误，崩溃栈停在 `std::atomic` 的 `store/load`
 
 **根本原因**：
 这是导出会话生命周期管理不完整导致的回归问题：
@@ -150,11 +151,14 @@
 1. 停止导出时，旧导出会话的 stage/worker 仍可能在后台收尾。
 2. 如果新一轮重试马上开始，错误的清理逻辑会提前销毁这些“仍在运行的旧 stage”，导致悬空对象、事件循环卡死或未响应。
 3. 关闭窗口与强制退出流程会复用同一批导出状态；一旦导出会话进入不一致状态，窗口控制也会连带异常。
+4. 3D 模型导出阶段中，活跃 worker 可能已经进入完成/删除流程；取消路径如果继续直接调用该 worker 的 `cancel()`，就可能访问到已释放对象里的 `std::atomic<bool>`。
 
 **修复方案**：
 - 停止导出时，立即结束**当前 UI 会话**，但旧后台任务只做隔离，不允许再回写当前会话。
 - 使用导出会话代数（generation）隔离迟到回调，旧会话的 `itemStatusChanged/progressChanged/completed` 必须被丢弃。
 - `cleanupExportStages()` 不能提前销毁仍在运行中的旧 stage，只能把它们从当前会话映射中移除，等其自然完成后再安全回收。
+- 3D 模型导出取消时只隔离当前 stage、清空待处理队列并回滚临时文件；不要在取消路径直接调用活跃 `Model3DExportWorker::cancel()`。
+- 3D worker 取消后迟到完成时不得提交临时 WRL/STEP 文件。
 - 标题栏关闭按钮不能直接复用 `window.close()` 作为普通关闭入口，必须走统一的 `WindowController` 关闭决策逻辑。
 - 强制退出时必须显式清理网络单例和后台线程，避免窗口已关但进程未退出。
 
@@ -164,6 +168,7 @@
 - 修改 stage 清理逻辑时，必须区分：
   - 当前会话的活动 stage
   - 旧会话仍在后台收尾的 stage
+- 修改 3D 导出取消逻辑时，不要直接访问活跃 worker 对象；把取消视为 stage 会话隔离和临时文件回滚，等待 worker 自然完成。
 - 修改窗口关闭逻辑时，必须同时验证：
   - 停止导出后立即重试
   - 导出中关闭后选择“继续导出”
@@ -173,6 +178,7 @@
 - `src/services/export/ParallelExportService.cpp`
 - `src/services/export/ParallelExportService.h`
 - `src/services/export/ExportTypeStage.cpp`
+- `src/services/export/Model3DExportStage.cpp`
 - `src/ui/qml/components/WindowController.qml`
 - `src/ui/qml/Main.qml`
 - `src/main.cpp`

--- a/docs/developer/FAQ.md
+++ b/docs/developer/FAQ.md
@@ -240,6 +240,72 @@
 
 ---
 
+### Q: 取消导出时程序崩溃（SIGSEGV），崩溃栈停在 std::atomic 的 loadRelaxed
+
+**问题描述**：
+导出过程中点击"停止导出"后程序崩溃，GDB 捕获到 SIGSEGV 信号，崩溃栈显示：
+
+```
+#0  QAtomicOps<int>::loadRelaxed (_q_value=Cannot access memory at address 0x7fffff7feff8)
+#1  QBasicAtomicInteger<int>::loadRelaxed
+#2  EasyKiConverter::Logger::shouldLog
+#3  EasyKiConverter::QtLogAdapter::qtMessageHandler
+#7  EasyKiConverter::ExportTypeStage::cancelWithTempRollback (line 182)
+#8  EasyKiConverter::DatasheetExportStage::cancel (line 72)
+#9  EasyKiConverter::ExportTypeStage::cancelWithTempRollback (line 184)
+#10 EasyKiConverter::DatasheetExportStage::cancel (line 72)
+#11 EasyKiConverter::ExportTypeStage::cancelWithTempRollback (line 184)
+...（无限递归）
+```
+
+**根本原因**：
+`ExportTypeStage::cancelWithTempRollback()` 内部调用虚函数 `cancel()`，而 `DatasheetExportStage::cancel()` 和 `PreviewImagesExportStage::cancel()` 覆盖了 `cancel()` 并反向调用 `cancelWithTempRollback()`，形成无限递归，最终栈溢出导致 SIGSEGV。
+
+调用链：
+```
+ExportTypeStage::cancelWithTempRollback()
+  → cancel()  (虚函数调用)
+    → DatasheetExportStage::cancel()  (子类覆盖)
+      → cancelWithTempRollback(m_tempManager)  (再次调用基类方法)
+        → cancel()  (虚函数调用)
+          → ... 无限递归 → 栈溢出 → SIGSEGV
+```
+
+此问题影响 `DatasheetExportStage` 和 `PreviewImagesExportStage`。`SymbolExportStage`、`FootprintExportStage`、`Model3DExportStage` 的 `cancel()` 实现直接处理取消逻辑，不受影响。
+
+**修复方案**：
+将 `DatasheetExportStage::cancel()` 和 `PreviewImagesExportStage::cancel()` 改为直接实现取消逻辑（与 Symbol/Footprint/Model3D 一致），不再调用 `cancelWithTempRollback()`：
+
+```cpp
+void DatasheetExportStage::cancel() {
+    if (!m_isExporting.load()) {
+        return;
+    }
+    qDebug() << "DatasheetExportStage: Cancelling...";
+    m_cancelled.store(true);
+    m_tempManager.rollbackAll();
+    m_isExporting.store(false);
+    qDebug() << "DatasheetExportStage: Cancelled";
+}
+```
+
+同时移除 `ExportTypeStage::cancelWithTempRollback()` 方法，该方法存在设计缺陷（调用虚函数导致递归风险），且已无调用者。
+
+**回归预防**：
+- 基类方法不要调用虚函数后再由子类覆盖该虚函数反向调用基类方法，否则会形成递归
+- 所有 `ExportTypeStage` 子类的 `cancel()` 实现应直接处理取消逻辑：设置 `m_cancelled` → 回滚临时文件 → 清除 `m_isExporting`
+- 修改导出取消逻辑时，必须验证 Datasheet、PreviewImages、Model3D、Symbol、Footprint 五种类型的取消行为
+
+**相关文件**：
+- `src/services/export/DatasheetExportStage.cpp` - 修复 cancel() 实现
+- `src/services/export/PreviewImagesExportStage.cpp` - 修复 cancel() 实现
+- `src/services/export/ExportTypeStage.h` - 移除 cancelWithTempRollback 声明
+- `src/services/export/ExportTypeStage.cpp` - 移除 cancelWithTempRollback 实现
+
+**状态**：✅ 已修复 (2026-05-30)
+
+---
+
 ## 3D 模型相关
 
 ### Q: 3D 模型选择使用循环切换逻辑而非独立 toggle
@@ -779,6 +845,7 @@ DelegateModel {
 - [ ] 3D 模型 UUID 使用 head.uuid_3d 优先（非 SVGNODE attrs.uuid）
 - [ ] CLI 模式 `--datasheet` 选项可用，数据手册导出成功
 - [ ] 数据手册 URL 白名单覆盖所有实际域名（item.szlcsc.com、atta.szlcsc.com、www.ti.com 等）
+- [ ] 取消导出时不崩溃（Datasheet/PreviewImages/Model3D/Symbol/Footprint 五种类型均验证）
 
 ---
 

--- a/src/services/export/DatasheetExportStage.cpp
+++ b/src/services/export/DatasheetExportStage.cpp
@@ -69,7 +69,15 @@ void DatasheetExportStage::start(const QStringList& componentIds,
 }
 
 void DatasheetExportStage::cancel() {
-    cancelWithTempRollback(m_tempManager);
+    if (!m_isExporting.load()) {
+        return;
+    }
+
+    qDebug() << "DatasheetExportStage: Cancelling...";
+    m_cancelled.store(true);
+    m_tempManager.rollbackAll();
+    m_isExporting.store(false);
+    qDebug() << "DatasheetExportStage: Cancelled";
 }
 
 QObject* DatasheetExportStage::createWorker() {
@@ -103,7 +111,7 @@ void DatasheetExportStage::startWorker(QObject* worker,
                 return;
             }
 
-            if (success && stagePtr->m_finalPaths.contains(componentId)) {
+            if (success && !stagePtr->m_cancelled.load() && stagePtr->m_finalPaths.contains(componentId)) {
                 QString tempPath = stagePtr->m_tempPaths.value(componentId);
                 QString finalPath = stagePtr->m_finalPaths.value(componentId);
                 success = stagePtr->m_tempManager.commitWithBackup(tempPath, finalPath);

--- a/src/services/export/ExportTypeStage.cpp
+++ b/src/services/export/ExportTypeStage.cpp
@@ -1,7 +1,6 @@
 #include "ExportTypeStage.h"
 
 #include "IExportWorker.h"
-#include "TempFileManager.h"
 
 #include <QDebug>
 #include <QMutexLocker>
@@ -143,22 +142,9 @@ void ExportTypeStage::cancel() {
 
     bool hasActiveWorkers = false;
 
-    // 取消所有活跃worker（在锁内完成以避免与 completeItemProgress 竞争）
-    // 使用 QPointer 保护 worker 指针，防止在 cancel 过程中 worker 被删除导致悬空指针
     {
         QMutexLocker locker(&m_workerMutex);
-        for (QObject* worker : m_activeWorkers) {
-            QPointer<QObject> workerPtr(worker);  // 使用 QPointer 保护
-            if (!workerPtr) {
-                continue;  // worker 已删除，跳过
-            }
-            if (auto* exportWorker = dynamic_cast<IExportWorker*>(workerPtr.data())) {
-                exportWorker->cancel();
-            }
-        }
-        // 清空待处理队列
         m_pendingComponents.clear();
-
         hasActiveWorkers = !m_activeWorkers.isEmpty();
         if (!hasActiveWorkers) {
             m_isRunning.store(false);
@@ -168,22 +154,23 @@ void ExportTypeStage::cancel() {
     qDebug() << "ExportTypeStage:" << m_typeName << "cancelled";
 }
 
-void ExportTypeStage::cancelWithTempRollback(TempFileManager& tempManager) {
-    if (!m_isExporting.load()) {
-        return;
+bool ExportTypeStage::waitForFinished(int timeoutMs) {
+    m_cancelled.store(true);
+    m_threadPool.clear();
+
+    if (!m_threadPool.waitForDone(timeoutMs)) {
+        qWarning() << "ExportTypeStage:" << m_typeName << "thread pool did not finish in" << timeoutMs << "ms";
+        return false;
     }
 
-    qDebug() << "ExportTypeStage:" << m_typeName << "cancelling (with temp rollback)...";
-
-    cancel();
-    tempManager.rollbackAll();
-
+    {
+        QMutexLocker locker(&m_workerMutex);
+        m_pendingComponents.clear();
+        m_activeWorkers.clear();
+    }
+    m_isRunning.store(false);
     m_isExporting.store(false);
-    if (!hasActiveWorkers()) {
-        m_isRunning.store(false);
-    }
-
-    qDebug() << "ExportTypeStage:" << m_typeName << "cancelled";
+    return true;
 }
 
 bool ExportTypeStage::waitForWorkerThread(QThread*& thread, int timeoutMs) {

--- a/src/services/export/ExportTypeStage.h
+++ b/src/services/export/ExportTypeStage.h
@@ -85,6 +85,16 @@ public:
     virtual void cancel();
 
     /**
+     * @brief 等待已提交的后台任务结束
+     * @param timeoutMs 最长等待时间（毫秒）
+     * @return true 表示后台任务已结束，false 表示超时
+     *
+     * 仅用于上层服务关闭或回收已取消 stage 时收敛后台线程。
+     * 普通取消流程应调用 cancel()，避免阻塞 UI。
+     */
+    virtual bool waitForFinished(int timeoutMs = 5000);
+
+    /**
      * @brief 获取当前进度
      * @return 线程安全的进度快照
      */
@@ -157,16 +167,6 @@ protected:
      * 线程安全：由m_workerMutex保护。
      */
     void startNextWorker();
-
-    /**
-     * @brief 带临时文件回滚的取消操作（供使用 TempFileManager 的子类调用）
-     * @param tempManager 子类的 TempFileManager 实例引用
-     *
-     * 统一执行：基类取消 → 临时文件回滚 → 状态清理。
-     * DatasheetExportStage、PreviewImagesExportStage、Model3DExportStage 共用此逻辑。
-     * 使用基类 m_isExporting 标志判断是否正在导出。
-     */
-    void cancelWithTempRollback(TempFileManager& tempManager);
 
     /**
      * @brief 等待单个工作线程退出（供使用独立 QThread 的子类调用）

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -260,15 +260,20 @@ void FootprintExportStage::cancel() {
 
     qDebug() << "FootprintExportStage: Cancelling...";
 
-    if (!waitForWorkerThread(m_workerThread)) {
-        return;  // 超时，交由析构函数再次等待
-    }
-
+    m_cancelled.store(true);
     m_tempManager.rollbackAll();
     m_isExporting.store(false);
-    m_isRunning.store(false);
 
     qDebug() << "FootprintExportStage: Cancelled";
+}
+
+bool FootprintExportStage::waitForFinished(int timeoutMs) {
+    const bool finished = waitForWorkerThread(m_workerThread, timeoutMs);
+    if (finished) {
+        m_isRunning.store(false);
+        m_isExporting.store(false);
+    }
+    return finished;
 }
 
 void FootprintExportStage::doLibraryExport(const QStringList& componentIds,

--- a/src/services/export/FootprintExportStage.h
+++ b/src/services/export/FootprintExportStage.h
@@ -69,6 +69,8 @@ public:
      */
     void cancel() override;
 
+    bool waitForFinished(int timeoutMs = 5000) override;
+
 protected:
     // 以下方法覆盖基类纯虚函数，但在此实现中不使用
     QObject* createWorker() override {

--- a/src/services/export/Model3DExportStage.cpp
+++ b/src/services/export/Model3DExportStage.cpp
@@ -100,7 +100,27 @@ void Model3DExportStage::start(const QStringList& componentIds,
 }
 
 void Model3DExportStage::cancel() {
-    cancelWithTempRollback(m_tempManager);
+    if (!m_isRunning.load() && !m_isExporting.load()) {
+        return;
+    }
+
+    qDebug() << "Model3DExportStage: cancelling...";
+    m_cancelled.store(true);
+
+    bool hasActiveWorkers = false;
+    {
+        QMutexLocker locker(&m_workerMutex);
+        m_pendingComponents.clear();
+        hasActiveWorkers = !m_activeWorkers.isEmpty();
+        if (!hasActiveWorkers) {
+            m_isRunning.store(false);
+        }
+    }
+
+    m_tempManager.rollbackAll();
+    m_isExporting.store(false);
+
+    qDebug() << "Model3DExportStage: cancelled";
 }
 
 QObject* Model3DExportStage::createWorker() {
@@ -163,7 +183,7 @@ void Model3DExportStage::startWorker(QObject* worker,
                 return;
             }
 
-            if (success && stagePtr->m_componentPaths.contains(componentId)) {
+            if (success && !stagePtr->m_cancelled.load() && stagePtr->m_componentPaths.contains(componentId)) {
                 const TempFilePaths paths = stagePtr->m_componentPaths.value(componentId);
                 const bool needWrl = stagePtr->m_options.needsModel3DWrl();
                 const bool needStep = stagePtr->m_options.needsModel3DStep();

--- a/src/services/export/Model3DExportWorker.cpp
+++ b/src/services/export/Model3DExportWorker.cpp
@@ -14,15 +14,11 @@
 
 namespace EasyKiConverter {
 
-Model3DExportWorker::Model3DExportWorker(QObject* parent) : QObject(parent), m_exporter(new Exporter3DModel(this)) {
+Model3DExportWorker::Model3DExportWorker(QObject* parent) : QObject(parent) {
     setAutoDelete(false);
 }
 
-Model3DExportWorker::~Model3DExportWorker() {
-    if (m_exporter) {
-        m_exporter->cancel();
-    }
-}
+Model3DExportWorker::~Model3DExportWorker() = default;
 
 void Model3DExportWorker::setData(const QString& componentId,
                                   const QSharedPointer<ComponentData>& data,
@@ -81,6 +77,8 @@ void Model3DExportWorker::run() {
         return;
     }
 
+    Exporter3DModel exporter;
+
     // 获取模型名称用于命名文件（仅在需要时）
     QString modelName;
     if (m_data && m_data->model3DData()) {
@@ -96,7 +94,8 @@ void Model3DExportWorker::run() {
     // 构建输出路径
     QString outputDir = m_options.outputPath;
     if (outputDir.isEmpty()) {
-        outputDir = QDir::currentPath() + QStringLiteral("/export/3dmodels");
+        outputDir =
+            QDir(QDir(QDir::currentPath()).filePath(QStringLiteral("export"))).filePath(QStringLiteral("3dmodels"));
     }
 
     QDir dir;
@@ -105,10 +104,9 @@ void Model3DExportWorker::run() {
         return;
     }
 
-    const QString wrlFinalPath =
-        needWrl ? (outputDir + QStringLiteral("/") + modelName + QStringLiteral(".wrl")) : QString();
-    const QString stepFinalPath =
-        needStep ? (outputDir + QStringLiteral("/") + modelName + QStringLiteral(".step")) : QString();
+    const QDir outputDirectory(outputDir);
+    const QString wrlFinalPath = needWrl ? outputDirectory.filePath(modelName + QStringLiteral(".wrl")) : QString();
+    const QString stepFinalPath = needStep ? outputDirectory.filePath(modelName + QStringLiteral(".step")) : QString();
     const QString wrlWritePath = m_outputPaths.wrlTempPath.isEmpty() ? wrlFinalPath : m_outputPaths.wrlTempPath;
     const QString stepWritePath = m_outputPaths.stepTempPath.isEmpty() ? stepFinalPath : m_outputPaths.stepTempPath;
 
@@ -168,7 +166,7 @@ void Model3DExportWorker::run() {
         if (objData.isEmpty() && cache->hasModel3DCached(uuid, QStringLiteral("wrl")) &&
             cache->copyModel3DToFile(uuid, QStringLiteral("wrl"), wrlWritePath)) {
             qDebug() << "Model3DExportWorker: WRL cache fallback for" << uuid;
-        } else if (objData.isEmpty() && !m_exporter->downloadObjDataSync(uuid, &objData, &error)) {
+        } else if (objData.isEmpty() && !exporter.downloadObjDataSync(uuid, &objData, &error)) {
             if (error.isEmpty()) {
                 error = QStringLiteral("Failed to download OBJ data for WRL export");
             }
@@ -178,7 +176,7 @@ void Model3DExportWorker::run() {
             cache->saveModel3D(uuid, objData, QStringLiteral("obj"));
             Model3DData modelData = buildModelData();
             modelData.setRawObj(QString::fromUtf8(objData));
-            if (!m_exporter->exportToWrl(modelData, wrlWritePath)) {
+            if (!exporter.exportToWrl(modelData, wrlWritePath)) {
                 error = QStringLiteral("Failed to convert OBJ to WRL");
             } else {
                 QFile file(wrlWritePath);
@@ -196,7 +194,7 @@ void Model3DExportWorker::run() {
         if (cache->copyModel3DToFile(uuid, QStringLiteral("step"), stepWritePath)) {
             qDebug() << "Model3DExportWorker: STEP cache hit for" << m_componentId << "uuid" << uuid;
         } else if (!m_cancelled.load()) {
-            if (!m_exporter->downloadStepDataSync(uuid, &stepData, &error)) {
+            if (!exporter.downloadStepDataSync(uuid, &stepData, &error)) {
                 if (error.isEmpty()) {
                     error = QStringLiteral("Failed to download STEP data");
                 }
@@ -205,7 +203,7 @@ void Model3DExportWorker::run() {
             if (!stepData.isEmpty()) {
                 Model3DData modelData = buildModelData();
                 modelData.setStep(stepData);
-                if (!m_exporter->exportToStep(modelData, stepWritePath)) {
+                if (!exporter.exportToStep(modelData, stepWritePath)) {
                     error = QStringLiteral("Failed to write STEP file");
                 } else {
                     cache->saveModel3D(uuid, stepData, QStringLiteral("step"));
@@ -244,9 +242,6 @@ void Model3DExportWorker::onDownloadError(const QString& error) {
 
 void Model3DExportWorker::cancel() {
     m_cancelled.store(true);
-    if (m_exporter) {
-        m_exporter->cancel();
-    }
 }
 
 }  // namespace EasyKiConverter

--- a/src/services/export/Model3DExportWorker.h
+++ b/src/services/export/Model3DExportWorker.h
@@ -13,7 +13,6 @@
 namespace EasyKiConverter {
 
 class ComponentData;
-class Exporter3DModel;
 
 /**
  * @brief 3D模型导出Worker
@@ -114,7 +113,6 @@ private:
     QSharedPointer<ComponentData> m_data;  ///< 预加载的元器件数据
     ExportOptions m_options;  ///< 导出选项
     std::atomic<bool> m_cancelled{false};  ///< 取消标志
-    Exporter3DModel* m_exporter;  ///< 3D模型导出器
 };
 
 }  // namespace EasyKiConverter

--- a/src/services/export/ParallelExportService.cpp
+++ b/src/services/export/ParallelExportService.cpp
@@ -14,6 +14,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QMutexLocker>
+#include <QPointer>
 #include <QSaveFile>
 #include <QTextStream>
 #include <QTimer>
@@ -25,27 +26,48 @@ ParallelExportService::ParallelExportService(QObject* parent) : QObject(parent),
 }
 
 ParallelExportService::~ParallelExportService() {
-    // 取消所有导出阶段，防止worker在stage销毁后访问已释放对象
-    for (auto* stage : m_exportStages) {
-        stage->cancel();
-        stage->deleteLater();  // 使用 deleteLater 确保线程安全清理
+    m_cancelRequested = true;
+    ++m_activeRunGeneration;
+    NetworkClient::instance().cancelAllRequests();
+
+    QList<ExportTypeStage*> stagesToStop;
+    const auto appendUniqueStage = [&stagesToStop](ExportTypeStage* stage) {
+        if (stage && !stagesToStop.contains(stage)) {
+            stagesToStop.append(stage);
+        }
+    };
+
+    for (auto* stage : std::as_const(m_exportStages)) {
+        appendUniqueStage(stage);
+    }
+    for (const QPointer<ExportTypeStage>& stage : std::as_const(m_retiredExportStages)) {
+        appendUniqueStage(stage.data());
     }
 
-    // 清理阶段列表
     m_exportStages.clear();
+    m_retiredExportStages.clear();
+
+    for (ExportTypeStage* stage : std::as_const(stagesToStop)) {
+        stage->cancel();
+    }
+    for (ExportTypeStage* stage : std::as_const(stagesToStop)) {
+        stage->waitForFinished(30000);
+        delete stage;
+    }
 }
 
 void ParallelExportService::cleanupExportStages() {
     for (auto* stage : m_exportStages) {
         if (stage) {
-            if (stage->isRunning()) {
-                stage->setParent(this);
+            if (stage->isRunning() || stage->hasActiveWorkers()) {
+                retireExportStage(stage);
             } else {
                 stage->deleteLater();
             }
         }
     }
     m_exportStages.clear();
+    cleanupRetiredExportStages();
 }
 
 void ParallelExportService::discardExportStage(const QString& typeName, ExportTypeStage* stage) {
@@ -53,6 +75,54 @@ void ParallelExportService::discardExportStage(const QString& typeName, ExportTy
         m_exportStages.remove(typeName);
     }
     if (stage) {
+        if (stage->isRunning() || stage->hasActiveWorkers()) {
+            retireExportStage(stage);
+        } else {
+            for (int i = m_retiredExportStages.size() - 1; i >= 0; --i) {
+                if (m_retiredExportStages.at(i).data() == stage || m_retiredExportStages.at(i).isNull()) {
+                    m_retiredExportStages.removeAt(i);
+                }
+            }
+            stage->deleteLater();
+        }
+    }
+    cleanupRetiredExportStages();
+}
+
+void ParallelExportService::retireExportStage(ExportTypeStage* stage) {
+    if (!stage) {
+        return;
+    }
+
+    stage->setParent(this);
+    for (const QPointer<ExportTypeStage>& retiredStage : std::as_const(m_retiredExportStages)) {
+        if (retiredStage.data() == stage) {
+            return;
+        }
+    }
+    m_retiredExportStages.append(QPointer<ExportTypeStage>(stage));
+
+    QPointer<ExportTypeStage> stagePtr(stage);
+    connect(stage, &ExportTypeStage::completed, this, [this, stagePtr](int, int, int) {
+        if (!stagePtr) {
+            cleanupRetiredExportStages();
+            return;
+        }
+        discardExportStage(stagePtr->typeName(), stagePtr.data());
+    });
+}
+
+void ParallelExportService::cleanupRetiredExportStages() {
+    for (int i = m_retiredExportStages.size() - 1; i >= 0; --i) {
+        ExportTypeStage* stage = m_retiredExportStages.at(i).data();
+        if (!stage) {
+            m_retiredExportStages.removeAt(i);
+            continue;
+        }
+        if (stage->isRunning() || stage->hasActiveWorkers()) {
+            continue;
+        }
+        m_retiredExportStages.removeAt(i);
         stage->deleteLater();
     }
 }
@@ -142,9 +212,9 @@ void ParallelExportService::cancelPreload() {
         m_progress.endTime = QDateTime::currentDateTime();
     }
     updateOverallProgress();
+    emit cancelled();
     logNetworkRuntimeStats(QStringLiteral("preload-cancelled"));
     writeExportDetailedReport(QStringLiteral("preload-cancelled"));
-    emit cancelled();
 }
 
 void ParallelExportService::startExport() {
@@ -266,6 +336,7 @@ void ParallelExportService::startExport() {
     // 创建并启动各导出类型的Stage
     if (enableSymbol) {
         auto* stage = new SymbolExportStage(this);
+        QPointer<ExportTypeStage> stagePtr(stage);
         stage->setOptions(m_options);
         m_exportStages[QStringLiteral("Symbol")] = stage;
 
@@ -290,9 +361,11 @@ void ParallelExportService::startExport() {
         connect(stage,
                 &SymbolExportStage::completed,
                 this,
-                [this, stage, runGeneration](int success, int failed, int skipped) {
+                [this, stagePtr, runGeneration](int success, int failed, int skipped) {
                     if (runGeneration != m_activeRunGeneration) {
-                        discardExportStage(QStringLiteral("Symbol"), stage);
+                        if (stagePtr) {
+                            discardExportStage(QStringLiteral("Symbol"), stagePtr.data());
+                        }
                         return;
                     }
                     onExportTypeCompleted(QStringLiteral("Symbol"), success, failed, skipped);
@@ -302,6 +375,7 @@ void ParallelExportService::startExport() {
 
     if (enableFootprint) {
         auto* stage = new FootprintExportStage(this);
+        QPointer<ExportTypeStage> stagePtr(stage);
         stage->setOptions(m_options);
         m_exportStages[QStringLiteral("Footprint")] = stage;
 
@@ -326,9 +400,11 @@ void ParallelExportService::startExport() {
         connect(stage,
                 &FootprintExportStage::completed,
                 this,
-                [this, stage, runGeneration](int success, int failed, int skipped) {
+                [this, stagePtr, runGeneration](int success, int failed, int skipped) {
                     if (runGeneration != m_activeRunGeneration) {
-                        discardExportStage(QStringLiteral("Footprint"), stage);
+                        if (stagePtr) {
+                            discardExportStage(QStringLiteral("Footprint"), stagePtr.data());
+                        }
                         return;
                     }
                     onExportTypeCompleted(QStringLiteral("Footprint"), success, failed, skipped);
@@ -338,6 +414,7 @@ void ParallelExportService::startExport() {
 
     if (enableModel3D) {
         auto* stage = new Model3DExportStage(this);
+        QPointer<ExportTypeStage> stagePtr(stage);
         stage->setOptions(m_options);
         m_exportStages[QStringLiteral("Model3D")] = stage;
 
@@ -362,9 +439,11 @@ void ParallelExportService::startExport() {
         connect(stage,
                 &Model3DExportStage::completed,
                 this,
-                [this, stage, runGeneration](int success, int failed, int skipped) {
+                [this, stagePtr, runGeneration](int success, int failed, int skipped) {
                     if (runGeneration != m_activeRunGeneration) {
-                        discardExportStage(QStringLiteral("Model3D"), stage);
+                        if (stagePtr) {
+                            discardExportStage(QStringLiteral("Model3D"), stagePtr.data());
+                        }
                         return;
                     }
                     onExportTypeCompleted(QStringLiteral("Model3D"), success, failed, skipped);
@@ -374,6 +453,7 @@ void ParallelExportService::startExport() {
 
     if (enablePreview) {
         auto* stage = new PreviewImagesExportStage(this);
+        QPointer<ExportTypeStage> stagePtr(stage);
         stage->setOptions(m_options);
         m_exportStages[QStringLiteral("PreviewImages")] = stage;
 
@@ -398,9 +478,11 @@ void ParallelExportService::startExport() {
         connect(stage,
                 &PreviewImagesExportStage::completed,
                 this,
-                [this, stage, runGeneration](int success, int failed, int skipped) {
+                [this, stagePtr, runGeneration](int success, int failed, int skipped) {
                     if (runGeneration != m_activeRunGeneration) {
-                        discardExportStage(QStringLiteral("PreviewImages"), stage);
+                        if (stagePtr) {
+                            discardExportStage(QStringLiteral("PreviewImages"), stagePtr.data());
+                        }
                         return;
                     }
                     onExportTypeCompleted(QStringLiteral("PreviewImages"), success, failed, skipped);
@@ -410,6 +492,7 @@ void ParallelExportService::startExport() {
 
     if (enableDatasheet) {
         auto* stage = new DatasheetExportStage(this);
+        QPointer<ExportTypeStage> stagePtr(stage);
         stage->setOptions(m_options);
         m_exportStages[QStringLiteral("Datasheet")] = stage;
 
@@ -434,9 +517,11 @@ void ParallelExportService::startExport() {
         connect(stage,
                 &DatasheetExportStage::completed,
                 this,
-                [this, stage, runGeneration](int success, int failed, int skipped) {
+                [this, stagePtr, runGeneration](int success, int failed, int skipped) {
                     if (runGeneration != m_activeRunGeneration) {
-                        discardExportStage(QStringLiteral("Datasheet"), stage);
+                        if (stagePtr) {
+                            discardExportStage(QStringLiteral("Datasheet"), stagePtr.data());
+                        }
                         return;
                     }
                     onExportTypeCompleted(QStringLiteral("Datasheet"), success, failed, skipped);
@@ -467,15 +552,33 @@ void ParallelExportService::cancelExport() {
         return;
     }
 
-    for (auto* stage : m_exportStages) {
-        stage->cancel();
-    }
-
     m_progress.currentStage = ExportOverallProgress::Stage::Cancelled;
     m_progress.endTime = QDateTime::currentDateTime();
-    logNetworkRuntimeStats(QStringLiteral("export-cancelled"));
-    writeExportDetailedReport(QStringLiteral("export-cancelled"));
     emit cancelled();
+
+    QList<QPointer<ExportTypeStage>> stagesToCancel;
+    for (auto* stage : m_exportStages) {
+        if (stage) {
+            disconnect(stage, nullptr, this, nullptr);
+            retireExportStage(stage);
+            stagesToCancel.append(QPointer<ExportTypeStage>(stage));
+        }
+    }
+    m_exportStages.clear();
+    m_runningExportStages = 0;
+
+    NetworkClient::instance().cancelAllRequests();
+    for (const QPointer<ExportTypeStage>& stage : std::as_const(stagesToCancel)) {
+        if (stage) {
+            stage->cancel();
+        }
+    }
+    cleanupRetiredExportStages();
+
+    QTimer::singleShot(0, this, [this]() {
+        logNetworkRuntimeStats(QStringLiteral("export-cancelled"));
+        writeExportDetailedReport(QStringLiteral("export-cancelled"));
+    });
 }
 
 ExportOverallProgress ParallelExportService::getProgress() const {

--- a/src/services/export/ParallelExportService.h
+++ b/src/services/export/ParallelExportService.h
@@ -2,9 +2,11 @@
 
 #include "ExportProgress.h"
 
+#include <QList>
 #include <QMap>
 #include <QMutex>
 #include <QObject>
+#include <QPointer>
 #include <QSharedPointer>
 #include <QString>
 #include <QStringList>
@@ -254,11 +256,14 @@ private:
      */
     void cleanupExportStages();
     void discardExportStage(const QString& typeName, ExportTypeStage* stage);
+    void retireExportStage(ExportTypeStage* stage);
+    void cleanupRetiredExportStages();
 
     ExportOptions m_options;  ///< 导出选项
     QStringList m_componentIds;  ///< 待处理的元器件ID列表
     QMap<QString, QSharedPointer<ComponentData>> m_cachedData;  ///< 缓存的元器件数据
     QMap<QString, ExportTypeStage*> m_exportStages;  ///< 各导出类型的Stage实例
+    QList<QPointer<ExportTypeStage>> m_retiredExportStages;  ///< 取消后仍需等待自然结束的旧Stage
     ComponentService* m_componentService{nullptr};  ///< 元器件服务引用（用于获取已验证的数据）
 
     ExportOverallProgress m_progress;  ///< 整体进度

--- a/src/services/export/PreviewImagesExportStage.cpp
+++ b/src/services/export/PreviewImagesExportStage.cpp
@@ -54,7 +54,15 @@ void PreviewImagesExportStage::start(const QStringList& componentIds,
 }
 
 void PreviewImagesExportStage::cancel() {
-    cancelWithTempRollback(m_tempManager);
+    if (!m_isExporting.load()) {
+        return;
+    }
+
+    qDebug() << "PreviewImagesExportStage: Cancelling...";
+    m_cancelled.store(true);
+    m_tempManager.rollbackAll();
+    m_isExporting.store(false);
+    qDebug() << "PreviewImagesExportStage: Cancelled";
 }
 
 QMap<QString, QString> PreviewImagesExportStage::createTempPathsForComponent(const QString& componentId,
@@ -133,7 +141,7 @@ void PreviewImagesExportStage::startWorker(QObject* worker,
                 return;
             }
 
-            if (success) {
+            if (success && !stagePtr->m_cancelled.load()) {
                 QString outputDir = stagePtr->m_outputDirs.value(componentId);
                 const QMap<QString, QString> tempPaths = stagePtr->m_componentTempPaths.value(componentId);
 

--- a/src/services/export/SymbolExportStage.cpp
+++ b/src/services/export/SymbolExportStage.cpp
@@ -75,15 +75,20 @@ void SymbolExportStage::cancel() {
 
     qDebug() << "SymbolExportStage: Cancelling...";
 
-    if (!waitForWorkerThread(m_workerThread)) {
-        return;  // 超时，交由析构函数再次等待
-    }
-
+    m_cancelled.store(true);
     m_tempManager.rollbackAll();
     m_isExporting.store(false);
-    m_isRunning.store(false);
 
     qDebug() << "SymbolExportStage: Cancelled";
+}
+
+bool SymbolExportStage::waitForFinished(int timeoutMs) {
+    const bool finished = waitForWorkerThread(m_workerThread, timeoutMs);
+    if (finished) {
+        m_isRunning.store(false);
+        m_isExporting.store(false);
+    }
+    return finished;
 }
 
 void SymbolExportStage::doLibraryExport(const QStringList& componentIds,

--- a/src/services/export/SymbolExportStage.h
+++ b/src/services/export/SymbolExportStage.h
@@ -67,6 +67,8 @@ public:
      */
     void cancel() override;
 
+    bool waitForFinished(int timeoutMs = 5000) override;
+
 protected:
     // 以下方法覆盖基类纯虚函数，但在此实现中不使用
     QObject* createWorker() override {

--- a/src/services/export/TempFileManager.cpp
+++ b/src/services/export/TempFileManager.cpp
@@ -545,6 +545,7 @@ bool TempFileManager::commitBatchLocked(const QVector<CommitItem>& items) {
         m_tempFiles.remove(entry.tempPath);
         qDebug() << "TempFileManager: Committed with backup:" << entry.tempPath << "->" << entry.finalPath;
     }
+    cleanupEmptyTempDirectoryLocked();
 
     return true;
 }
@@ -566,6 +567,7 @@ void TempFileManager::rollbackAll() {
     }
 
     m_tempFiles.clear();
+    cleanupEmptyTempDirectoryLocked();
 
     locker.unlock();
     emit cleanupCompleted(deletedCount);
@@ -666,6 +668,32 @@ bool TempFileManager::deleteFile(const QString& path) const {
     }
 
     qWarning() << "TempFileManager: Failed to delete:" << path;
+    return false;
+}
+
+bool TempFileManager::cleanupEmptyTempDirectoryLocked() const {
+    const QString tempDir = tempDirectory();
+    if (tempDir.isEmpty()) {
+        return true;
+    }
+
+    QDir dir(tempDir);
+    if (!dir.exists()) {
+        return true;
+    }
+
+    const QFileInfoList entries =
+        dir.entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries | QDir::Hidden | QDir::System);
+    if (!entries.isEmpty()) {
+        return false;
+    }
+
+    if (QDir().rmdir(tempDir)) {
+        qDebug() << "TempFileManager: Removed empty temp directory:" << tempDir;
+        return true;
+    }
+
+    qWarning() << "TempFileManager: Failed to remove empty temp directory:" << tempDir;
     return false;
 }
 

--- a/src/services/export/TempFileManager.h
+++ b/src/services/export/TempFileManager.h
@@ -198,6 +198,7 @@ private:
     bool deleteFile(const QString& path) const;
 
     bool commitBatchLocked(const QVector<CommitItem>& items);
+    bool cleanupEmptyTempDirectoryLocked() const;
 
     QString m_outputPath;  ///< 输出目录路径
     mutable QMutex m_mutex;  ///< 保护临时文件集合

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -38,6 +38,17 @@ Rectangle {
             return "data:image/webp;base64," + imageData;
         return "data:image/png;base64," + imageData;
     }
+    function previewImageSources() {
+        var result = [];
+        if (!itemData || !itemData.previewImages)
+            return result;
+        for (var i = 0; i < itemData.previewImages.length && result.length < 3; ++i) {
+            var source = previewImageSource(itemData.previewImages[i]);
+            if (source !== "")
+                result.push(source);
+        }
+        return result;
+    }
     Timer {
         id: regexUpdateTimer
         interval: 100
@@ -202,8 +213,8 @@ Rectangle {
                             return "";
                         if (!itemData.previewImages || itemData.previewImages.length === 0)
                             return "";
-                        var imageData = itemData.previewImages[0];
-                        return rootItem.previewImageSource(imageData);
+                        var sources = rootItem.previewImageSources();
+                        return sources.length > 0 ? sources[0] : "";
                     }
                     fillMode: Image.PreserveAspectFit
                     cache: true
@@ -314,10 +325,16 @@ Rectangle {
                 }
                 sourceComponent: Popup {
                     id: previewPopup
-                    parent: previewBackground
-                    width: ResponsiveHelper.responsive(360, 420, 490, 490)
-                    height: ResponsiveHelper.responsive(130, 150, 170, 170)
-                    padding: 0
+                    parent: rootItem.Window.window ? rootItem.Window.window.contentItem : rootItem
+                    readonly property var imageSources: rootItem.previewImageSources()
+                    readonly property int imageCount: Math.max(1, imageSources.length)
+                    readonly property int imageSize: ResponsiveHelper.responsive(104, 118, 132, 132)
+                    readonly property int imageSpacing: AppStyle.spacing.md
+                    readonly property int framePadding: AppStyle.borderWidths.thick
+                    readonly property int rowWidth: imageSize * imageCount + imageSpacing * Math.max(0, imageCount - 1)
+                    width: rowWidth + framePadding * 2
+                    height: imageSize + framePadding * 2
+                    padding: framePadding
                     // visible 由 Timer 控制，悬停1秒后显示
                     visible: false
                     closePolicy: Popup.NoAutoClose
@@ -327,33 +344,29 @@ Rectangle {
                     // 位置计算（clamp 到窗口可视范围）
                     onVisibleChanged: {
                         if (visible) {
-                            var win = rootItem.Window ? rootItem.Window.window : null;
-                            var winW = win ? win.width : rootItem.width;
-                            var winH = win ? win.height : rootItem.height;
+                            var popupParent = parent || rootItem;
+                            var winW = popupParent.width;
+                            var winH = popupParent.height;
                             var gap = AppStyle.spacing.lg;
                             var thumbW = previewBackground.width;
                             var thumbH = previewBackground.height;
-                            var thumbGlobalPos = previewBackground.mapToGlobal(Qt.point(0, 0));
-                            var winGlobalX = win ? win.x : 0;
-                            var winGlobalY = win ? win.y : 0;
-                            var thumbRelX = thumbGlobalPos.x - winGlobalX;
-                            var thumbRelY = thumbGlobalPos.y - winGlobalY;
+                            var thumbPos = previewBackground.mapToItem(popupParent, 0, 0);
                             // 优先右侧，空间不足则左侧
-                            var spaceRight = winW - (thumbRelX + thumbW);
-                            var spaceLeft = thumbRelX;
+                            var spaceRight = winW - (thumbPos.x + thumbW);
+                            var spaceLeft = thumbPos.x;
                             var targetX;
                             if (spaceRight >= width + gap) {
-                                targetX = thumbW + gap;
+                                targetX = thumbPos.x + thumbW + gap;
                             } else if (spaceLeft >= width + gap) {
-                                targetX = -(width + gap);
+                                targetX = thumbPos.x - width - gap;
                             } else {
                                 // 两侧都不够，贴右侧边缘
-                                targetX = winW - thumbRelX - width - AppStyle.spacing.xs;
+                                targetX = winW - width - AppStyle.spacing.xs;
                             }
-                            x = Math.max(-thumbRelX + AppStyle.spacing.xs, Math.min(targetX, winW - thumbRelX - width - AppStyle.spacing.xs));
+                            x = Math.max(AppStyle.spacing.xs, Math.min(targetX, winW - width - AppStyle.spacing.xs));
                             // 垂直居中，clamp 到窗口范围
-                            var targetY = (thumbH - height) / 2;
-                            y = Math.max(-thumbRelY + AppStyle.spacing.xs, Math.min(targetY, winH - thumbRelY - height - AppStyle.spacing.xs));
+                            var targetY = thumbPos.y + (thumbH - height) / 2;
+                            y = Math.max(AppStyle.spacing.xs, Math.min(targetY, winH - height - AppStyle.spacing.xs));
                         }
                     }
 
@@ -378,7 +391,7 @@ Rectangle {
                     background: Rectangle {
                         color: AppStyle.colors.surface
                         border.color: AppStyle.colors.primary
-                        border.width: AppStyle.borderWidths.thick
+                        border.width: previewPopup.framePadding
                         radius: AppStyle.radius.md
                         // 阴影效果
                         layer.enabled: true
@@ -392,21 +405,20 @@ Rectangle {
                     }
 
                     contentItem: Item {
-                        anchors.fill: parent
-                        anchors.margins: AppStyle.spacing.md
+                        implicitWidth: previewPopup.rowWidth
+                        implicitHeight: previewPopup.imageSize
                         visible: itemData && itemData.isValid
                         // 有预览图时显示所有图片（最多3张）
                         Row {
+                            id: previewPopupImageRow
                             anchors.fill: parent
-                            spacing: AppStyle.spacing.md
-                            visible: itemData && itemData.previewImageCount > 0
-                            property int imageCount: itemData ? Math.min(itemData.previewImageCount, 3) : 0
-                            property int imageSize: Math.floor((width - spacing * Math.max(0, imageCount - 1)) / Math.max(1, imageCount))
+                            spacing: previewPopup.imageSpacing
+                            visible: previewPopup.imageSources.length > 0
                             Repeater {
-                                model: imageCount
+                                model: previewPopup.imageSources.length
                                 Rectangle {
-                                    width: parent.imageSize
-                                    height: parent.imageSize
+                                    width: previewPopup.imageSize
+                                    height: previewPopup.imageSize
                                     color: AppStyle.colors.background
                                     radius: AppStyle.radius.sm
                                     border.color: AppStyle.colors.border
@@ -414,14 +426,12 @@ Rectangle {
                                     clip: true
                                     Image {
                                         anchors.fill: parent
-                                        anchors.margins: 5
-                                        sourceSize: Qt.size(parent.imageSize, parent.imageSize)
+                                        sourceSize: Qt.size(previewPopup.imageSize, previewPopup.imageSize)
                                         source: {
-                                            if (!itemData || !itemData.previewImages) {
+                                            if (index < 0 || index >= previewPopup.imageSources.length) {
                                                 return "";
                                             }
-                                            var imageData = itemData.previewImages[index];
-                                            return rootItem.previewImageSource(imageData);
+                                            return previewPopup.imageSources[index];
                                         }
                                         fillMode: Image.PreserveAspectFit
                                         cache: true
@@ -471,7 +481,7 @@ Rectangle {
                             font.pixelSize: AppStyle.fontSizes.lg
                             font.bold: true
                             color: AppStyle.colors.textSecondary
-                            visible: !itemData || !itemData.previewImageCount || itemData.previewImageCount === 0
+                            visible: !itemData || previewPopup.imageSources.length === 0
                         }
                     }
                 }

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -316,7 +316,6 @@ Rectangle {
                 id: previewPopupLoader
                 active: false
                 asynchronous: true
-                // 跟踪是否应该在加载完成后显示
                 property bool pendingShow: false
                 onLoaded: {
                     if (pendingShow && item) {
@@ -327,23 +326,33 @@ Rectangle {
                     id: previewPopup
                     parent: rootItem.Window.window ? rootItem.Window.window.contentItem : rootItem
                     readonly property var imageSources: rootItem.previewImageSources()
-                    readonly property int imageCount: Math.max(1, imageSources.length)
-                    readonly property int imageSize: ResponsiveHelper.responsive(104, 118, 132, 132)
-                    readonly property int imageSpacing: AppStyle.spacing.md
-                    readonly property int framePadding: AppStyle.borderWidths.thick
-                    readonly property int rowWidth: imageSize * imageCount + imageSpacing * Math.max(0, imageCount - 1)
-                    width: rowWidth + framePadding * 2
-                    height: imageSize + framePadding * 2
-                    padding: framePadding
-                    // visible 由 Timer 控制，悬停1秒后显示
+                    property int mainIndex: 0
+                    property real popupScale: 1
+                    property real scaleOriginX: 0
+                    property real scaleOriginY: 0
+                    readonly property bool hasImages: imageSources.length > 0
+                    readonly property bool containsMouse: previewPopupHover.hovered
+                    readonly property int panelPadding: AppStyle.spacing.md
+                    readonly property int headerHeight: 34
+                    readonly property int mainImageSize: Math.min(Math.max(180, parent ? parent.width * 0.22 : 220), 260)
+                    readonly property int thumbSize: 42
+                    readonly property int thumbGap: AppStyle.spacing.xs
+                    readonly property int stripHeight: imageSources.length > 1 ? thumbSize : 0
+                    readonly property int galleryWidth: Math.max(mainImageSize, imageSources.length * thumbSize + Math.max(0, imageSources.length - 1) * thumbGap) + panelPadding * 2
+                    readonly property int galleryHeight: hasImages ? headerHeight + mainImageSize + stripHeight + panelPadding * 2 + (stripHeight > 0 ? AppStyle.spacing.sm : 0) : 184
+                    width: galleryWidth
+                    height: galleryHeight
+                    padding: 0
                     visible: false
                     closePolicy: Popup.NoAutoClose
                     modal: false
                     focus: false
                     dim: false
-                    // 位置计算（clamp 到窗口可视范围）
+                    opacity: 1
+
                     onVisibleChanged: {
                         if (visible) {
+                            mainIndex = 0;
                             var popupParent = parent || rootItem;
                             var winW = popupParent.width;
                             var winH = popupParent.height;
@@ -351,7 +360,8 @@ Rectangle {
                             var thumbW = previewBackground.width;
                             var thumbH = previewBackground.height;
                             var thumbPos = previewBackground.mapToItem(popupParent, 0, 0);
-                            // 优先右侧，空间不足则左侧
+                            var thumbCenterX = thumbPos.x + thumbW / 2;
+                            var thumbCenterY = thumbPos.y + thumbH / 2;
                             var spaceRight = winW - (thumbPos.x + thumbW);
                             var spaceLeft = thumbPos.x;
                             var targetX;
@@ -360,135 +370,283 @@ Rectangle {
                             } else if (spaceLeft >= width + gap) {
                                 targetX = thumbPos.x - width - gap;
                             } else {
-                                // 两侧都不够，贴右侧边缘
-                                targetX = winW - width - AppStyle.spacing.xs;
+                                targetX = (winW - width) / 2;
                             }
                             x = Math.max(AppStyle.spacing.xs, Math.min(targetX, winW - width - AppStyle.spacing.xs));
-                            // 垂直居中，clamp 到窗口范围
                             var targetY = thumbPos.y + (thumbH - height) / 2;
                             y = Math.max(AppStyle.spacing.xs, Math.min(targetY, winH - height - AppStyle.spacing.xs));
+                            scaleOriginX = Math.max(0, Math.min(width, thumbCenterX - x));
+                            scaleOriginY = Math.max(0, Math.min(height, thumbCenterY - y));
                         }
                     }
 
                     enter: Transition {
-                        NumberAnimation {
-                            property: "opacity"
-                            from: 0
-                            to: 1
-                            duration: 150
+                        ParallelAnimation {
+                            NumberAnimation {
+                                property: "opacity"
+                                from: 0
+                                to: 1
+                                duration: AppStyle.durations.fast
+                                easing.type: AppStyle.easings.easeOut
+                            }
+                            NumberAnimation {
+                                property: "popupScale"
+                                from: 0.38
+                                to: 1
+                                duration: AppStyle.durations.normal
+                                easing.type: AppStyle.easings.easeOut
+                            }
                         }
                     }
 
                     exit: Transition {
-                        NumberAnimation {
-                            property: "opacity"
-                            from: 1
-                            to: 0
-                            duration: 150
+                        ParallelAnimation {
+                            NumberAnimation {
+                                property: "opacity"
+                                from: 1
+                                to: 0
+                                duration: AppStyle.durations.fast
+                                easing.type: AppStyle.easings.easeIn
+                            }
+                            NumberAnimation {
+                                property: "popupScale"
+                                from: 1
+                                to: 0.92
+                                duration: AppStyle.durations.fast
+                                easing.type: AppStyle.easings.easeIn
+                            }
                         }
                     }
 
                     background: Rectangle {
-                        color: AppStyle.colors.surface
-                        border.color: AppStyle.colors.primary
-                        border.width: previewPopup.framePadding
-                        radius: AppStyle.radius.md
-                        // 阴影效果
-                        layer.enabled: true
-                        layer.effect: MultiEffect {
-                            shadowEnabled: true
-                            shadowBlur: 1.0
-                            shadowColor: AppStyle.isDarkMode ? "#00000000" : "#33000000"
-                            shadowVerticalOffset: 2
-                            shadowHorizontalOffset: 2
-                        }
+                        color: "transparent"
                     }
 
                     contentItem: Item {
-                        implicitWidth: previewPopup.rowWidth
-                        implicitHeight: previewPopup.imageSize
+                        implicitWidth: previewPopup.width
+                        implicitHeight: previewPopup.height
                         visible: itemData && itemData.isValid
-                        // 有预览图时显示所有图片（最多3张）
-                        Row {
-                            id: previewPopupImageRow
+                        transform: Scale {
+                            origin.x: previewPopup.scaleOriginX
+                            origin.y: previewPopup.scaleOriginY
+                            xScale: previewPopup.popupScale
+                            yScale: previewPopup.popupScale
+                        }
+
+                        Rectangle {
                             anchors.fill: parent
-                            spacing: previewPopup.imageSpacing
-                            visible: previewPopup.imageSources.length > 0
-                            Repeater {
-                                model: previewPopup.imageSources.length
-                                Rectangle {
-                                    width: previewPopup.imageSize
-                                    height: previewPopup.imageSize
-                                    color: AppStyle.colors.background
-                                    radius: AppStyle.radius.sm
-                                    border.color: AppStyle.colors.border
-                                    border.width: AppStyle.borderWidths.thin
-                                    clip: true
-                                    Image {
-                                        anchors.fill: parent
-                                        sourceSize: Qt.size(previewPopup.imageSize, previewPopup.imageSize)
-                                        source: {
-                                            if (index < 0 || index >= previewPopup.imageSources.length) {
-                                                return "";
-                                            }
-                                            return previewPopup.imageSources[index];
-                                        }
-                                        fillMode: Image.PreserveAspectFit
-                                        cache: true
-                                        asynchronous: true
-                                    }
+                            color: AppStyle.isDarkMode ? Qt.rgba(15 / 255, 23 / 255, 42 / 255, 0.9) : Qt.rgba(1, 1, 1, 0.92)
+                            border.width: AppStyle.borderWidths.thin
+                            border.color: AppStyle.isDarkMode ? Qt.rgba(1, 1, 1, 0.12) : Qt.rgba(15 / 255, 23 / 255, 42 / 255, 0.08)
+                            radius: AppStyle.radius.lg
+                            layer.enabled: true
+                            layer.effect: MultiEffect {
+                                shadowEnabled: true
+                                shadowBlur: 0.82
+                                shadowColor: AppStyle.isDarkMode ? "#cc000000" : "#2a0f172a"
+                                shadowVerticalOffset: 10
+                                shadowHorizontalOffset: 0
+                            }
+                        }
 
-                                    // 图片序号标记
-                                    Rectangle {
-                                        anchors.top: parent.top
-                                        anchors.right: parent.right
-                                        width: 20
-                                        height: 20
-                                        color: AppStyle.colors.primary
-                                        radius: width / 2  // 声明式圆角
-                                        Text {
-                                            anchors.centerIn: parent
-                                            text: index + 1
-                                            font.pixelSize: 11  // 小尺寸序号，暂不归入标准字体阶梯
-                                            font.bold: true
-                                            color: AppStyle.colors.textOnPrimary
+                        HoverHandler {
+                            id: previewPopupHover
+                            onHoveredChanged: {
+                                if (hovered) {
+                                    previewHideTimer.stop();
+                                } else {
+                                    previewHideTimer.restart();
+                                }
+                            }
+                        }
+
+                        Column {
+                            id: galleryColumn
+                            anchors.fill: parent
+                            anchors.margins: previewPopup.panelPadding
+                            spacing: previewPopup.stripHeight > 0 ? AppStyle.spacing.sm : 0
+                            visible: previewPopup.hasImages
+
+                            Rectangle {
+                                width: parent.width
+                                height: previewPopup.headerHeight
+                                color: "transparent"
+                                Text {
+                                    anchors.left: parent.left
+                                    anchors.right: imageCounter.left
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    anchors.rightMargin: AppStyle.spacing.md
+                                    text: itemData ? itemData.componentId : ""
+                                    color: AppStyle.colors.textPrimary
+                                    font.pixelSize: AppStyle.fontSizes.sm
+                                    font.family: "Courier New"
+                                    font.bold: true
+                                    elide: Text.ElideRight
+                                }
+                                Text {
+                                    id: imageCounter
+                                    anchors.right: parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    text: previewPopup.imageSources.length > 1 ? (previewPopup.mainIndex + 1) + "/" + previewPopup.imageSources.length : ""
+                                    color: AppStyle.colors.textSecondary
+                                    font.pixelSize: AppStyle.fontSizes.xs
+                                }
+                            }
+
+                            Rectangle {
+                                id: mainImageSurface
+                                width: parent.width
+                                height: previewPopup.mainImageSize
+                                color: AppStyle.isDarkMode ? Qt.rgba(1, 1, 1, 0.035) : Qt.rgba(15 / 255, 23 / 255, 42 / 255, 0.025)
+                                radius: AppStyle.radius.md
+                                clip: true
+                                border.width: AppStyle.borderWidths.thin
+                                border.color: AppStyle.isDarkMode ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(15 / 255, 23 / 255, 42 / 255, 0.06)
+
+                                Canvas {
+                                    anchors.fill: parent
+                                    opacity: AppStyle.isDarkMode ? 0.28 : 0.42
+                                    onPaint: {
+                                        var ctx = getContext("2d");
+                                        ctx.clearRect(0, 0, width, height);
+                                        ctx.strokeStyle = AppStyle.isDarkMode ? "rgba(148, 163, 184, 0.24)" : "rgba(100, 116, 139, 0.24)";
+                                        ctx.lineWidth = 1;
+                                        var step = 16;
+                                        for (var xPos = 0; xPos <= width; xPos += step) {
+                                            ctx.beginPath();
+                                            ctx.moveTo(xPos + 0.5, 0);
+                                            ctx.lineTo(xPos + 0.5, height);
+                                            ctx.stroke();
+                                        }
+                                        for (var yPos = 0; yPos <= height; yPos += step) {
+                                            ctx.beginPath();
+                                            ctx.moveTo(0, yPos + 0.5);
+                                            ctx.lineTo(width, yPos + 0.5);
+                                            ctx.stroke();
                                         }
                                     }
+                                }
 
-                                    // 底部元器件编号遮罩
+                                Image {
+                                    anchors.fill: parent
+                                    anchors.margins: AppStyle.spacing.sm
+                                    sourceSize: Qt.size(previewPopup.mainImageSize * 1.5, previewPopup.mainImageSize * 1.5)
+                                    source: previewPopup.imageSources.length > 0 ? previewPopup.imageSources[Math.min(previewPopup.mainIndex, previewPopup.imageSources.length - 1)] : ""
+                                    fillMode: Image.PreserveAspectFit
+                                    cache: true
+                                    asynchronous: true
+                                    smooth: true
+                                    mipmap: true
+                                }
+                            }
+
+                            Row {
+                                id: thumbnailStrip
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                height: previewPopup.stripHeight
+                                spacing: previewPopup.thumbGap
+                                visible: previewPopup.imageSources.length > 1
+                                Repeater {
+                                    model: previewPopup.imageSources.length
                                     Rectangle {
-                                        anchors.bottom: parent.bottom
-                                        anchors.horizontalCenter: parent.horizontalCenter
-                                        width: parent.width
-                                        height: 25
-                                        color: AppStyle.colors.overlay
-                                        Text {
-                                            anchors.centerIn: parent
-                                            text: itemData ? itemData.componentId : ""
-                                            color: AppStyle.colors.textOnPrimary
-                                            font.bold: true
-                                            font.pixelSize: AppStyle.fontSizes.xxs
+                                        width: previewPopup.thumbSize
+                                        height: previewPopup.thumbSize
+                                        color: index === previewPopup.mainIndex ? (AppStyle.isDarkMode ? Qt.rgba(59 / 255, 130 / 255, 246 / 255, 0.18) : Qt.rgba(59 / 255, 130 / 255, 246 / 255, 0.1)) : "transparent"
+                                        radius: AppStyle.radius.xs
+                                        border.width: AppStyle.borderWidths.thin
+                                        border.color: index === previewPopup.mainIndex ? AppStyle.colors.primary : (AppStyle.isDarkMode ? Qt.rgba(1, 1, 1, 0.12) : Qt.rgba(15 / 255, 23 / 255, 42 / 255, 0.08))
+                                        clip: true
+                                        Image {
+                                            anchors.fill: parent
+                                            anchors.margins: 3
+                                            sourceSize: Qt.size(previewPopup.thumbSize, previewPopup.thumbSize)
+                                            source: previewPopup.imageSources[index]
+                                            fillMode: Image.PreserveAspectFit
+                                            cache: true
+                                            asynchronous: true
+                                            smooth: true
+                                        }
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            hoverEnabled: true
+                                            cursorShape: Qt.PointingHandCursor
+                                            onEntered: previewPopup.mainIndex = index
+                                            onClicked: previewPopup.mainIndex = index
                                         }
                                     }
                                 }
                             }
                         }
 
-                        // 无预览图时显示提示
-                        Text {
-                            anchors.centerIn: parent
-                            text: "无预览图"
-                            font.pixelSize: AppStyle.fontSizes.lg
-                            font.bold: true
-                            color: AppStyle.colors.textSecondary
+                        Item {
+                            anchors.fill: parent
                             visible: !itemData || previewPopup.imageSources.length === 0
+
+                            Item {
+                                id: emptyChipShape
+                                anchors.centerIn: parent
+                                anchors.verticalCenterOffset: -AppStyle.spacing.lg
+                                width: 74
+                                height: 54
+                                Rectangle {
+                                    anchors.centerIn: parent
+                                    width: 38
+                                    height: 30
+                                    radius: AppStyle.radius.xs
+                                    color: "transparent"
+                                    border.width: AppStyle.borderWidths.thin
+                                    border.color: AppStyle.colors.textDisabled
+                                }
+                                Repeater {
+                                    model: 4
+                                    Rectangle {
+                                        x: 8
+                                        y: 15 + index * 7
+                                        width: 10
+                                        height: 1
+                                        color: AppStyle.colors.textDisabled
+                                    }
+                                }
+                                Repeater {
+                                    model: 4
+                                    Rectangle {
+                                        x: 56
+                                        y: 15 + index * 7
+                                        width: 10
+                                        height: 1
+                                        color: AppStyle.colors.textDisabled
+                                    }
+                                }
+                            }
+                            Text {
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                anchors.top: emptyChipShape.bottom
+                                anchors.topMargin: AppStyle.spacing.sm
+                                text: "无预览图"
+                                font.pixelSize: AppStyle.fontSizes.sm
+                                color: AppStyle.colors.textSecondary
+                            }
                         }
                     }
                 }
             }
 
+            Timer {
+                id: previewHideTimer
+                interval: 120
+                repeat: false
+                onTriggered: {
+                    if (previewMouseArea.containsMouse)
+                        return;
+                    if (previewPopupLoader.item && previewPopupLoader.item.containsMouse)
+                        return;
+                    previewArea.hidePreviewPopup();
+                }
+            }
+
             // 预览图弹窗显示函数
             function showPreviewPopup() {
+                previewHideTimer.stop();
                 if (!previewPopupLoader.active) {
                     previewPopupLoader.pendingShow = true;
                     previewPopupLoader.active = true;
@@ -524,10 +682,11 @@ Rectangle {
                 }
                 onContainsMouseChanged: {
                     if (containsMouse) {
+                        previewHideTimer.stop();
                         hoverDelayTimer.start();
                     } else {
                         hoverDelayTimer.stop();
-                        previewArea.hidePreviewPopup();
+                        previewHideTimer.restart();
                     }
                 }
             }

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -23,6 +23,21 @@ Rectangle {
     // 缓存搜索正则以优化性能
     property string cachedSearchText: ""
     property var cachedRegex: null
+    function previewImageSource(imageData) {
+        if (!imageData || imageData === "")
+            return "";
+        if (imageData.indexOf("data:image/") === 0)
+            return imageData;
+        if (imageData.indexOf("/9j/") === 0)
+            return "data:image/jpeg;base64," + imageData;
+        if (imageData.indexOf("iVBOR") === 0)
+            return "data:image/png;base64," + imageData;
+        if (imageData.indexOf("R0lG") === 0)
+            return "data:image/gif;base64," + imageData;
+        if (imageData.indexOf("UklGR") === 0)
+            return "data:image/webp;base64," + imageData;
+        return "data:image/png;base64," + imageData;
+    }
     Timer {
         id: regexUpdateTimer
         interval: 100
@@ -188,9 +203,7 @@ Rectangle {
                         if (!itemData.previewImages || itemData.previewImages.length === 0)
                             return "";
                         var imageData = itemData.previewImages[0];
-                        if (!imageData || imageData === "")
-                            return "";
-                        return "data:image/jpeg;base64," + imageData;
+                        return rootItem.previewImageSource(imageData);
                     }
                     fillMode: Image.PreserveAspectFit
                     cache: true
@@ -408,10 +421,7 @@ Rectangle {
                                                 return "";
                                             }
                                             var imageData = itemData.previewImages[index];
-                                            if (!imageData) {
-                                                return "";
-                                            }
-                                            return "data:image/jpeg;base64," + imageData;
+                                            return rootItem.previewImageSource(imageData);
                                         }
                                         fillMode: Image.PreserveAspectFit
                                         cache: true

--- a/src/ui/qml/components/ResultListItem.qml
+++ b/src/ui/qml/components/ResultListItem.qml
@@ -68,7 +68,7 @@ Rectangle {
     }
 
     height: 72
-    color: itemMouseArea.containsMouse ? AppStyle.colors.background : AppStyle.colors.surface
+    color: itemHover.hovered ? AppStyle.colors.background : AppStyle.colors.surface
     radius: AppStyle.radius.md
     border.color: AppStyle.colors.border
     border.width: AppStyle.borderWidths.thin
@@ -126,6 +126,34 @@ Rectangle {
         id: copyFeedbackTimer
         interval: 1500
         onTriggered: copyFeedback.visible = false
+    }
+
+    HoverHandler {
+        id: itemHover
+    }
+
+    MouseArea {
+        id: itemMouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        cursorShape: Qt.ArrowCursor
+        acceptedButtons: Qt.RightButton | Qt.LeftButton
+        onClicked: mouse => {
+            if (mouse.button === Qt.RightButton) {
+                if (componentId) {
+                    copyHelper.text = componentId;
+                    copyHelper.selectAll();
+                    copyHelper.copy();
+                    item.copyClicked();
+                    copyFeedback.visible = true;
+                    copyFeedbackTimer.start();
+                }
+            } else if (mouse.button === Qt.LeftButton && (mouse.modifiers & Qt.ControlModifier)) {
+                if (componentId) {
+                    Qt.openUrlExternally("https://so.szlcsc.com/global.html?k=" + componentId);
+                }
+            }
+        }
     }
 
     RowLayout {
@@ -292,7 +320,7 @@ Rectangle {
             Layout.alignment: Qt.AlignVCenter
             Rectangle {
                 anchors.fill: parent
-                color: retryButtonHovered ? AppStyle.colors.warningLight : "transparent"
+                color: retryButtonMouseArea.containsMouse ? AppStyle.colors.warningLight : "transparent"
                 radius: AppStyle.radius.sm
             }
             Text {
@@ -302,9 +330,17 @@ Rectangle {
                 font.bold: true
                 color: AppStyle.colors.warning
             }
-            ToolTip.visible: retryButtonHovered
+            ToolTip.visible: retryButtonMouseArea.containsMouse
             ToolTip.text: qsTr("重试")
             ToolTip.delay: 500
+            MouseArea {
+                id: retryButtonMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                acceptedButtons: Qt.LeftButton
+                onClicked: item.retryClicked()
+            }
         }
 
         Item {
@@ -316,7 +352,7 @@ Rectangle {
             Layout.alignment: Qt.AlignVCenter
             Rectangle {
                 anchors.fill: parent
-                color: deleteButtonHovered ? AppStyle.colors.dangerLight : "transparent"
+                color: deleteButtonMouseArea.containsMouse ? AppStyle.colors.dangerLight : "transparent"
                 radius: AppStyle.radius.sm
             }
             Text {
@@ -326,71 +362,16 @@ Rectangle {
                 font.bold: true
                 color: AppStyle.colors.danger
             }
-            ToolTip.visible: deleteButtonHovered
+            ToolTip.visible: deleteButtonMouseArea.containsMouse
             ToolTip.text: qsTr("删除")
             ToolTip.delay: 500
-        }
-    }
-
-    property bool retryButtonHovered: false
-    property bool deleteButtonHovered: false
-    MouseArea {
-        id: itemMouseArea
-        anchors.fill: parent
-        hoverEnabled: true
-        cursorShape: Qt.ArrowCursor
-        acceptedButtons: Qt.RightButton | Qt.LeftButton
-        onMouseXChanged: {
-            var inRetryArea = false;
-            var inDeleteArea = false;
-            if (retryButton.visible) {
-                var retryBtnX = item.width - AppStyle.spacing.lg - retryButton.width - AppStyle.spacing.md - deleteButton.width;
-                var retryBtnY = (item.height - retryButton.height) / 2;
-                if (mouseX >= retryBtnX && mouseX <= retryBtnX + retryButton.width && mouseY >= retryBtnY && mouseY <= retryBtnY + retryButton.height)
-                    inRetryArea = true;
-            }
-            if (deleteButton.visible) {
-                var deleteBtnX = item.width - AppStyle.spacing.lg - deleteButton.width;
-                var deleteBtnY = (item.height - deleteButton.height) / 2;
-                if (mouseX >= deleteBtnX && mouseX <= deleteBtnX + deleteButton.width && mouseY >= deleteBtnY && mouseY <= deleteBtnY + deleteButton.height)
-                    inDeleteArea = true;
-            }
-            retryButtonHovered = inRetryArea;
-            deleteButtonHovered = inDeleteArea;
-        }
-
-        onClicked: mouse => {
-            if (deleteButton.visible) {
-                var deleteBtnX = item.width - AppStyle.spacing.lg - deleteButton.width;
-                var deleteBtnY = (item.height - deleteButton.height) / 2;
-                if (mouse.x >= deleteBtnX && mouse.x <= deleteBtnX + deleteButton.width && mouse.y >= deleteBtnY && mouse.y <= deleteBtnY + deleteButton.height) {
-                    item.deleteClicked();
-                    return;
-                }
-            }
-
-            if (retryButton.visible) {
-                var retryBtnX = item.width - AppStyle.spacing.lg - retryButton.width - AppStyle.spacing.md - deleteButton.width;
-                var retryBtnY = (item.height - retryButton.height) / 2;
-                if (mouse.x >= retryBtnX && mouse.x <= retryBtnX + retryButton.width && mouse.y >= retryBtnY && mouse.y <= retryBtnY + retryButton.height) {
-                    item.retryClicked();
-                    return;
-                }
-            }
-
-            if (mouse.button === Qt.RightButton) {
-                if (componentId) {
-                    copyHelper.text = componentId;
-                    copyHelper.selectAll();
-                    copyHelper.copy();
-                    item.copyClicked();
-                    copyFeedback.visible = true;
-                    copyFeedbackTimer.start();
-                }
-            } else if (mouse.button === Qt.LeftButton && (mouse.modifiers & Qt.ControlModifier)) {
-                if (componentId) {
-                    Qt.openUrlExternally("https://so.szlcsc.com/global.html?k=" + componentId);
-                }
+            MouseArea {
+                id: deleteButtonMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                acceptedButtons: Qt.LeftButton
+                onClicked: item.deleteClicked()
             }
         }
     }

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -996,8 +996,19 @@ void ComponentListViewModel::batchUpdatePreviewImages() {
                 images.append(img);
             }
 
-            auto callback = [this](const QString& cid, const QStringList& encoded) {
-                onPreviewImageEncodingDone(cid, encoded);
+            QPointer<ComponentListViewModel> self(this);
+            auto callback = [self](const QString& cid, const QStringList& encoded) {
+                if (!self) {
+                    return;
+                }
+                QMetaObject::invokeMethod(
+                    self,
+                    [self, cid, encoded]() {
+                        if (self) {
+                            self->onPreviewImageEncodingDone(cid, encoded);
+                        }
+                    },
+                    Qt::QueuedConnection);
             };
             PreviewImageEncodeRunnable* runnable = new PreviewImageEncodeRunnable(item, images, callback);
 

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -17,7 +17,7 @@ namespace EasyKiConverter {
 PreviewImageEncodeRunnable::PreviewImageEncodeRunnable(ComponentListItemData* item,
                                                        const QList<QImage>& images,
                                                        std::function<void(const QString&, const QStringList&)> callback)
-    : m_item(item), m_images(images), m_callback(callback) {}
+    : m_componentId(item ? item->componentId() : QString()), m_images(images), m_callback(callback) {}
 
 void PreviewImageEncodeRunnable::run() {
     QStringList encodedList;
@@ -33,9 +33,8 @@ void PreviewImageEncodeRunnable::run() {
         encodedList.append(QString::fromLatin1(byteArray.toBase64().data()));
     }
 
-    QString componentId = m_item ? m_item->componentId() : QString();
     if (m_callback) {
-        m_callback(componentId, encodedList);
+        m_callback(m_componentId, encodedList);
     }
 }
 
@@ -185,6 +184,13 @@ ComponentListViewModel::ComponentListViewModel(ComponentService* service, QObjec
 }
 
 ComponentListViewModel::~ComponentListViewModel() {
+    if (m_encodingThreadPool) {
+        m_encodingThreadPool->clear();
+        if (!m_encodingThreadPool->waitForDone(5000)) {
+            qWarning() << "ComponentListViewModel: preview image encoding thread pool did not finish in time";
+        }
+    }
+
     qDeleteAll(m_componentList);
     m_componentList.clear();
 }
@@ -996,19 +1002,9 @@ void ComponentListViewModel::batchUpdatePreviewImages() {
                 images.append(img);
             }
 
-            QPointer<ComponentListViewModel> self(this);
-            auto callback = [self](const QString& cid, const QStringList& encoded) {
-                if (!self) {
-                    return;
-                }
+            auto callback = [this](const QString& cid, const QStringList& encoded) {
                 QMetaObject::invokeMethod(
-                    self,
-                    [self, cid, encoded]() {
-                        if (self) {
-                            self->onPreviewImageEncodingDone(cid, encoded);
-                        }
-                    },
-                    Qt::QueuedConnection);
+                    this, [this, cid, encoded]() { onPreviewImageEncodingDone(cid, encoded); }, Qt::QueuedConnection);
             };
             PreviewImageEncodeRunnable* runnable = new PreviewImageEncodeRunnable(item, images, callback);
 

--- a/src/ui/viewmodels/ComponentListViewModel.h
+++ b/src/ui/viewmodels/ComponentListViewModel.h
@@ -29,7 +29,7 @@ public:
     void run() override;
 
 private:
-    QPointer<ComponentListItemData> m_item;
+    QString m_componentId;
     QList<QImage> m_images;
     std::function<void(const QString&, const QStringList&)> m_callback;
 };

--- a/tests/ui/tst_ExportResultsCard.qml
+++ b/tests/ui/tst_ExportResultsCard.qml
@@ -142,6 +142,12 @@ TestCase {
         return button
     }
 
+    function resultActionButton(componentId, objectName) {
+        var button = findByObjectName(resultItem(componentId), objectName)
+        verify(button !== null, "result action button should be discoverable: " + objectName)
+        return button
+    }
+
     function test_hiddenWhenIdleWithNoResults() {
         compare(resultsCard.active, false)
         compare(resultsCard.visible, false)
@@ -204,6 +210,16 @@ TestCase {
         compare(progressController.lastRetryComponentId, "C200")
 
         failedItem.deleteClicked()
+        compare(progressController.lastRemovedComponentId, "C200")
+    }
+
+    function test_retryAndDeleteButtonsUseTheirVisualHitAreas() {
+        loadResults()
+
+        mouseClick(resultActionButton("C200", "retryResultButton"))
+        compare(progressController.lastRetryComponentId, "C200")
+
+        mouseClick(resultActionButton("C200", "deleteResultButton"))
         compare(progressController.lastRemovedComponentId, "C200")
     }
 }

--- a/tests/unit/test_temp_file_manager.cpp
+++ b/tests/unit/test_temp_file_manager.cpp
@@ -39,6 +39,7 @@ private slots:
         QCOMPARE(commitSpy.at(0).at(1).toBool(), true);
         QCOMPARE(readFile(finalPath), QByteArrayLiteral("symbol library"));
         QVERIFY(!QFile::exists(tempPath));
+        QVERIFY(!QDir(QDir(tempDir.path()).filePath(QStringLiteral(".tmp"))).exists());
         QVERIFY(manager.registeredTempFiles().isEmpty());
     }
 
@@ -61,6 +62,7 @@ private slots:
         QVERIFY(manager.commitDirectory(finalDirPath));
 
         QVERIFY(!QDir(tempDirPath).exists());
+        QVERIFY(!QDir(QDir(tempDir.path()).filePath(QStringLiteral(".tmp"))).exists());
         QVERIFY(!QFile::exists(QDir(finalDirPath).filePath(QStringLiteral("old.kicad_mod"))));
         QCOMPARE(readFile(QDir(finalDirPath).filePath(QStringLiteral("new.kicad_mod"))), QByteArrayLiteral("new"));
         QVERIFY(manager.registeredTempFiles().isEmpty());
@@ -171,6 +173,7 @@ private slots:
         QCOMPARE(cleanupSpy.at(0).at(0).toInt(), 2);
         QVERIFY(!QFile::exists(tempFilePath));
         QVERIFY(!QDir(tempDirPath).exists());
+        QVERIFY(!QDir(QDir(tempDir.path()).filePath(QStringLiteral(".tmp"))).exists());
         QVERIFY(manager.registeredTempFiles().isEmpty());
     }
 


### PR DESCRIPTION
Summary

  - 修复导出取消时 cancelWithTempRollback() 无限递归导致的 SIGSEGV 崩溃
  - 修复 3D 模型导出取消时访问已释放 std::atomic 的段错误
  - 重构 Model3DExportWorker，移除 Exporter3DModel 成员变量，改用局部变量
  - 新增 TempFileManager 临时目录清理功能
  - 重设计 ComponentListItem 预览图悬停弹窗：自适应尺寸、Flow 布局、整体边框
  - 重构 ResultListItem 鼠标交互逻辑