### PR TITLE
feat(ui): 响应式侧边栏布局重构与缓存写入保护机制

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,12 @@ set(QML_FILES
     src/ui/qml/components/WindowResizeHandles.qml
     src/ui/qml/components/ExitDialog.qml
     src/ui/qml/components/SliderDialogBase.qml
+    src/ui/qml/components/SidebarPanel.qml
+    src/ui/qml/components/SidebarSettingsView.qml
+    src/ui/qml/components/SidebarSection.qml
+    src/ui/qml/components/SidebarToggleRow.qml
+    src/ui/qml/components/SidebarTextField.qml
+    src/ui/qml/components/SidebarSegmentedControl.qml
     src/ui/qml/styles/AppStyle.qml
     src/ui/qml/styles/ResponsiveHelper.qml
 )

--- a/resources/translations/translations_easykiconverter_en.ts
+++ b/resources/translations/translations_easykiconverter_en.ts
@@ -272,6 +272,55 @@ Conversion completed: %1 succeeded, %2 failed</translation>
     </message>
 </context>
 <context>
+    <name>SystemTrayManager</name>
+    <message>
+        <source>EasyKiConverter - LCSC 转换工具</source>
+        <translation>EasyKiConverter - LCSC Converter</translation>
+    </message>
+    <message>
+        <source>显示窗口</source>
+        <translation>Show Window</translation>
+    </message>
+    <message>
+        <source>退出</source>
+        <translation>Quit</translation>
+    </message>
+    <message>
+        <source>导出完成</source>
+        <translation>Export Complete</translation>
+    </message>
+    <message>
+        <source>导出失败：%1 个元器件全部失败</source>
+        <translation>Export failed: all %1 components failed</translation>
+    </message>
+    <message>
+        <source>成功 %1 个，失败 %2 个</source>
+        <translation>%1 succeeded, %2 failed</translation>
+    </message>
+    <message>
+        <source>
+输出：符号 %1 · 封装 %2 · 3D %3</source>
+        <translation>
+Output: Symbols %1 · Footprints %2 · 3D %3</translation>
+    </message>
+    <message>
+        <source>成功导出 1 个元器件</source>
+        <translation>Successfully exported 1 component</translation>
+    </message>
+    <message>
+        <source>成功导出 %1 个元器件</source>
+        <translation>Successfully exported %1 components</translation>
+    </message>
+    <message>
+        <source>输出：符号 %1 · 封装 %2 · 3D %3</source>
+        <translation>Output: Symbols %1 · Footprints %2 · 3D %3</translation>
+    </message>
+    <message>
+        <source>耗时：%1</source>
+        <translation>Duration: %1</translation>
+    </message>
+</context>
+<context>
     <name>ComponentListCard</name>
     <message>
         <location filename="../../src/ui/qml/components/ComponentListCard.qml" line="386"/>
@@ -293,6 +342,10 @@ Conversion completed: %1 succeeded, %2 failed</translation>
         <source>无效 (%1)</source>
         <translation>Invalid (%1)</translation>
     </message>
+    <message>
+        <source>无预览图</source>
+        <translation>No Preview</translation>
+    </message>
 </context>
 <context>
     <name>ComponentListItem</name>
@@ -309,6 +362,53 @@ Conversion completed: %1 succeeded, %2 failed</translation>
         <location filename="../../src/ui/qml/components/ComponentListItem.qml" line="590"/>
         <source>编辑元器件描述</source>
         <translation>Edit Component Description</translation>
+    </message>
+    <message>
+        <source>正在导出...</source>
+        <translation>Exporting...</translation>
+    </message>
+    <message>
+        <source>导出完成</source>
+        <translation>Export Complete</translation>
+    </message>
+    <message>
+        <source>导出失败</source>
+        <translation>Export Failed</translation>
+    </message>
+    <message>
+        <source>正在验证 CAD 数据...</source>
+        <translation>Validating CAD data...</translation>
+    </message>
+    <message>
+        <source>正在获取预览图...</source>
+        <translation>Fetching preview...</translation>
+    </message>
+    <message>
+        <source>验证失败</source>
+        <translation>Validation Failed</translation>
+    </message>
+</context>
+<context>
+    <name>ComponentListViewModel</name>
+    <message>
+        <source>元器件不存在（404）</source>
+        <translation>Component not found (404)</translation>
+    </message>
+    <message>
+        <source>预览图获取超时（网络不稳定）</source>
+        <translation>Preview image fetch timeout (unstable network)</translation>
+    </message>
+    <message>
+        <source>预览图不存在</source>
+        <translation>Preview image not found</translation>
+    </message>
+    <message>
+        <source>预览图获取被拒绝</source>
+        <translation>Preview image access denied</translation>
+    </message>
+    <message>
+        <source>预览图获取失败</source>
+        <translation>Preview image fetch failed</translation>
     </message>
 </context>
 <context>
@@ -443,6 +543,10 @@ Conversion completed: %1 succeeded, %2 failed</translation>
 </context>
 <context>
     <name>Main</name>
+    <message>
+        <source>EasyKiConverter - 元器件转换工具</source>
+        <translation>EasyKiConverter - Component Converter</translation>
+    </message>
     <message>
         <location filename="../../src/ui/qml/Main.qml" line="35"/>
         <source>确认退出</source>
@@ -984,6 +1088,154 @@ Conversion completed: %1 succeeded, %2 failed</translation>
         <location filename="../../src/ui/qml/components/UpdateBanner.qml" line="72"/>
         <source>稍后提醒</source>
         <translation>Remind Later</translation>
+    </message>
+    <message>
+        <source>元器件添加方式</source>
+        <translation>Component Input Method</translation>
+    </message>
+    <message>
+        <source>手动添加元器件</source>
+        <translation>Add Component Manually</translation>
+    </message>
+    <message>
+        <source>通过BOM表导入元器件</source>
+        <translation>Import Components from BOM</translation>
+    </message>
+    <message>
+        <source>点击选择 BOM 文件</source>
+        <translation>Click to Select BOM File</translation>
+    </message>
+    <message>
+        <source>文件已就绪</source>
+        <translation>File Ready</translation>
+    </message>
+    <message>
+        <source>支持格式: .xlsx, .csv, .txt</source>
+        <translation>Supported formats: .xlsx, .csv, .txt</translation>
+    </message>
+    <message>
+        <source>输出配置</source>
+        <translation>Output Configuration</translation>
+    </message>
+    <message>
+        <source>路径</source>
+        <translation>Path</translation>
+    </message>
+    <message>
+        <source>选择目录...</source>
+        <translation>Select Directory...</translation>
+    </message>
+    <message>
+        <source>符号库描述</source>
+        <translation>Symbol Library Description</translation>
+    </message>
+    <message>
+        <source>封装库描述</source>
+        <translation>Footprint Library Description</translation>
+    </message>
+    <message>
+        <source>库信息 (可选)</source>
+        <translation>Library Info (Optional)</translation>
+    </message>
+    <message>
+        <source>导出内容</source>
+        <translation>Export Content</translation>
+    </message>
+    <message>
+        <source>3D 模型</source>
+        <translation>3D Model</translation>
+    </message>
+    <message>
+        <source>数据手册</source>
+        <translation>Datasheet</translation>
+    </message>
+    <message>
+        <source>格式</source>
+        <translation>Format</translation>
+    </message>
+    <message>
+        <source>相对</source>
+        <translation>Relative</translation>
+    </message>
+    <message>
+        <source>覆盖</source>
+        <translation>Overwrite</translation>
+    </message>
+    <message>
+        <source>保留已有元器件，追加新的</source>
+        <translation>Keep existing components, append new ones</translation>
+    </message>
+    <message>
+        <source>覆盖已有元器件，追加新的</source>
+        <translation>Overwrite existing components, append new ones</translation>
+    </message>
+    <message>
+        <source>运行策略</source>
+        <translation>Runtime Strategy</translation>
+    </message>
+    <message>
+        <source>弱网模式</source>
+        <translation>Weak Network Mode</translation>
+    </message>
+    <message>
+        <source>展开设置</source>
+        <translation>Expand Settings</translation>
+    </message>
+    <message>
+        <source>收起设置</source>
+        <translation>Collapse Settings</translation>
+    </message>
+    <message>
+        <source>请先添加元器件</source>
+        <translation>Please add components first</translation>
+    </message>
+    <message>
+        <source>请至少选择一种导出类型</source>
+        <translation>Please select at least one export type</translation>
+    </message>
+    <message>
+        <source>开始导出</source>
+        <translation>Start Export</translation>
+    </message>
+    <message>
+        <source>正在导出中...</source>
+        <translation>Exporting...</translation>
+    </message>
+    <message>
+        <source>导出中</source>
+        <translation>Exporting</translation>
+    </message>
+    <message>
+        <source>转换中</source>
+        <translation>Converting</translation>
+    </message>
+    <message>
+        <source>停止</source>
+        <translation>Stop</translation>
+    </message>
+    <message>
+        <source>停止中</source>
+        <translation>Stopping</translation>
+    </message>
+    <message>
+        <source>重试</source>
+        <translation>Retry</translation>
+    </message>
+    <message>
+        <source>重试失败</source>
+        <translation>Retry Failed</translation>
+    </message>
+    <message>
+        <source>就绪</source>
+        <translation>Ready</translation>
+    </message>
+    <message>
+        <source>有 %1 项失败</source>
+        <translation>%1 item(s) failed</translation>
+    </message>
+    <message>
+        <source>打开目录</source>
+        <translation>Open Directory</translation>
     </message>
 </context>
 <context>

--- a/resources/translations/translations_easykiconverter_zh_CN.ts
+++ b/resources/translations/translations_easykiconverter_zh_CN.ts
@@ -271,6 +271,55 @@
     </message>
 </context>
 <context>
+    <name>SystemTrayManager</name>
+    <message>
+        <source>EasyKiConverter - LCSC 转换工具</source>
+        <translation>EasyKiConverter - LCSC 转换工具</translation>
+    </message>
+    <message>
+        <source>显示窗口</source>
+        <translation>显示窗口</translation>
+    </message>
+    <message>
+        <source>退出</source>
+        <translation>退出</translation>
+    </message>
+    <message>
+        <source>导出完成</source>
+        <translation>导出完成</translation>
+    </message>
+    <message>
+        <source>导出失败：%1 个元器件全部失败</source>
+        <translation>导出失败：%1 个元器件全部失败</translation>
+    </message>
+    <message>
+        <source>成功 %1 个，失败 %2 个</source>
+        <translation>成功 %1 个，失败 %2 个</translation>
+    </message>
+    <message>
+        <source>
+输出：符号 %1 · 封装 %2 · 3D %3</source>
+        <translation>
+输出：符号 %1 · 封装 %2 · 3D %3</translation>
+    </message>
+    <message>
+        <source>成功导出 1 个元器件</source>
+        <translation>成功导出 1 个元器件</translation>
+    </message>
+    <message>
+        <source>成功导出 %1 个元器件</source>
+        <translation>成功导出 %1 个元器件</translation>
+    </message>
+    <message>
+        <source>输出：符号 %1 · 封装 %2 · 3D %3</source>
+        <translation>输出：符号 %1 · 封装 %2 · 3D %3</translation>
+    </message>
+    <message>
+        <source>耗时：%1</source>
+        <translation>耗时：%1</translation>
+    </message>
+</context>
+<context>
     <name>ComponentListCard</name>
     <message>
         <location filename="../../src/ui/qml/components/ComponentListCard.qml" line="386"/>
@@ -292,6 +341,10 @@
         <source>无效 (%1)</source>
         <translation>无效 (%1)</translation>
     </message>
+    <message>
+        <source>无预览图</source>
+        <translation>无预览图</translation>
+    </message>
 </context>
 <context>
     <name>ComponentListItem</name>
@@ -303,7 +356,54 @@
     <message>
         <location filename="../../src/ui/qml/components/ComponentListItem.qml" line="590"/>
         <source>编辑元器件描述</source>
-        <translation type="unfinished"></translation>
+        <translation>编辑元器件描述</translation>
+    </message>
+    <message>
+        <source>正在导出...</source>
+        <translation>正在导出...</translation>
+    </message>
+    <message>
+        <source>导出完成</source>
+        <translation>导出完成</translation>
+    </message>
+    <message>
+        <source>导出失败</source>
+        <translation>导出失败</translation>
+    </message>
+    <message>
+        <source>正在验证 CAD 数据...</source>
+        <translation>正在验证 CAD 数据...</translation>
+    </message>
+    <message>
+        <source>正在获取预览图...</source>
+        <translation>正在获取预览图...</translation>
+    </message>
+    <message>
+        <source>验证失败</source>
+        <translation>验证失败</translation>
+    </message>
+</context>
+<context>
+    <name>ComponentListViewModel</name>
+    <message>
+        <source>元器件不存在（404）</source>
+        <translation>元器件不存在（404）</translation>
+    </message>
+    <message>
+        <source>预览图获取超时（网络不稳定）</source>
+        <translation>预览图获取超时（网络不稳定）</translation>
+    </message>
+    <message>
+        <source>预览图不存在</source>
+        <translation>预览图不存在</translation>
+    </message>
+    <message>
+        <source>预览图获取被拒绝</source>
+        <translation>预览图获取被拒绝</translation>
+    </message>
+    <message>
+        <source>预览图获取失败</source>
+        <translation>预览图获取失败</translation>
     </message>
 </context>
 <context>
@@ -530,6 +630,10 @@
 </context>
 <context>
     <name>Main</name>
+    <message>
+        <source>EasyKiConverter - 元器件转换工具</source>
+        <translation>EasyKiConverter - 元器件转换工具</translation>
+    </message>
     <message>
         <location filename="../../src/ui/qml/Main.qml" line="35"/>
         <source>确认退出</source>
@@ -1071,6 +1175,154 @@
         <location filename="../../src/ui/qml/components/UpdateBanner.qml" line="72"/>
         <source>稍后提醒</source>
         <translation>稍后提醒</translation>
+    </message>
+    <message>
+        <source>元器件添加方式</source>
+        <translation>元器件添加方式</translation>
+    </message>
+    <message>
+        <source>手动添加元器件</source>
+        <translation>手动添加元器件</translation>
+    </message>
+    <message>
+        <source>通过BOM表导入元器件</source>
+        <translation>通过BOM表导入元器件</translation>
+    </message>
+    <message>
+        <source>点击选择 BOM 文件</source>
+        <translation>点击选择 BOM 文件</translation>
+    </message>
+    <message>
+        <source>文件已就绪</source>
+        <translation>文件已就绪</translation>
+    </message>
+    <message>
+        <source>支持格式: .xlsx, .csv, .txt</source>
+        <translation>支持格式: .xlsx, .csv, .txt</translation>
+    </message>
+    <message>
+        <source>输出配置</source>
+        <translation>输出配置</translation>
+    </message>
+    <message>
+        <source>路径</source>
+        <translation>路径</translation>
+    </message>
+    <message>
+        <source>选择目录...</source>
+        <translation>选择目录...</translation>
+    </message>
+    <message>
+        <source>符号库描述</source>
+        <translation>符号库描述</translation>
+    </message>
+    <message>
+        <source>封装库描述</source>
+        <translation>封装库描述</translation>
+    </message>
+    <message>
+        <source>库信息 (可选)</source>
+        <translation>库信息 (可选)</translation>
+    </message>
+    <message>
+        <source>导出内容</source>
+        <translation>导出内容</translation>
+    </message>
+    <message>
+        <source>3D 模型</source>
+        <translation>3D 模型</translation>
+    </message>
+    <message>
+        <source>数据手册</source>
+        <translation>数据手册</translation>
+    </message>
+    <message>
+        <source>格式</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <source>相对</source>
+        <translation>相对</translation>
+    </message>
+    <message>
+        <source>覆盖</source>
+        <translation>覆盖</translation>
+    </message>
+    <message>
+        <source>保留已有元器件，追加新的</source>
+        <translation>保留已有元器件，追加新的</translation>
+    </message>
+    <message>
+        <source>覆盖已有元器件，追加新的</source>
+        <translation>覆盖已有元器件，追加新的</translation>
+    </message>
+    <message>
+        <source>运行策略</source>
+        <translation>运行策略</translation>
+    </message>
+    <message>
+        <source>弱网模式</source>
+        <translation>弱网模式</translation>
+    </message>
+    <message>
+        <source>展开设置</source>
+        <translation>展开设置</translation>
+    </message>
+    <message>
+        <source>收起设置</source>
+        <translation>收起设置</translation>
+    </message>
+    <message>
+        <source>请先添加元器件</source>
+        <translation>请先添加元器件</translation>
+    </message>
+    <message>
+        <source>请至少选择一种导出类型</source>
+        <translation>请至少选择一种导出类型</translation>
+    </message>
+    <message>
+        <source>开始导出</source>
+        <translation>开始导出</translation>
+    </message>
+    <message>
+        <source>正在导出中...</source>
+        <translation>正在导出中...</translation>
+    </message>
+    <message>
+        <source>导出中</source>
+        <translation>导出中</translation>
+    </message>
+    <message>
+        <source>转换中</source>
+        <translation>转换中</translation>
+    </message>
+    <message>
+        <source>停止</source>
+        <translation>停止</translation>
+    </message>
+    <message>
+        <source>停止中</source>
+        <translation>停止中</translation>
+    </message>
+    <message>
+        <source>重试</source>
+        <translation>重试</translation>
+    </message>
+    <message>
+        <source>重试失败</source>
+        <translation>重试失败</translation>
+    </message>
+    <message>
+        <source>就绪</source>
+        <translation>就绪</translation>
+    </message>
+    <message>
+        <source>有 %1 项失败</source>
+        <translation>有 %1 项失败</translation>
+    </message>
+    <message>
+        <source>打开目录</source>
+        <translation>打开目录</translation>
     </message>
 </context>
 <context>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -532,6 +532,8 @@ int main(int argc, char* argv[]) {
     // GUI 模式：使用完整的 QApplication
     // 设置 QML 样式为 Basic，以消除原生样式自定义警告
     QQuickStyle::setStyle("Basic");
+    // High DPI 适配：使用 PassThrough 策略避免分数缩放下的模糊和舍入误差
+    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 
     QApplication app(argc, argv);
 

--- a/src/services/CacheRepository.h
+++ b/src/services/CacheRepository.h
@@ -58,6 +58,7 @@ public:
         }
 
         const RetryPolicy policy = RetryPolicy::fromProfile(RequestProfiles::previewImage(), weakNetwork);
+        const uint64_t gen = cache->currentGeneration();
         AsyncNetworkRequest* request =
             NetworkClient::instance().getAsync(QUrl(imageUrl), ResourceType::PreviewImage, policy);
 
@@ -73,7 +74,7 @@ public:
                 diag.errorString = QStringLiteral("Cancelled");
                 onComplete(QByteArray(), diag);
             } else if (result.success) {
-                cache->savePreviewImage(lcscId, result.data, imageIndex);
+                cache->savePreviewImage(lcscId, result.data, imageIndex, gen);
                 onComplete(result.data, diag);
             } else {
                 diag.errorString = result.error;
@@ -120,6 +121,7 @@ public:
         }
 
         const RetryPolicy policy = RetryPolicy::fromProfile(RequestProfiles::datasheet(), weakNetwork);
+        const uint64_t gen = cache->currentGeneration();
         AsyncNetworkRequest* request =
             NetworkClient::instance().getAsync(QUrl(datasheetUrl), ResourceType::Datasheet, policy);
 
@@ -138,7 +140,7 @@ public:
                 if (ext == QStringLiteral("pdf") && result.data.size() >= 5 && !result.data.startsWith("%PDF-")) {
                     ext = QStringLiteral("html");
                 }
-                cache->saveDatasheet(lcscId, result.data, ext);
+                cache->saveDatasheet(lcscId, result.data, ext, gen);
                 onComplete(result.data, diag);
             } else {
                 diag.errorString = result.error;

--- a/src/services/ComponentCacheService.cpp
+++ b/src/services/ComponentCacheService.cpp
@@ -461,11 +461,14 @@ void ComponentCacheService::saveComponentMetadata(const QString& componentId,
     LOG_DEBUG(LogModule::Core, "Saved component metadata to cache: {}", componentId);
 }
 
-void ComponentCacheService::saveComponentMetadataAsync(const QString& componentId, const ComponentData& data) {
+void ComponentCacheService::saveComponentMetadataAsync(const QString& componentId,
+                                                       const ComponentData& data,
+                                                       uint64_t expectedGeneration) {
     // 异步版本：在后台线程执行文件I/O，不阻塞UI
     // 复制需要的数据以供后台线程使用
     const ComponentData dataCopy = data;
-    const uint64_t generation = m_cacheGeneration.load();
+    // 如果调用方没有传入 generation，则在入队时捕获当前值
+    const uint64_t generation = (expectedGeneration != 0) ? expectedGeneration : m_cacheGeneration.load();
 
     (void)QtConcurrent::run([this, componentId, dataCopy, generation]() {
         // 写入前检查代次：如果 clearAllCache 已调用，丢弃本次写入
@@ -770,6 +773,7 @@ QByteArray ComponentCacheService::downloadPreviewImage(const QString& lcscId,
     if (imageUrl.isEmpty() || imageIndex < 0) {
         return QByteArray();
     }
+    const uint64_t gen = currentGeneration();
 
     QElapsedTimer timer;
     timer.start();
@@ -834,7 +838,7 @@ QByteArray ComponentCacheService::downloadPreviewImage(const QString& lcscId,
 
     if (errorString.isEmpty() && !data.isEmpty()) {
         // 保存到磁盘缓存
-        savePreviewImage(lcscId, data, imageIndex);
+        savePreviewImage(lcscId, data, imageIndex, gen);
     } else if (!errorString.isEmpty() && errorString != "Cancelled") {
         LOG_WARN(LogModule::Core, "Preview image download failed for {}: {}", lcscId, errorString);
     }
@@ -909,6 +913,7 @@ QByteArray ComponentCacheService::downloadDatasheet(const QString& lcscId,
     if (datasheetUrl.isEmpty()) {
         return QByteArray();
     }
+    const uint64_t gen = currentGeneration();
 
     QElapsedTimer timer;
     timer.start();
@@ -985,7 +990,7 @@ QByteArray ComponentCacheService::downloadDatasheet(const QString& lcscId,
 
     if (errorString.isEmpty() && !data.isEmpty()) {
         // 保存到磁盘缓存
-        saveDatasheet(lcscId, data, ext);
+        saveDatasheet(lcscId, data, ext, gen);
     } else if (!errorString.isEmpty() && errorString != "Cancelled") {
         LOG_WARN(LogModule::Core, "Datasheet download failed for {}: {}", lcscId, errorString);
     }

--- a/src/services/ComponentCacheService.cpp
+++ b/src/services/ComponentCacheService.cpp
@@ -421,7 +421,9 @@ QSharedPointer<ComponentData> ComponentCacheService::loadComponentData(const QSt
     return componentData;
 }
 
-void ComponentCacheService::saveComponentMetadata(const QString& componentId, const ComponentData& data) {
+void ComponentCacheService::saveComponentMetadata(const QString& componentId,
+                                                  const ComponentData& data,
+                                                  uint64_t expectedGeneration) {
     QJsonObject metadata = buildMetadata(componentId, data);
     const QJsonObject existingMetadata = loadMetadata(componentId);
     metadata = mergeMetadata(existingMetadata, metadata);
@@ -431,13 +433,28 @@ void ComponentCacheService::saveComponentMetadata(const QString& componentId, co
     QByteArray* newData = new QByteArray(doc.toJson(QJsonDocument::Compact));
     qint64 sizeAfterUpdate = 0;
 
+    // 代次检查 + L1 写入 + 磁盘写入在同一个互斥区内，彻底关闭竞态窗口
     {
-        QMutexLocker locker(&m_mutex);
-        m_memoryCache.insert(key, newData, newData->size());
-        sizeAfterUpdate = m_memoryCache.totalCost();
+        QMutexLocker diskLocker(&m_diskWriteMutex);
+        if (expectedGeneration != 0) {
+            if (m_cacheGeneration.load() != expectedGeneration) {
+                LOG_DEBUG(LogModule::Core, "Discarded stale write for {} (generation mismatch)", componentId);
+                delete newData;
+                return;
+            }
+            if (isTombstoned(componentId)) {
+                LOG_DEBUG(LogModule::Core, "Discarded write for tombstoned component {}", componentId);
+                delete newData;
+                return;
+            }
+        }
+        {
+            QMutexLocker locker(&m_mutex);
+            m_memoryCache.insert(key, newData, newData->size());
+            sizeAfterUpdate = m_memoryCache.totalCost();
+        }
+        saveMetadata(componentId, metadata);
     }
-
-    saveMetadata(componentId, metadata);
     enforceDiskCacheLimit();
     emit memoryCacheSizeChanged(sizeAfterUpdate);
     emit cacheSaved(componentId);
@@ -448,15 +465,31 @@ void ComponentCacheService::saveComponentMetadataAsync(const QString& componentI
     // 异步版本：在后台线程执行文件I/O，不阻塞UI
     // 复制需要的数据以供后台线程使用
     const ComponentData dataCopy = data;
+    const uint64_t generation = m_cacheGeneration.load();
 
-    (void)QtConcurrent::run([this, componentId, dataCopy]() { saveComponentMetadata(componentId, dataCopy); });
+    (void)QtConcurrent::run([this, componentId, dataCopy, generation]() {
+        // 写入前检查代次：如果 clearAllCache 已调用，丢弃本次写入
+        if (m_cacheGeneration.load() != generation) {
+            return;
+        }
+        saveComponentMetadata(componentId, dataCopy, generation);
+    });
 }
 
-void ComponentCacheService::saveSymbolData(const QString& lcscId, const QByteArray& data) {
+void ComponentCacheService::saveSymbolData(const QString& lcscId, const QByteArray& data, uint64_t expectedGeneration) {
     if (data.isEmpty()) {
         return;
     }
 
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    if (expectedGeneration != 0) {
+        if (m_cacheGeneration.load() != expectedGeneration) {
+            return;
+        }
+        if (isTombstoned(lcscId)) {
+            return;
+        }
+    }
     QString symbolPath;
     {
         QMutexLocker locker(&m_mutex);
@@ -500,11 +533,22 @@ QByteArray ComponentCacheService::loadSymbolData(const QString& lcscId) const {
     return QByteArray();
 }
 
-void ComponentCacheService::saveFootprintData(const QString& lcscId, const QByteArray& data) {
+void ComponentCacheService::saveFootprintData(const QString& lcscId,
+                                              const QByteArray& data,
+                                              uint64_t expectedGeneration) {
     if (data.isEmpty()) {
         return;
     }
 
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    if (expectedGeneration != 0) {
+        if (m_cacheGeneration.load() != expectedGeneration) {
+            return;
+        }
+        if (isTombstoned(lcscId)) {
+            return;
+        }
+    }
     QString footprintPath;
     {
         QMutexLocker locker(&m_mutex);
@@ -548,11 +592,22 @@ QByteArray ComponentCacheService::loadFootprintData(const QString& lcscId) const
     return QByteArray();
 }
 
-void ComponentCacheService::saveCadDataJson(const QString& lcscId, const QByteArray& cadData) {
+void ComponentCacheService::saveCadDataJson(const QString& lcscId,
+                                            const QByteArray& cadData,
+                                            uint64_t expectedGeneration) {
     if (cadData.isEmpty()) {
         return;
     }
 
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    if (expectedGeneration != 0) {
+        if (m_cacheGeneration.load() != expectedGeneration) {
+            return;
+        }
+        if (isTombstoned(lcscId)) {
+            return;
+        }
+    }
     QString cadDataPath;
     {
         QMutexLocker locker(&m_mutex);
@@ -671,11 +726,23 @@ QByteArray ComponentCacheService::loadPreviewImage(const QString& lcscId, int im
     return QByteArray();
 }
 
-void ComponentCacheService::savePreviewImage(const QString& lcscId, const QByteArray& imageData, int imageIndex) {
+void ComponentCacheService::savePreviewImage(const QString& lcscId,
+                                             const QByteArray& imageData,
+                                             int imageIndex,
+                                             uint64_t expectedGeneration) {
     if (imageIndex < 0 || imageIndex >= 3 || imageData.isEmpty()) {
         return;
     }
 
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    if (expectedGeneration != 0) {
+        if (m_cacheGeneration.load() != expectedGeneration) {
+            return;
+        }
+        if (isTombstoned(lcscId)) {
+            return;
+        }
+    }
     QString previewPath;
     {
         QMutexLocker locker(&m_mutex);
@@ -794,11 +861,21 @@ QByteArray ComponentCacheService::loadDatasheet(const QString& lcscId) const {
 
 void ComponentCacheService::saveDatasheet(const QString& lcscId,
                                           const QByteArray& datasheetData,
-                                          const QString& format) {
+                                          const QString& format,
+                                          uint64_t expectedGeneration) {
     if (datasheetData.isEmpty()) {
         return;
     }
 
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    if (expectedGeneration != 0) {
+        if (m_cacheGeneration.load() != expectedGeneration) {
+            return;
+        }
+        if (isTombstoned(lcscId)) {
+            return;
+        }
+    }
     QString actualPath;
     {
         QMutexLocker locker(&m_mutex);
@@ -942,11 +1019,18 @@ QByteArray ComponentCacheService::loadModel3D(const QString& uuid, const QString
     return QByteArray();
 }
 
-void ComponentCacheService::saveModel3D(const QString& uuid, const QByteArray& data, const QString& extension) {
+void ComponentCacheService::saveModel3D(const QString& uuid,
+                                        const QByteArray& data,
+                                        const QString& extension,
+                                        uint64_t expectedGeneration) {
     if (data.isEmpty()) {
         return;
     }
 
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    if (expectedGeneration != 0 && m_cacheGeneration.load() != expectedGeneration) {
+        return;
+    }
     QString path;
     {
         QMutexLocker locker(&m_mutex);
@@ -1006,7 +1090,14 @@ bool ComponentCacheService::copyModel3DToFile(const QString& uuid,
 // ==================== 缓存管理 ====================
 
 void ComponentCacheService::removeCache(const QString& lcscId) {
-    // 先删除L2磁盘缓存（不需要锁）
+    // 锁顺序：先 disk，后 tombstone（与其他方法一致）
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    // 标记为 tombstone，阻止旧回调写回
+    {
+        QMutexLocker tombLocker(&m_tombstoneMutex);
+        m_tombstones.insert(lcscId.toUpper());
+    }
+    // 先删除L2磁盘缓存
     QString dirPath = componentCacheDir(lcscId);
     if (dirPath.isEmpty()) {
         return;
@@ -1039,7 +1130,32 @@ void ComponentCacheService::removeCache(const QString& lcscId) {
     emit memoryCacheSizeChanged(sizeAfterUpdate);
 }
 
+void ComponentCacheService::clearTombstone(const QString& lcscId) {
+    QMutexLocker tombLocker(&m_tombstoneMutex);
+    m_tombstones.remove(lcscId.toUpper());
+}
+
+void ComponentCacheService::clearGlobalTombstone() {
+    QMutexLocker tombLocker(&m_tombstoneMutex);
+    m_allTombstoned = false;
+    m_tombstones.clear();
+}
+
+bool ComponentCacheService::isTombstoned(const QString& lcscId) const {
+    QMutexLocker tombLocker(&m_tombstoneMutex);
+    return m_allTombstoned || m_tombstones.contains(lcscId.toUpper());
+}
+
 void ComponentCacheService::clearAllCache() {
+    // 递增代次，使所有正在排队的异步写入任务失效
+    m_cacheGeneration.fetch_add(1);
+    // 锁顺序：先 disk，后 tombstone（与 save 方法一致，避免死锁）
+    QMutexLocker diskLocker(&m_diskWriteMutex);
+    // 全局 tombstone：阻止所有旧回调写入
+    {
+        QMutexLocker tombLocker(&m_tombstoneMutex);
+        m_allTombstoned = true;
+    }
     // 先清空L2磁盘缓存（不需要锁）
     {
         QDir dir(m_cacheDir);
@@ -1056,19 +1172,24 @@ void ComponentCacheService::clearAllCache() {
         }
     }
 
-    // 再清空L1内存缓存（需要锁）
-    clearMemoryCache();
+    // 再清空L1内存缓存（不重置 tombstone）
+    clearMemoryCacheInternal();
 
     emit cacheSizeChanged(0);
 }
 
+void ComponentCacheService::clearMemoryCacheInternal() {
+    QMutexLocker locker(&m_mutex);
+    m_memoryCache.clear();
+}
+
 void ComponentCacheService::clearMemoryCache() {
     {
-        QMutexLocker locker(&m_mutex);
-
-        // QCache::clear() 会删除所有对象并重置 totalCost() 为 0
-        m_memoryCache.clear();
+        QMutexLocker tombLocker(&m_tombstoneMutex);
+        m_allTombstoned = false;
+        m_tombstones.clear();
     }
+    clearMemoryCacheInternal();
     LOG_DEBUG(LogModule::Core, "Cleared memory cache");
     emit memoryCacheSizeChanged(0);
 }

--- a/src/services/ComponentCacheService.h
+++ b/src/services/ComponentCacheService.h
@@ -579,7 +579,7 @@ private:
     // 跟踪L1缓存总大小（字节）
     qint64 m_memoryCacheSize;
     // 缓存代次：clearAllCache 时递增，异步写入前检查，防止清空后旧任务写回
-    std::atomic<uint64_t> m_cacheGeneration{0};
+    std::atomic<uint64_t> m_cacheGeneration{1};
     // Per-component tombstone：removeCache 后阻止旧回调写回
     mutable QMutex m_tombstoneMutex;
     QSet<QString> m_tombstones;

--- a/src/services/ComponentCacheService.h
+++ b/src/services/ComponentCacheService.h
@@ -12,9 +12,12 @@
 #include <QJsonObject>
 #include <QMutex>
 #include <QObject>
+#include <QSet>
 #include <QSharedPointer>
 #include <QString>
 
+#include <atomic>
+#include <cstdint>
 #include <memory>
 
 class CacheHealthManager;
@@ -192,7 +195,7 @@ public:
      * @param data 元器件数据
      * @note 适用于测试或需要保存后立即可见的场景
      */
-    void saveComponentMetadata(const QString& componentId, const ComponentData& data);
+    void saveComponentMetadata(const QString& componentId, const ComponentData& data, uint64_t expectedGeneration = 0);
 
     /**
      * @brief 异步保存元器件元数据到L2磁盘缓存（不阻塞UI）
@@ -207,14 +210,14 @@ public:
      * @param lcscId 元器件ID
      * @param data 符号CAD JSON数据
      */
-    void saveSymbolData(const QString& lcscId, const QByteArray& data);
+    void saveSymbolData(const QString& lcscId, const QByteArray& data, uint64_t expectedGeneration = 0);
 
     /**
      * @brief 保存封装CAD数据到L2磁盘缓存
      * @param lcscId 元器件ID
      * @param data 封装CAD JSON数据
      */
-    void saveFootprintData(const QString& lcscId, const QByteArray& data);
+    void saveFootprintData(const QString& lcscId, const QByteArray& data, uint64_t expectedGeneration = 0);
 
     /**
      * @brief 从L2磁盘缓存加载符号CAD JSON
@@ -235,7 +238,7 @@ public:
      * @param lcscId 元器件ID
      * @param cadData CAD数据JSON
      */
-    void saveCadDataJson(const QString& lcscId, const QByteArray& cadData);
+    void saveCadDataJson(const QString& lcscId, const QByteArray& cadData, uint64_t expectedGeneration = 0);
 
     /**
      * @brief 从缓存加载完整的CAD数据JSON
@@ -258,7 +261,10 @@ public:
      * @param imageData 图片数据
      * @param imageIndex 图片索引（0-2）
      */
-    void savePreviewImage(const QString& lcscId, const QByteArray& imageData, int imageIndex);
+    void savePreviewImage(const QString& lcscId,
+                          const QByteArray& imageData,
+                          int imageIndex,
+                          uint64_t expectedGeneration = 0);
 
     /**
      * @brief 加载数据手册
@@ -287,7 +293,10 @@ public:
      * @param datasheetData 数据手册数据
      * @param format 数据格式（pdf/html）
      */
-    void saveDatasheet(const QString& lcscId, const QByteArray& datasheetData, const QString& format);
+    void saveDatasheet(const QString& lcscId,
+                       const QByteArray& datasheetData,
+                       const QString& format,
+                       uint64_t expectedGeneration = 0);
 
     /**
      * @brief 下载数据手册（同步网络请求，支持取消）
@@ -319,7 +328,10 @@ public:
      * @param data 模型数据
      * @param extension 文件扩展名（step/wrl）
      */
-    void saveModel3D(const QString& uuid, const QByteArray& data, const QString& extension);
+    void saveModel3D(const QString& uuid,
+                     const QByteArray& data,
+                     const QString& extension,
+                     uint64_t expectedGeneration = 0);
 
     /**
      * @brief 检查3D模型是否有缓存
@@ -358,9 +370,36 @@ public:
     Q_INVOKABLE void clearAllCache();
 
     /**
-     * @brief 清空L1内存缓存
+     * @brief 获取当前缓存代次（供调用方在请求创建时捕获）
+     */
+    uint64_t currentGeneration() const {
+        return m_cacheGeneration.load();
+    }
+
+    /**
+     * @brief 清除指定组件的 tombstone（新请求开始时调用）
+     */
+    void clearTombstone(const QString& lcscId);
+
+    /**
+     * @brief 检查组件是否被 tombstone
+     */
+    bool isTombstoned(const QString& lcscId) const;
+
+    /**
+     * @brief 解除全局 tombstone（新一轮导出开始时调用）
+     */
+    void clearGlobalTombstone();
+
+    /**
+     * @brief 清空L1内存缓存（同时重置 tombstone）
      */
     void clearMemoryCache();
+
+    /**
+     * @brief 清空L1内存缓存（不重置 tombstone，供 clearAllCache 内部使用）
+     */
+    void clearMemoryCacheInternal();
 
     /**
      * @brief 获取所有缓存的元器件ID列表
@@ -523,7 +562,8 @@ private:
     QString makeMemoryKey(const QString& lcscId, const QString& type) const;
 
     static std::unique_ptr<ComponentCacheService> s_instance;
-    mutable QMutex m_mutex;
+    mutable QMutex m_mutex;  // 保护 L1 内存缓存
+    mutable QMutex m_diskWriteMutex;  // 串行化 generation 检查与磁盘写入
     QString m_cacheDir;
     int m_memoryCacheLimitMB;
     int m_diskCacheLimitMB;
@@ -536,6 +576,12 @@ private:
 
     // 跟踪L1缓存总大小（字节）
     qint64 m_memoryCacheSize;
+    // 缓存代次：clearAllCache 时递增，异步写入前检查，防止清空后旧任务写回
+    std::atomic<uint64_t> m_cacheGeneration{0};
+    // Per-component tombstone：removeCache 后阻止旧回调写回
+    mutable QMutex m_tombstoneMutex;
+    QSet<QString> m_tombstones;
+    bool m_allTombstoned = false;
 };
 
 }  // namespace EasyKiConverter

--- a/src/services/ComponentCacheService.h
+++ b/src/services/ComponentCacheService.h
@@ -203,7 +203,9 @@ public:
      * @param data 元器件数据
      * @note 适用于批量操作，避免频繁的同步文件I/O阻塞UI
      */
-    void saveComponentMetadataAsync(const QString& componentId, const ComponentData& data);
+    void saveComponentMetadataAsync(const QString& componentId,
+                                    const ComponentData& data,
+                                    uint64_t expectedGeneration = 0);
 
     /**
      * @brief 保存符号CAD数据到L2磁盘缓存

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -169,6 +169,7 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
     }
 
     ComponentData reusableData;
+    uint64_t gen = 0;  // 请求创建时的缓存 generation，用于过滤旧回调
     bool reuseExistingData = false;
     bool shouldSkipAsDuplicate = false;
 
@@ -232,7 +233,18 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
     }
 
     // 符号封装缓存不存在，改为后台线程直接获取并解析 CAD 数据，避免主线程卡顿。
-    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
+    // 从 FetchingComponent 读取请求创建时的 generation
+    {
+        QMutexLocker locker(&m_fetchingComponentsMutex);
+        auto it = m_fetchingComponents.find(normalizedId);
+        if (it != m_fetchingComponents.end()) {
+            gen = it->cacheGeneration;
+        }
+    }
+    if (gen == 0) {
+        qWarning() << "fetchComponentDataInternal: No FetchingComponent for" << normalizedId << ", aborting";
+        return;
+    }
     auto future = QtConcurrent::run([normalizedId]() { return CadDataLoader::fetchAndParseCadData(normalizedId); });
     auto* watcher = new QFutureWatcher<CadFetchTaskResult>(this);
     connect(watcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, watcher, gen]() {
@@ -280,6 +292,19 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
 void ComponentService::loadComponentDataFromCacheAsync(const QString& normalizedId,
                                                        bool fetch3DModel,
                                                        ComponentCacheService* cache) {
+    // 从 FetchingComponent 读取请求创建时的 generation
+    uint64_t gen = 0;
+    {
+        QMutexLocker locker(&m_fetchingComponentsMutex);
+        auto it = m_fetchingComponents.find(normalizedId);
+        if (it != m_fetchingComponents.end()) {
+            gen = it->cacheGeneration;
+        }
+    }
+    if (gen == 0) {
+        qWarning() << "loadComponentDataFromCacheAsync: No FetchingComponent for" << normalizedId << ", aborting";
+        return;
+    }
     // 在后台线程执行缓存加载（I/O 密集型）
     QFuture<CacheLoadResult> future = QtConcurrent::run([normalizedId, fetch3DModel, cache]() -> CacheLoadResult {
         CacheLoadResult result;
@@ -361,7 +386,6 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
     });
 
     // 等待后台任务完成并在主线程处理结果
-    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
     QFutureWatcher<CacheLoadResult>* watcher = new QFutureWatcher<CacheLoadResult>(this);
     connect(
         watcher, &QFutureWatcher<CacheLoadResult>::finished, this, [this, watcher, normalizedId, fetch3DModel, gen]() {
@@ -372,6 +396,7 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
                 qWarning() << "ComponentService: Failed to load cache for" << normalizedId
                            << ", falling back to network fetch";
                 // 缓存加载失败时，回退到网络获取
+                uint64_t retryGen = 0;
                 {
                     QMutexLocker locker(&m_fetchingComponentsMutex);
                     auto it = m_fetchingComponents.find(normalizedId);
@@ -380,11 +405,17 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
                     }
                     FetchingComponent& fetchingComponent = *it;
                     initializeFetchingComponent(fetchingComponent, normalizedId, fetch3DModel);
+                    // retry 视为新请求，使用新的 generation
+                    retryGen = fetchingComponent.cacheGeneration;
+                }
+                if (retryGen == 0) {
+                    qWarning() << "Cache retry: No FetchingComponent for" << normalizedId << ", aborting";
+                    return;
                 }
                 auto retryFuture =
                     QtConcurrent::run([normalizedId]() { return CadDataLoader::fetchAndParseCadData(normalizedId); });
                 auto* retryWatcher = new QFutureWatcher<CadFetchTaskResult>(this);
-                connect(retryWatcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, retryWatcher, gen]() {
+                connect(retryWatcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, retryWatcher, retryGen]() {
                     const CadFetchTaskResult result = retryWatcher->result();
                     retryWatcher->deleteLater();
 
@@ -415,11 +446,11 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
                     emit cadDataReady(result.componentId, result.parsed.componentData);
                     // 使用异步保存，不阻塞UI
                     ComponentCacheService::instance()->saveComponentMetadataAsync(
-                        result.componentId, result.parsed.componentData, gen);
+                        result.componentId, result.parsed.componentData, retryGen);
                     ComponentCacheService::instance()->saveCadDataJson(
                         result.componentId,
                         QJsonDocument(result.parsed.resultData).toJson(QJsonDocument::Compact),
-                        gen);
+                        retryGen);
 
                     if (m_parallelContext != nullptr) {
                         handleParallelDataCollected(result.componentId, result.parsed.componentData);

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -152,6 +152,7 @@ void ComponentService::initializeFetchingComponent(FetchingComponent& fetchingCo
     fetchingComponent.requestActive = true;
     fetchingComponent.errorMessage.clear();
     fetchingComponent.pendingAsyncDownloads = 0;
+    fetchingComponent.cacheGeneration = ComponentCacheService::instance()->currentGeneration();
 }
 
 void ComponentService::fetchComponentDataInternal(const QString& componentId, bool fetch3DModel) {
@@ -160,9 +161,6 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
 
     // 确保 componentId 格式统一（大写）
     QString normalizedId = componentId.toUpper();
-
-    // 新请求开始，清除该组件的 tombstone 以允许缓存写入
-    ComponentCacheService::instance()->clearTombstone(normalizedId);
 
     // 使用互斥锁保护 m_currentComponentId 的并发访问
     {
@@ -198,6 +196,8 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
             // 创建占位条目，防止重复调度
             FetchingComponent& fc = m_fetchingComponents[normalizedId];
             initializeFetchingComponent(fc, normalizedId, fetch3DModel);
+            // 真正创建新请求时才解除 tombstone，允许缓存写入
+            ComponentCacheService::instance()->clearTombstone(normalizedId);
         }
     }
 
@@ -232,9 +232,10 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
     }
 
     // 符号封装缓存不存在，改为后台线程直接获取并解析 CAD 数据，避免主线程卡顿。
+    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
     auto future = QtConcurrent::run([normalizedId]() { return CadDataLoader::fetchAndParseCadData(normalizedId); });
     auto* watcher = new QFutureWatcher<CadFetchTaskResult>(this);
-    connect(watcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, watcher]() {
+    connect(watcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, watcher, gen]() {
         const CadFetchTaskResult result = watcher->result();
         watcher->deleteLater();
 
@@ -264,9 +265,10 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
         updateComponentCache(result.componentId, result.parsed.componentData);
         emit cadDataReady(result.componentId, result.parsed.componentData);
         // 使用异步保存，不阻塞UI
-        ComponentCacheService::instance()->saveComponentMetadataAsync(result.componentId, result.parsed.componentData);
+        ComponentCacheService::instance()->saveComponentMetadataAsync(
+            result.componentId, result.parsed.componentData, gen);
         ComponentCacheService::instance()->saveCadDataJson(
-            result.componentId, QJsonDocument(result.parsed.resultData).toJson(QJsonDocument::Compact));
+            result.componentId, QJsonDocument(result.parsed.resultData).toJson(QJsonDocument::Compact), gen);
 
         if (m_parallelContext != nullptr) {
             handleParallelDataCollected(result.componentId, result.parsed.componentData);
@@ -359,15 +361,92 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
     });
 
     // 等待后台任务完成并在主线程处理结果
+    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
     QFutureWatcher<CacheLoadResult>* watcher = new QFutureWatcher<CacheLoadResult>(this);
-    connect(watcher, &QFutureWatcher<CacheLoadResult>::finished, this, [this, watcher, normalizedId, fetch3DModel]() {
-        CacheLoadResult result = watcher->result();
-        watcher->deleteLater();
+    connect(
+        watcher, &QFutureWatcher<CacheLoadResult>::finished, this, [this, watcher, normalizedId, fetch3DModel, gen]() {
+            CacheLoadResult result = watcher->result();
+            watcher->deleteLater();
 
-        if (!result.success || !result.cachedData) {
-            qWarning() << "ComponentService: Failed to load cache for" << normalizedId
-                       << ", falling back to network fetch";
-            // 缓存加载失败时，回退到网络获取
+            if (!result.success || !result.cachedData) {
+                qWarning() << "ComponentService: Failed to load cache for" << normalizedId
+                           << ", falling back to network fetch";
+                // 缓存加载失败时，回退到网络获取
+                {
+                    QMutexLocker locker(&m_fetchingComponentsMutex);
+                    auto it = m_fetchingComponents.find(normalizedId);
+                    if (it == m_fetchingComponents.end()) {
+                        return;
+                    }
+                    FetchingComponent& fetchingComponent = *it;
+                    initializeFetchingComponent(fetchingComponent, normalizedId, fetch3DModel);
+                }
+                auto retryFuture =
+                    QtConcurrent::run([normalizedId]() { return CadDataLoader::fetchAndParseCadData(normalizedId); });
+                auto* retryWatcher = new QFutureWatcher<CadFetchTaskResult>(this);
+                connect(retryWatcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, retryWatcher, gen]() {
+                    const CadFetchTaskResult result = retryWatcher->result();
+                    retryWatcher->deleteLater();
+
+                    {
+                        QMutexLocker locker(&m_fetchingComponentsMutex);
+                        if (!m_fetchingComponents.contains(result.componentId)) {
+                            return;
+                        }
+                    }
+
+                    if (!result.success) {
+                        emitFetchErrorAndClearState(result.componentId, result.errorMessage);
+                        return;
+                    }
+
+                    {
+                        QMutexLocker locker(&m_fetchingComponentsMutex);
+                        auto it = m_fetchingComponents.find(result.componentId);
+                        if (it == m_fetchingComponents.end()) {
+                            return;
+                        }
+                        it->data = result.parsed.componentData;
+                        it->hasCadData = true;
+                        it->requestActive = false;
+                    }
+
+                    updateComponentCache(result.componentId, result.parsed.componentData);
+                    emit cadDataReady(result.componentId, result.parsed.componentData);
+                    // 使用异步保存，不阻塞UI
+                    ComponentCacheService::instance()->saveComponentMetadataAsync(
+                        result.componentId, result.parsed.componentData, gen);
+                    ComponentCacheService::instance()->saveCadDataJson(
+                        result.componentId,
+                        QJsonDocument(result.parsed.resultData).toJson(QJsonDocument::Compact),
+                        gen);
+
+                    if (m_parallelContext != nullptr) {
+                        handleParallelDataCollected(result.componentId, result.parsed.componentData);
+                    }
+                });
+                retryWatcher->setFuture(retryFuture);
+                return;
+            }
+
+            // 使用后台线程预解析的符号和封装数据
+            if (result.symbolData) {
+                result.cachedData->setSymbolData(result.symbolData);
+            }
+            if (result.footprintData) {
+                result.cachedData->setFootprintData(result.footprintData);
+                const Model3DData parsedModel3D = result.footprintData->model3D();
+                if (!parsedModel3D.uuid().isEmpty()) {
+                    auto model3DData = QSharedPointer<Model3DData>::create();
+                    model3DData->setUuid(parsedModel3D.uuid());
+                    model3DData->setName(parsedModel3D.name());
+                    model3DData->setTranslation(parsedModel3D.translation());
+                    model3DData->setRotation(parsedModel3D.rotation());
+                    result.cachedData->setModel3DData(model3DData);
+                }
+            }
+
+            // 更新 m_fetchingComponents
             {
                 QMutexLocker locker(&m_fetchingComponentsMutex);
                 auto it = m_fetchingComponents.find(normalizedId);
@@ -375,117 +454,44 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
                     return;
                 }
                 FetchingComponent& fetchingComponent = *it;
-                initializeFetchingComponent(fetchingComponent, normalizedId, fetch3DModel);
+                fetchingComponent.componentId = normalizedId;
+                fetchingComponent.data = *result.cachedData;
+                fetchingComponent.fetch3DModel = fetch3DModel;
+                fetchingComponent.hasCadData =
+                    (result.cachedData->symbolData() != nullptr && result.cachedData->footprintData() != nullptr);
+                fetchingComponent.requestActive = false;
             }
-            auto retryFuture =
-                QtConcurrent::run([normalizedId]() { return CadDataLoader::fetchAndParseCadData(normalizedId); });
-            auto* retryWatcher = new QFutureWatcher<CadFetchTaskResult>(this);
-            connect(retryWatcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, retryWatcher]() {
-                const CadFetchTaskResult result = retryWatcher->result();
-                retryWatcher->deleteLater();
 
-                {
-                    QMutexLocker locker(&m_fetchingComponentsMutex);
-                    if (!m_fetchingComponents.contains(result.componentId)) {
-                        return;
-                    }
-                }
+            // 发送缓存加载的信号
+            qDebug() << "ComponentService: Emitting cadDataReady for" << normalizedId
+                     << "with symbolData:" << (result.cachedData->symbolData() != nullptr)
+                     << "footprintData:" << (result.cachedData->footprintData() != nullptr);
 
-                if (!result.success) {
-                    emitFetchErrorAndClearState(result.componentId, result.errorMessage);
-                    return;
-                }
+            // 更新缓存
+            updateComponentCache(normalizedId, *result.cachedData);
 
-                {
-                    QMutexLocker locker(&m_fetchingComponentsMutex);
-                    auto it = m_fetchingComponents.find(result.componentId);
-                    if (it == m_fetchingComponents.end()) {
-                        return;
-                    }
-                    it->data = result.parsed.componentData;
-                    it->hasCadData = true;
-                    it->requestActive = false;
-                }
+            emit cadDataReady(normalizedId, *result.cachedData);
 
-                updateComponentCache(result.componentId, result.parsed.componentData);
-                emit cadDataReady(result.componentId, result.parsed.componentData);
-                // 使用异步保存，不阻塞UI
-                ComponentCacheService::instance()->saveComponentMetadataAsync(result.componentId,
-                                                                              result.parsed.componentData);
-                ComponentCacheService::instance()->saveCadDataJson(
-                    result.componentId, QJsonDocument(result.parsed.resultData).toJson(QJsonDocument::Compact));
-
-                if (m_parallelContext != nullptr) {
-                    handleParallelDataCollected(result.componentId, result.parsed.componentData);
-                }
-            });
-            retryWatcher->setFuture(retryFuture);
-            return;
-        }
-
-        // 使用后台线程预解析的符号和封装数据
-        if (result.symbolData) {
-            result.cachedData->setSymbolData(result.symbolData);
-        }
-        if (result.footprintData) {
-            result.cachedData->setFootprintData(result.footprintData);
-            const Model3DData parsedModel3D = result.footprintData->model3D();
-            if (!parsedModel3D.uuid().isEmpty()) {
-                auto model3DData = QSharedPointer<Model3DData>::create();
-                model3DData->setUuid(parsedModel3D.uuid());
-                model3DData->setName(parsedModel3D.name());
-                model3DData->setTranslation(parsedModel3D.translation());
-                model3DData->setRotation(parsedModel3D.rotation());
-                result.cachedData->setModel3DData(model3DData);
+            // 如果在并行模式，处理并行数据收集
+            if (m_parallelContext != nullptr) {
+                handleParallelDataCollected(normalizedId, *result.cachedData);
             }
-        }
 
-        // 更新 m_fetchingComponents
-        {
-            QMutexLocker locker(&m_fetchingComponentsMutex);
-            auto it = m_fetchingComponents.find(normalizedId);
-            if (it == m_fetchingComponents.end()) {
-                return;
+            // 从缓存加载预览图数据（批量发送，避免频繁 UI 更新）
+            if (!result.encodedPreviewImages.isEmpty()) {
+                const QStringList encodedImages = result.encodedPreviewImages;
+                QTimer::singleShot(0, this, [this, normalizedId, encodedImages]() {
+                    emit previewImagesReady(normalizedId, encodedImages);
+                });
             }
-            FetchingComponent& fetchingComponent = *it;
-            fetchingComponent.componentId = normalizedId;
-            fetchingComponent.data = *result.cachedData;
-            fetchingComponent.fetch3DModel = fetch3DModel;
-            fetchingComponent.hasCadData =
-                (result.cachedData->symbolData() != nullptr && result.cachedData->footprintData() != nullptr);
-            fetchingComponent.requestActive = false;
-        }
 
-        // 发送缓存加载的信号
-        qDebug() << "ComponentService: Emitting cadDataReady for" << normalizedId
-                 << "with symbolData:" << (result.cachedData->symbolData() != nullptr)
-                 << "footprintData:" << (result.cachedData->footprintData() != nullptr);
+            // 加载数据手册
+            if (!result.datasheetData.isEmpty()) {
+                emit datasheetReady(normalizedId, result.datasheetData);
+            }
 
-        // 更新缓存
-        updateComponentCache(normalizedId, *result.cachedData);
-
-        emit cadDataReady(normalizedId, *result.cachedData);
-
-        // 如果在并行模式，处理并行数据收集
-        if (m_parallelContext != nullptr) {
-            handleParallelDataCollected(normalizedId, *result.cachedData);
-        }
-
-        // 从缓存加载预览图数据（批量发送，避免频繁 UI 更新）
-        if (!result.encodedPreviewImages.isEmpty()) {
-            const QStringList encodedImages = result.encodedPreviewImages;
-            QTimer::singleShot(0, this, [this, normalizedId, encodedImages]() {
-                emit previewImagesReady(normalizedId, encodedImages);
-            });
-        }
-
-        // 加载数据手册
-        if (!result.datasheetData.isEmpty()) {
-            emit datasheetReady(normalizedId, result.datasheetData);
-        }
-
-        qDebug() << "ComponentService: Cache loaded successfully for" << normalizedId;
-    });
+            qDebug() << "ComponentService: Cache loaded successfully for" << normalizedId;
+        });
     watcher->setFuture(future);
 }
 
@@ -534,6 +540,7 @@ void ComponentService::handleLcscDataReady(const QString& componentId,
     // 准备要更新的数据（在锁外构建，避免长时间持锁）
     ComponentData updatedData;
     bool hasValidUpdate = false;
+    uint64_t gen = 0;
 
     // 加锁保护共享数据的访问
     {
@@ -578,6 +585,7 @@ void ComponentService::handleLcscDataReady(const QString& componentId,
 
             // 复制数据用于锁外处理
             updatedData = fetchingComponent.data;
+            gen = fetchingComponent.cacheGeneration;
             hasValidUpdate = true;
         } else {
             qWarning() << "Component" << componentId << "not found in m_fetchingComponents, cannot update LCSC data";
@@ -590,7 +598,7 @@ void ComponentService::handleLcscDataReady(const QString& componentId,
         emit lcscDataUpdated(componentId, manufacturerPart, datasheetUrl, imageUrls);
 
         // 保存到磁盘缓存（异步，不阻塞UI）
-        ComponentCacheService::instance()->saveComponentMetadataAsync(componentId, updatedData);
+        ComponentCacheService::instance()->saveComponentMetadataAsync(componentId, updatedData, gen);
 
         // 更新内存缓存，确保 startPreload 时能获取到最新数据
         updateComponentCache(componentId, updatedData);
@@ -798,10 +806,24 @@ void ComponentService::handleComponentInfoFetched(const QString& componentId, co
 }
 
 void ComponentService::handleCadDataFetched(const QString& componentId, const QJsonObject& data) {
+    // 从 FetchingComponent 读取请求创建时的 generation，而非当前值
+    uint64_t gen = 0;
+    {
+        QMutexLocker locker(&m_fetchingComponentsMutex);
+        auto it = m_fetchingComponents.find(componentId.toUpper());
+        if (it != m_fetchingComponents.end()) {
+            gen = it->cacheGeneration;
+        }
+    }
+    if (gen == 0) {
+        // 找不到 FetchingComponent，说明是已过期的孤儿回调，直接丢弃
+        qDebug() << "handleCadDataFetched: No FetchingComponent for" << componentId << ", discarding stale callback";
+        return;
+    }
     auto future =
         QtConcurrent::run([componentId, data]() { return CadDataLoader::parseCadPayload(componentId, data); });
     auto* watcher = new QFutureWatcher<CadParseResult>(this);
-    connect(watcher, &QFutureWatcher<CadParseResult>::finished, this, [this, watcher]() {
+    connect(watcher, &QFutureWatcher<CadParseResult>::finished, this, [this, watcher, gen]() {
         const CadParseResult parsed = watcher->result();
         watcher->deleteLater();
 
@@ -824,9 +846,9 @@ void ComponentService::handleCadDataFetched(const QString& componentId, const QJ
         updateComponentCache(parsed.componentId, parsed.componentData);
         emit cadDataReady(parsed.componentId, parsed.componentData);
         // 使用异步保存，不阻塞UI
-        ComponentCacheService::instance()->saveComponentMetadataAsync(parsed.componentId, parsed.componentData);
+        ComponentCacheService::instance()->saveComponentMetadataAsync(parsed.componentId, parsed.componentData, gen);
         ComponentCacheService::instance()->saveCadDataJson(
-            parsed.componentId, QJsonDocument(parsed.resultData).toJson(QJsonDocument::Compact));
+            parsed.componentId, QJsonDocument(parsed.resultData).toJson(QJsonDocument::Compact), gen);
 
         if (m_parallelContext != nullptr) {
             handleParallelDataCollected(parsed.componentId, parsed.componentData);

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -161,6 +161,9 @@ void ComponentService::fetchComponentDataInternal(const QString& componentId, bo
     // 确保 componentId 格式统一（大写）
     QString normalizedId = componentId.toUpper();
 
+    // 新请求开始，清除该组件的 tombstone 以允许缓存写入
+    ComponentCacheService::instance()->clearTombstone(normalizedId);
+
     // 使用互斥锁保护 m_currentComponentId 的并发访问
     {
         QMutexLocker locker(&m_currentIdMutex);
@@ -1097,6 +1100,14 @@ void ComponentService::handleQueueTimeout() {
 
         resetQueueState();
     }
+}
+
+void ComponentService::abortBatchFetch() {
+    // 取消所有网络请求（包括预览图、数据手册、CAD数据）
+    cancelAllPendingRequests();
+    // 重置队列和并行上下文
+    resetQueueState();
+    qDebug() << "ComponentService: Batch fetch aborted, all state cleared";
 }
 
 void ComponentService::resetQueueState() {

--- a/src/services/ComponentService.cpp
+++ b/src/services/ComponentService.cpp
@@ -415,47 +415,50 @@ void ComponentService::loadComponentDataFromCacheAsync(const QString& normalized
                 auto retryFuture =
                     QtConcurrent::run([normalizedId]() { return CadDataLoader::fetchAndParseCadData(normalizedId); });
                 auto* retryWatcher = new QFutureWatcher<CadFetchTaskResult>(this);
-                connect(retryWatcher, &QFutureWatcher<CadFetchTaskResult>::finished, this, [this, retryWatcher, retryGen]() {
-                    const CadFetchTaskResult result = retryWatcher->result();
-                    retryWatcher->deleteLater();
+                connect(retryWatcher,
+                        &QFutureWatcher<CadFetchTaskResult>::finished,
+                        this,
+                        [this, retryWatcher, retryGen]() {
+                            const CadFetchTaskResult result = retryWatcher->result();
+                            retryWatcher->deleteLater();
 
-                    {
-                        QMutexLocker locker(&m_fetchingComponentsMutex);
-                        if (!m_fetchingComponents.contains(result.componentId)) {
-                            return;
-                        }
-                    }
+                            {
+                                QMutexLocker locker(&m_fetchingComponentsMutex);
+                                if (!m_fetchingComponents.contains(result.componentId)) {
+                                    return;
+                                }
+                            }
 
-                    if (!result.success) {
-                        emitFetchErrorAndClearState(result.componentId, result.errorMessage);
-                        return;
-                    }
+                            if (!result.success) {
+                                emitFetchErrorAndClearState(result.componentId, result.errorMessage);
+                                return;
+                            }
 
-                    {
-                        QMutexLocker locker(&m_fetchingComponentsMutex);
-                        auto it = m_fetchingComponents.find(result.componentId);
-                        if (it == m_fetchingComponents.end()) {
-                            return;
-                        }
-                        it->data = result.parsed.componentData;
-                        it->hasCadData = true;
-                        it->requestActive = false;
-                    }
+                            {
+                                QMutexLocker locker(&m_fetchingComponentsMutex);
+                                auto it = m_fetchingComponents.find(result.componentId);
+                                if (it == m_fetchingComponents.end()) {
+                                    return;
+                                }
+                                it->data = result.parsed.componentData;
+                                it->hasCadData = true;
+                                it->requestActive = false;
+                            }
 
-                    updateComponentCache(result.componentId, result.parsed.componentData);
-                    emit cadDataReady(result.componentId, result.parsed.componentData);
-                    // 使用异步保存，不阻塞UI
-                    ComponentCacheService::instance()->saveComponentMetadataAsync(
-                        result.componentId, result.parsed.componentData, retryGen);
-                    ComponentCacheService::instance()->saveCadDataJson(
-                        result.componentId,
-                        QJsonDocument(result.parsed.resultData).toJson(QJsonDocument::Compact),
-                        retryGen);
+                            updateComponentCache(result.componentId, result.parsed.componentData);
+                            emit cadDataReady(result.componentId, result.parsed.componentData);
+                            // 使用异步保存，不阻塞UI
+                            ComponentCacheService::instance()->saveComponentMetadataAsync(
+                                result.componentId, result.parsed.componentData, retryGen);
+                            ComponentCacheService::instance()->saveCadDataJson(
+                                result.componentId,
+                                QJsonDocument(result.parsed.resultData).toJson(QJsonDocument::Compact),
+                                retryGen);
 
-                    if (m_parallelContext != nullptr) {
-                        handleParallelDataCollected(result.componentId, result.parsed.componentData);
-                    }
-                });
+                            if (m_parallelContext != nullptr) {
+                                handleParallelDataCollected(result.componentId, result.parsed.componentData);
+                            }
+                        });
                 retryWatcher->setFuture(retryFuture);
                 return;
             }

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -455,6 +455,7 @@ private:
         bool requestActive = false;  // 主验证请求仍在进行中，用于区分真实重复请求和陈旧条目
         QString errorMessage;
         int pendingAsyncDownloads;  // 等待的异步下载数量（数据手册、预览图等）
+        uint64_t cacheGeneration = 0;  // 请求创建时的缓存代次，用于过滤旧回调
     };
 
     QMap<QString, FetchingComponent> m_fetchingComponents;

--- a/src/services/ComponentService.h
+++ b/src/services/ComponentService.h
@@ -53,6 +53,12 @@ public:
     ~ComponentService() override;
 
     /**
+     * @brief 中止所有批量获取任务，重置队列和并行上下文
+     * @note 供 ParallelExportService 在取消导出时调用
+     */
+    void abortBatchFetch();
+
+    /**
      * @brief 获取元件数据
      *
      * @param componentId 元件ID

--- a/src/services/LcscImageService.cpp
+++ b/src/services/LcscImageService.cpp
@@ -425,16 +425,16 @@ void LcscImageService::performDownload(const QString& componentId, const QString
         return;
     }
 
+    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
     AsyncNetworkRequest* request = NetworkClient::instance().getAsync(
         QUrl(imageUrl),
         ResourceType::PreviewImage,
         RetryPolicy::fromProfile(RequestProfiles::previewImage(), isWeakNetworkEnabled()));
     trackAsyncRequest(request);
-
     connect(request,
             &AsyncNetworkRequest::finished,
             this,
-            [this, request, componentId, imageIndex](const NetworkResult& result) {
+            [this, request, componentId, imageIndex, gen](const NetworkResult& result) {
                 untrackAsyncRequest(request);
 
                 if (m_isCancelled) {
@@ -457,7 +457,7 @@ void LcscImageService::performDownload(const QString& componentId, const QString
 
                 const QByteArray imageData = result.data;
                 if (!imageData.isEmpty() && !QString::fromUtf8(imageData).contains("<!DOCTYPE", Qt::CaseInsensitive)) {
-                    ComponentCacheService::instance()->savePreviewImage(componentId, imageData, imageIndex);
+                    ComponentCacheService::instance()->savePreviewImage(componentId, imageData, imageIndex, gen);
                     m_downloadCounts[componentId]++;
                     emit imageReady(componentId, imageData, imageIndex);
                     checkDownloadCompletion(componentId);
@@ -511,16 +511,16 @@ void LcscImageService::performDatasheetDownload(const QString& componentId, cons
         return;
     }
 
+    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
     AsyncNetworkRequest* request = NetworkClient::instance().getAsync(
         QUrl(datasheetUrl),
         ResourceType::Datasheet,
         RetryPolicy::fromProfile(RequestProfiles::datasheet(), isWeakNetworkEnabled()));
     trackAsyncRequest(request);
-
     connect(request,
             &AsyncNetworkRequest::finished,
             this,
-            [this, request, componentId, datasheetUrl](const NetworkResult& result) {
+            [this, request, componentId, datasheetUrl, gen](const NetworkResult& result) {
                 untrackAsyncRequest(request);
 
                 if (m_isCancelled) {
@@ -537,7 +537,7 @@ void LcscImageService::performDatasheetDownload(const QString& componentId, cons
                 const QByteArray datasheetData = result.data;
                 if (!datasheetData.isEmpty()) {
                     QString format = datasheetUrl.toLower().contains(".html") ? "html" : "pdf";
-                    ComponentCacheService::instance()->saveDatasheet(componentId, datasheetData, format);
+                    ComponentCacheService::instance()->saveDatasheet(componentId, datasheetData, format, gen);
                     QByteArray savedData = ComponentCacheService::instance()->loadDatasheet(componentId);
                     emit datasheetReady(componentId, savedData);
                 } else {

--- a/src/services/export/FootprintExportStage.cpp
+++ b/src/services/export/FootprintExportStage.cpp
@@ -280,6 +280,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
                                            const QMap<QString, QSharedPointer<ComponentData>>& cachedData) {
     qDebug() << "FootprintExportStage: Starting library export in worker thread for" << componentIds.size()
              << "components";
+    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
 
     QList<FootprintData> footprintList;
     QStringList failedIds;
@@ -335,7 +336,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
                     Exporter3DModel modelExporter;
                     if (modelExporter.downloadStepDataSync(model3D.uuid(), &stepData) && !stepData.isEmpty()) {
                         ComponentCacheService::instance()->saveModel3D(
-                            model3D.uuid(), stepData, QStringLiteral("step"));
+                            model3D.uuid(), stepData, QStringLiteral("step"), gen);
                     }
                 }
 
@@ -356,7 +357,7 @@ void FootprintExportStage::doLibraryExport(const QStringList& componentIds,
                         Exporter3DModel modelExporter;
                         if (modelExporter.downloadObjDataSync(model3D.uuid(), &objData) && !objData.isEmpty()) {
                             ComponentCacheService::instance()->saveModel3D(
-                                model3D.uuid(), objData, QStringLiteral("obj"));
+                                model3D.uuid(), objData, QStringLiteral("obj"), gen);
                         }
                     }
 

--- a/src/services/export/Model3DExportWorker.cpp
+++ b/src/services/export/Model3DExportWorker.cpp
@@ -37,6 +37,7 @@ void Model3DExportWorker::run() {
         emit completed(m_componentId, false, QStringLiteral("Cancelled"));
         return;
     }
+    const uint64_t gen = ComponentCacheService::instance()->currentGeneration();
 
     if (!m_data) {
         emit completed(m_componentId, false, QStringLiteral("No data available"));
@@ -173,7 +174,7 @@ void Model3DExportWorker::run() {
         } else if (objData.isEmpty()) {
             error = QStringLiteral("OBJ data is empty for WRL export");
         } else {
-            cache->saveModel3D(uuid, objData, QStringLiteral("obj"));
+            cache->saveModel3D(uuid, objData, QStringLiteral("obj"), gen);
             Model3DData modelData = buildModelData();
             modelData.setRawObj(QString::fromUtf8(objData));
             if (!exporter.exportToWrl(modelData, wrlWritePath)) {
@@ -181,7 +182,7 @@ void Model3DExportWorker::run() {
             } else {
                 QFile file(wrlWritePath);
                 if (file.open(QIODevice::ReadOnly)) {
-                    cache->saveModel3D(uuid, file.readAll(), QStringLiteral("wrl"));
+                    cache->saveModel3D(uuid, file.readAll(), QStringLiteral("wrl"), gen);
                     qDebug() << "Model3DExportWorker: Saved WRL to cache for" << m_componentId << "uuid" << uuid;
                 }
             }
@@ -206,7 +207,7 @@ void Model3DExportWorker::run() {
                 if (!exporter.exportToStep(modelData, stepWritePath)) {
                     error = QStringLiteral("Failed to write STEP file");
                 } else {
-                    cache->saveModel3D(uuid, stepData, QStringLiteral("step"));
+                    cache->saveModel3D(uuid, stepData, QStringLiteral("step"), gen);
                     qDebug() << "Model3DExportWorker: Saved STEP to cache for" << m_componentId << "uuid" << uuid;
                 }
             }

--- a/src/services/export/ParallelExportService.cpp
+++ b/src/services/export/ParallelExportService.cpp
@@ -153,7 +153,8 @@ void ParallelExportService::startPreload(const QStringList& componentIds) {
     m_runningExportStages = 0;
     ++m_activeRunGeneration;
     m_cancelRequested = false;
-    // 新一轮导出开始，解除全局 tombstone
+    // 新一轮验证/导出开始，解除全局 tombstone
+    // 旧回调靠 generation token 被拒绝，新请求携带新 token 可正常写入
     ComponentCacheService::instance()->clearGlobalTombstone();
     qDebug() << "ParallelExportService: Starting preload for" << componentIds.size() << "components";
 
@@ -240,6 +241,8 @@ void ParallelExportService::startExport() {
 
     cleanupExportStages();
     m_cancelRequested = false;
+    // 预加载完成，旧回调已全部处理，解除全局 tombstone
+    ComponentCacheService::instance()->clearGlobalTombstone();
     // 从 ComponentService 刷新最新的组件数据（确保用户在 UI 中的编辑生效）
     if (m_componentService) {
         for (auto it = m_cachedData.begin(); it != m_cachedData.end(); ++it) {

--- a/src/services/export/ParallelExportService.cpp
+++ b/src/services/export/ParallelExportService.cpp
@@ -237,6 +237,18 @@ void ParallelExportService::startExport() {
 
     cleanupExportStages();
     m_cancelRequested = false;
+    // 从 ComponentService 刷新最新的组件数据（确保用户在 UI 中的编辑生效）
+    if (m_componentService) {
+        for (auto it = m_cachedData.begin(); it != m_cachedData.end(); ++it) {
+            ComponentData freshData = m_componentService->getComponentData(it.key());
+            if (freshData.symbolData() && it.value() && it.value()->symbolData()) {
+                it.value()->symbolData()->setInfo(freshData.symbolData()->info());
+            }
+            if (freshData.footprintData() && it.value() && it.value()->footprintData()) {
+                it.value()->footprintData()->setInfo(freshData.footprintData()->info());
+            }
+        }
+    }
     const quint64 runGeneration = m_activeRunGeneration;
 
     qDebug() << "ParallelExportService: Starting export for" << m_componentIds.size() << "components"

--- a/src/services/export/ParallelExportService.cpp
+++ b/src/services/export/ParallelExportService.cpp
@@ -153,6 +153,8 @@ void ParallelExportService::startPreload(const QStringList& componentIds) {
     m_runningExportStages = 0;
     ++m_activeRunGeneration;
     m_cancelRequested = false;
+    // 新一轮导出开始，解除全局 tombstone
+    ComponentCacheService::instance()->clearGlobalTombstone();
     qDebug() << "ParallelExportService: Starting preload for" << componentIds.size() << "components";
 
     m_componentIds = componentIds;
@@ -203,6 +205,7 @@ void ParallelExportService::cancelPreload() {
     m_nextPreloadIndex = m_componentIds.size();
     if (m_componentService) {
         disconnect(m_componentService, &ComponentService::allComponentsDataCollected, this, nullptr);
+        m_componentService->abortBatchFetch();
     }
     {
         QMutexLocker locker(&m_progressMutex);
@@ -269,7 +272,8 @@ void ParallelExportService::startExport() {
 
     for (const QString& componentId : std::as_const(m_componentIds)) {
         const auto it = m_cachedData.constFind(componentId);
-        if (it != m_cachedData.cend() && it.value()) {
+        if (it != m_cachedData.cend() && it.value() && it.value()->isValid() && it.value()->symbolData() &&
+            it.value()->footprintData()) {
             exportableComponentIds.append(componentId);
         } else {
             missingDataComponentIds.append(componentId);
@@ -564,6 +568,11 @@ void ParallelExportService::cancelExport() {
         return;
     }
 
+    // 重置 ComponentService 批处理上下文
+    if (m_componentService) {
+        m_componentService->abortBatchFetch();
+    }
+
     m_progress.currentStage = ExportOverallProgress::Stage::Cancelled;
     m_progress.endTime = QDateTime::currentDateTime();
     emit cancelled();
@@ -744,14 +753,17 @@ void ParallelExportService::processNextPreloadBatch() {
 
         {
             QMutexLocker locker(&m_progressMutex);
-            if (!data.lcscId().isEmpty()) {
+            // 严格校验：必须有 lcscId + symbolData + footprintData + isValid 才算有效
+            bool hasValidData = !data.lcscId().isEmpty() && data.isValid() && data.symbolData() != nullptr &&
+                                data.footprintData() != nullptr;
+            if (hasValidData) {
                 auto sharedData = QSharedPointer<ComponentData>::create(data);
                 m_cachedData[componentId] = sharedData;
                 m_progress.preloadProgress.successCount++;
                 qDebug() << "ParallelExportService: Loaded data for" << componentId;
             } else {
                 m_progress.preloadProgress.failedCount++;
-                m_progress.preloadProgress.failedComponents[componentId] = QStringLiteral("No component data found");
+                m_progress.preloadProgress.failedComponents[componentId] = QStringLiteral("Incomplete component data");
                 qWarning() << "ParallelExportService: No data found for component:" << componentId;
             }
 
@@ -816,8 +828,8 @@ void ParallelExportService::onAllComponentDataCollected(const QList<ComponentDat
             continue;
         }
 
-        // 检查数据是否有效（至少需要有 symbol 或 footprint 数据）
-        bool hasValidData = (data.symbolData() != nullptr || data.footprintData() != nullptr);
+        // 严格校验：必须同时有 symbol 和 footprint 数据且通过验证
+        bool hasValidData = data.isValid() && data.symbolData() != nullptr && data.footprintData() != nullptr;
 
         if (hasValidData) {
             auto sharedData = QSharedPointer<ComponentData>::create(data);

--- a/src/ui/qml/Main.qml
+++ b/src/ui/qml/Main.qml
@@ -18,7 +18,7 @@ ApplicationWindow {
     minimumWidth: dynamicMinimumWidth
     minimumHeight: 620
     visible: false
-    title: "EasyKiConverter - 元器件转换工具"
+    title: qsTr("EasyKiConverter - 元器件转换工具")
     color: "transparent"
     flags: Qt.Window | Qt.FramelessWindowHint | Qt.CustomizeWindowHint | Qt.WindowMinimizeButtonHint | Qt.WindowMaximizeButtonHint
     // 将 context property 显式绑定到 ApplicationWindow 属性，避免 WindowController 内同名属性自引用

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -509,7 +509,6 @@ Item {
                                         property bool hasFile: window.componentListController && window.componentListController.bomFilePath && window.componentListController.bomFilePath.length > 0
                                         property string fileName: hasFile ? window.componentListController.bomFilePath.split("/").pop() : ""
                                         property string bomResult: window.componentListController ? window.componentListController.bomResult : ""
-
                                         // 文件选择区域
                                         Rectangle {
                                             Layout.fillWidth: true

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Dialogs
 import QtQuick.Window
+import QtQuick.Effects
 import QtQml.Models
 import "styles"
 import "components"
@@ -21,8 +22,15 @@ Item {
     readonly property bool isMaximized: Window.window ? (Window.window.visibility === Window.Maximized || Window.window.visibility === Window.FullScreen) : false
     readonly property int windowRadius: isMaximized ? 0 : AppStyle.radius.lg
     readonly property int calculatedMinimumWindowWidth: ResponsiveHelper.minimumWindowWidth
+    // 响应式布局模式
+    readonly property bool isSidebarMode: ResponsiveHelper.isAtLeastMedium
+    // 交互状态
+    property int inputMode: 0  // 0=单个, 1=BOM
+    // 滚动跟踪（用于 compact 模式下的 sticky bar）
+    property bool compactScrolledPastThreshold: false
+    property real stickyBarOpacity: 0
     function mainFlickable() {
-        return scrollView.contentItem;
+        return workspaceFlickable;
     }
 
     function clampScroll(targetY) {
@@ -158,52 +166,55 @@ Item {
         anchors.fill: parent
         color: "transparent"
         radius: AppStyle.radius.lg
-        // 使用 Canvas 裁剪顶层窗口背景，避免 Windows + Vulkan 透明窗口下的 mask 区域变黑。
+        // GPU 渲染背景（替代 Canvas）
         Image {
             id: bgSource
             visible: false
             source: "qrc:/qt/qml/EasyKiconverter_Cpp_Version/resources/imgs/background.jpg"
             asynchronous: true
             cache: true
-            onStatusChanged: if (status === Image.Ready) {
-                backgroundCanvas.requestPaint();
+        }
+
+        Image {
+            id: backgroundImage
+            anchors.fill: parent
+            source: bgSource.source
+            fillMode: Image.PreserveAspectCrop
+            visible: bgSource.status === Image.Ready
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                maskEnabled: true
+                maskSource: bgMask
             }
         }
 
-        Canvas {
-            id: backgroundCanvas
+        ShaderEffectSource {
+            id: bgMask
+            sourceItem: bgMaskRect
+            visible: false
+            live: window.isMaximized !== undefined
+        }
+
+        Rectangle {
+            id: bgMaskRect
+            width: mainContainer.width
+            height: mainContainer.height
+            radius: windowRadius
+            visible: false
+        }
+
+        // 背景填充（图片未加载时的纯色背景）
+        Rectangle {
             anchors.fill: parent
-            onPaint: {
-                const ctx = getContext("2d");
-                ctx.reset();
-                const r = windowRadius;
-                ctx.beginPath();
-                ctx.roundedRect(0, 0, width, height, r, r);
-                ctx.closePath();
-                ctx.clip();
-                ctx.fillStyle = AppStyle.colors.background;
-                ctx.fill();
-                if (bgSource.status === Image.Ready) {
-                    const sw = bgSource.sourceSize.width;
-                    const sh = bgSource.sourceSize.height;
-                    if (sw > 0 && sh > 0) {
-                        const scale = Math.max(width / sw, height / sh);
-                        const dw = sw * scale;
-                        const dh = sh * scale;
-                        const dx = (width - dw) / 2;
-                        const dy = (height - dh) / 2;
-                        ctx.drawImage(bgSource, dx, dy, dw, dh);
-                    }
+            color: AppStyle.colors.background
+            radius: windowRadius
+            z: -1
+            Behavior on color {
+                ColorAnimation {
+                    duration: AppStyle.durations.themeSwitch
+                    easing.type: AppStyle.easings.easeOut
                 }
             }
-
-            onWidthChanged: requestPaint()
-            onHeightChanged: requestPaint()
-            onVisibleChanged: requestPaint()
-            property int radiusTrigger: windowRadius
-            onRadiusTriggerChanged: requestPaint()
-            property color backgroundTrigger: AppStyle.colors.background
-            onBackgroundTriggerChanged: requestPaint()
         }
         // 半透明遮罩层（确保内容可读性）
         Rectangle {
@@ -233,100 +244,573 @@ Item {
             windowController: Window.window ? Window.window.windowController : null
         }
 
-        // 主滚动区域
-        ScrollView {
-            id: scrollView
+        // 主布局：侧边栏 + 工作区
+        RowLayout {
+            id: mainLayout
             anchors.top: titleBar.bottom
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: parent.bottom
-            clip: true
-            enabled: true  // 确保能传递鼠标事件
-            ScrollBar.vertical.policy: ScrollBar.AlwaysOff
-            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-            // 内容容器（添加左右边距）
-            Item {
-                width: scrollView.width
-                implicitHeight: contentLayout.implicitHeight
-                enabled: true  // 确保能传递鼠标事件
-                // 内容区域（自适应边距 + 最大宽度约束）
-                ColumnLayout {
-                    id: contentLayout
-                    width: Math.max(0, Math.min(parent.width - ResponsiveHelper.contentMargin * 2, ResponsiveHelper.contentMaxWidth))
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    spacing: ResponsiveHelper.cardSpacing
-                    // 头部区域（标题 + 语言选择器 + GitHub + 主题切换 + 分隔线）
-                    HeaderSection {
-                        Layout.fillWidth: true
-                        themeController: window.themeController
-                        componentListController: window.componentListController
+            spacing: 0
+            // ==================== 侧边栏控制面板 ====================
+            Loader {
+                id: sidebarLoader
+                active: window.isSidebarMode
+                Layout.preferredWidth: active ? 360 : 0
+                Layout.fillHeight: true
+                sourceComponent: Component {
+                    SidebarPanel {
+                        window: window
                     }
+                }
+            }
 
-                    UpdateBanner {
-                        Layout.fillWidth: true
-                        updateChecker: window.updateChecker
+            // ==================== 工作区（始终可见） ====================
+            Flickable {
+                id: workspaceFlickable
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                contentWidth: width
+                contentHeight: workspaceContentItem.implicitHeight
+                boundsBehavior: Flickable.StopAtBounds
+                ScrollBar.vertical: ScrollBar {
+                    policy: ScrollBar.AlwaysOff
+                }
+
+                onContentYChanged: {
+                    window.updateCompactScrollState();
+                }
+
+                Item {
+                    id: workspaceContentItem
+                    width: workspaceFlickable.width
+                    implicitHeight: workspaceColumn.implicitHeight
+                    ColumnLayout {
+                        id: workspaceColumn
+                        width: Math.max(0, Math.min(parent.width - ResponsiveHelper.contentMargin * 2, ResponsiveHelper.contentMaxWidth))
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        spacing: ResponsiveHelper.cardSpacing
+                        // 头部区域
+                        HeaderSection {
+                            Layout.fillWidth: true
+                            themeController: window.themeController
+                            componentListController: window.componentListController
+                        }
+
+                        UpdateBanner {
+                            Layout.fillWidth: true
+                            updateChecker: window.updateChecker
+                        }
+
+                        // ==================== 数据源输入卡片（合并） ====================
+                        Card {
+                            Layout.fillWidth: true
+                            title: qsTranslate("MainWindow", "数据源")
+                            ColumnLayout {
+                                width: parent.width
+                                spacing: AppStyle.spacing.lg
+                                // 模式切换标签
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: AppStyle.spacing.sm
+                                    Rectangle {
+                                        Layout.fillWidth: true
+                                        Layout.preferredHeight: 34
+                                        radius: AppStyle.radius.sm
+                                        color: inputMode === 0 ? AppStyle.colors.primary : "transparent"
+                                        border.color: inputMode === 0 ? AppStyle.colors.primary : AppStyle.colors.border
+                                        border.width: AppStyle.borderWidths.thin
+                                        Text {
+                                            anchors.centerIn: parent
+                                            text: qsTranslate("MainWindow", "单个元器件")
+                                            font.pixelSize: AppStyle.fontSizes.sm
+                                            color: inputMode === 0 ? AppStyle.colors.textOnPrimary : AppStyle.colors.textSecondary
+                                            font.bold: inputMode === 0
+                                        }
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: inputMode = 0
+                                        }
+                                    }
+
+                                    Rectangle {
+                                        Layout.fillWidth: true
+                                        Layout.preferredHeight: 34
+                                        radius: AppStyle.radius.sm
+                                        color: inputMode === 1 ? AppStyle.colors.success : "transparent"
+                                        border.color: inputMode === 1 ? AppStyle.colors.success : AppStyle.colors.border
+                                        border.width: AppStyle.borderWidths.thin
+                                        Text {
+                                            anchors.centerIn: parent
+                                            text: qsTranslate("MainWindow", "批量导入 BOM")
+                                            font.pixelSize: AppStyle.fontSizes.sm
+                                            color: inputMode === 1 ? AppStyle.colors.textOnPrimary : AppStyle.colors.textSecondary
+                                            font.bold: inputMode === 1
+                                        }
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            cursorShape: Qt.PointingHandCursor
+                                            onClicked: inputMode = 1
+                                        }
+                                    }
+                                }
+
+                                // 单个元器件输入 / BOM 导入（带横向滑动切换）
+                                Item {
+                                    Layout.fillWidth: true
+                                    Layout.preferredHeight: Math.max(singleInputColumn.implicitHeight, bomImportColumn.implicitHeight)
+                                    clip: true
+                                    // 单个元器件输入
+                                    ColumnLayout {
+                                        id: singleInputColumn
+                                        width: parent.width
+                                        spacing: AppStyle.spacing.sm
+                                        opacity: inputMode === 0 ? 1 : 0
+                                        x: inputMode === 0 ? 0 : -20
+                                        visible: opacity > 0 || inputMode === 0
+                                        Behavior on opacity {
+                                            NumberAnimation {
+                                                duration: AppStyle.durations.fast
+                                            }
+                                        }
+                                        Behavior on x {
+                                            NumberAnimation {
+                                                duration: AppStyle.durations.fast
+                                                easing.type: Easing.OutCubic
+                                            }
+                                        }
+
+                                        RowLayout {
+                                            width: parent.width
+                                            spacing: 12
+                                            TextField {
+                                                id: componentInput
+                                                objectName: "componentInputField"
+                                                Layout.fillWidth: true
+                                                placeholderText: qsTranslate("MainWindow", "输入LCSC元件编号 (例如: C2040)")
+                                                font.pixelSize: AppStyle.fontSizes.md
+                                                color: AppStyle.colors.textPrimary
+                                                placeholderTextColor: AppStyle.colors.textSecondary
+                                                Component.onCompleted: {
+                                                    Qt.callLater(function () {
+                                                        forceActiveFocus();
+                                                    });
+                                                }
+                                                background: Rectangle {
+                                                    color: componentInput.enabled ? AppStyle.colors.surface : AppStyle.colors.background
+                                                    border.color: componentInput.focus ? AppStyle.colors.borderFocus : AppStyle.colors.border
+                                                    border.width: componentInput.focus ? 2 : 1
+                                                    radius: AppStyle.radius.md
+                                                    Behavior on border.color {
+                                                        ColorAnimation {
+                                                            duration: AppStyle.durations.fast
+                                                        }
+                                                    }
+                                                    Behavior on border.width {
+                                                        NumberAnimation {
+                                                            duration: AppStyle.durations.fast
+                                                        }
+                                                    }
+                                                }
+                                                onAccepted: {
+                                                    if (componentInput.text.length > 0) {
+                                                        window.componentListController.addComponent(componentInput.text);
+                                                        componentInput.text = "";
+                                                    }
+                                                }
+                                            }
+
+                                            ModernButton {
+                                                text: qsTranslate("MainWindow", "添加")
+                                                iconName: "add"
+                                                enabled: componentInput.text.length > 0
+                                                onClicked: {
+                                                    if (componentInput.text.length > 0) {
+                                                        window.componentListController.addComponent(componentInput.text);
+                                                        componentInput.text = "";
+                                                    }
+                                                }
+                                            }
+
+                                            ModernButton {
+                                                text: qsTranslate("MainWindow", "粘贴")
+                                                iconName: "folder"
+                                                backgroundColor: AppStyle.colors.textSecondary
+                                                hoverColor: AppStyle.colors.textPrimary
+                                                pressedColor: AppStyle.colors.textPrimary
+                                                onClicked: {
+                                                    window.componentListController.pasteFromClipboard();
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // BOM 导入
+                                    ColumnLayout {
+                                        id: bomImportColumn
+                                        width: parent.width
+                                        spacing: AppStyle.spacing.sm
+                                        opacity: inputMode === 1 ? 1 : 0
+                                        x: inputMode === 1 ? 0 : 20
+                                        visible: opacity > 0 || inputMode === 1
+                                        Behavior on opacity {
+                                            NumberAnimation {
+                                                duration: AppStyle.durations.fast
+                                            }
+                                        }
+                                        Behavior on x {
+                                            NumberAnimation {
+                                                duration: AppStyle.durations.fast
+                                                easing.type: Easing.OutCubic
+                                            }
+                                        }
+
+                                        RowLayout {
+                                            width: parent.width
+                                            spacing: 12
+                                            ModernButton {
+                                                text: qsTranslate("MainWindow", "选择BOM文件")
+                                                iconName: "upload"
+                                                backgroundColor: AppStyle.colors.success
+                                                hoverColor: AppStyle.colors.successDark
+                                                pressedColor: AppStyle.colors.successDark
+                                                onClicked: {
+                                                    bomFileDialog.open();
+                                                }
+                                            }
+
+                                            Text {
+                                                Layout.fillWidth: true
+                                                text: window.componentListController && window.componentListController.bomFilePath && window.componentListController.bomFilePath.length > 0 ? window.componentListController.bomFilePath.split("/").pop() : qsTranslate("MainWindow", "未选择文件")
+                                                font.pixelSize: AppStyle.fontSizes.sm
+                                                color: AppStyle.colors.textSecondary
+                                                horizontalAlignment: Text.AlignHCenter
+                                                elide: Text.ElideMiddle
+                                            }
+                                        }
+
+                                        Text {
+                                            Layout.fillWidth: true
+                                            Layout.topMargin: AppStyle.spacing.xs
+                                            text: window.componentListController ? window.componentListController.bomResult : ""
+                                            font.pixelSize: AppStyle.fontSizes.sm
+                                            color: AppStyle.colors.success
+                                            horizontalAlignment: Text.AlignHCenter
+                                            visible: window.componentListController && window.componentListController.bomResult && window.componentListController.bomResult.length > 0
+                                        }
+                                    }
+                                }
+
+                                // 弱网络选项（始终可见）
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: 12
+                                    CheckBox {
+                                        id: weakNetworkCheckbox
+                                        Layout.fillWidth: false
+                                        text: qsTranslate("MainWindow", "客户端弱网络适配")
+                                        checked: window.exportSettingsController ? window.exportSettingsController.weakNetworkSupport : false
+                                        onCheckedChanged: {
+                                            if (window.exportSettingsController) {
+                                                window.exportSettingsController.setWeakNetworkSupport(checked);
+                                            }
+                                        }
+                                        font.pixelSize: AppStyle.fontSizes.sm
+                                        ToolTip.visible: hovered
+                                        ToolTip.text: qsTranslate("MainWindow", "仅影响本机网络请求策略，不代表服务器限流；开启后会使用更保守的并发、超时和重试配置")
+                                        ToolTip.delay: 500
+                                        indicator: Rectangle {
+                                            implicitWidth: 22
+                                            implicitHeight: 22
+                                            x: weakNetworkCheckbox.leftPadding
+                                            y: parent.height / 2 - height / 2
+                                            radius: AppStyle.radius.xs
+                                            color: weakNetworkCheckbox.checked ? AppStyle.colors.primary : "transparent"
+                                            border.color: weakNetworkCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                                            border.width: AppStyle.borderWidths.normal
+                                            Behavior on color {
+                                                ColorAnimation {
+                                                    duration: 150
+                                                }
+                                            }
+                                            Behavior on border.color {
+                                                ColorAnimation {
+                                                    duration: 150
+                                                }
+                                            }
+
+                                            Text {
+                                                anchors.centerIn: parent
+                                                text: "✓"
+                                                font.pixelSize: AppStyle.fontSizes.sm
+                                                color: AppStyle.colors.textOnPrimary
+                                                visible: weakNetworkCheckbox.checked
+                                            }
+                                        }
+
+                                        contentItem: Text {
+                                            text: parent.text
+                                            font: parent.font
+                                            color: AppStyle.colors.textPrimary
+                                            verticalAlignment: Text.AlignVCenter
+                                            leftPadding: parent.indicator.width + parent.spacing
+                                        }
+                                    }
+
+                                    Text {
+                                        Layout.fillWidth: true
+                                        text: qsTranslate("MainWindow", "导入 BOM 前可先开启，验证和预览图加载也会使用该策略")
+                                        font.pixelSize: AppStyle.fontSizes.xs
+                                        color: AppStyle.colors.textSecondary
+                                        elide: Text.ElideRight
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                            }
+                        }
+
+                        // 元件列表卡片
+                        ComponentListCard {
+                            Layout.fillWidth: true
+                            componentListController: window.componentListController
+                            exportProgressController: window.exportProgressController
+                        }
+
+                        // ==================== Compact 模式独有内容 ====================
+                        // 转换进度
+                        ExportProgressCard {
+                            Layout.fillWidth: true
+                            exportProgressController: window.exportProgressController
+                            visible: !window.isSidebarMode && ((window.exportProgressController && window.exportProgressController.isExporting) || (window.exportProgressController && window.exportProgressController.progress > 0))
+                        }
+
+                        // 转换结果
+                        ExportResultsCard {
+                            Layout.fillWidth: true
+                            exportProgressController: window.exportProgressController
+                            visible: !window.isSidebarMode
+                        }
+
+                        // 导出统计
+                        ExportStatisticsCard {
+                            Layout.fillWidth: true
+                            exportProgressController: window.exportProgressController
+                            exportSettingsController: window.exportSettingsController
+                            visible: !window.isSidebarMode
+                        }
+
+                        // 导出设置
+                        Loader {
+                            id: compactSettingsLoader
+                            Layout.fillWidth: true
+                            active: !window.isSidebarMode
+                            sourceComponent: ExportSettingsCard {
+                                exportSettingsController: window.exportSettingsController
+                            }
+                        }
+
+                        Connections {
+                            target: compactSettingsLoader.item
+                            function onOpenOutputFolderDialog() {
+                                outputFolderDialog.open();
+                            }
+                            function onOpenCacheFolderDialog() {
+                                cacheFolderDialog.open();
+                            }
+                        }
+
+                        // 导出按钮组
+                        Loader {
+                            id: compactButtonsLoader
+                            Layout.fillWidth: true
+                            active: !window.isSidebarMode
+                            sourceComponent: ExportButtonsSection {
+                                exportProgressController: window.exportProgressController
+                                exportSettingsController: window.exportSettingsController
+                                componentListController: window.componentListController
+                            }
+                        }
+
+                        // 底部间距（为 sticky bar 预留空间）
+                        Item {
+                            Layout.preferredHeight: window.compactScrolledPastThreshold ? 80 : ResponsiveHelper.contentMargin
+                        }
                     }
+                }
+            }
+        }
 
-                    // 元件输入卡片
-                    ComponentInputCard {
-                        Layout.fillWidth: true
-                        componentListController: window.componentListController
+        // ==================== Compact 模式浮动操作栏 ====================
+        Rectangle {
+            id: stickyActionBar
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: 64
+            color: AppStyle.isDarkMode ? Qt.rgba(15 / 255, 23 / 255, 42 / 255, 0.95) : Qt.rgba(255, 255, 255, 0.95)
+            visible: !window.isSidebarMode && window.compactScrolledPastThreshold
+            opacity: window.stickyBarOpacity
+            z: 500
+            // 顶部边框
+            Rectangle {
+                anchors.top: parent.top
+                width: parent.width
+                height: 1
+                color: AppStyle.colors.border
+            }
+
+            layer.enabled: true
+            layer.effect: MultiEffect {
+                shadowEnabled: true
+                shadowBlur: 0.6
+                shadowColor: AppStyle.isDarkMode ? "#80000000" : "#20000000"
+                shadowVerticalOffset: -4
+                shadowHorizontalOffset: 0
+            }
+
+            Behavior on opacity {
+                NumberAnimation {
+                    duration: AppStyle.durations.fast
+                    easing.type: AppStyle.easings.easeOut
+                }
+            }
+
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: ResponsiveHelper.contentMargin
+                anchors.rightMargin: ResponsiveHelper.contentMargin
+                spacing: AppStyle.spacing.md
+                Text {
+                    text: {
+                        var lang = window.currentLanguage;
+                        var pc = window.exportProgressController;
+                        if (pc && pc.isExporting)
+                            return qsTranslate("MainWindow", "正在转换...");
+                        if (pc && pc.failureCount > 0)
+                            return qsTranslate("MainWindow", "有 %1 项失败").arg(pc.failureCount);
+                        return qsTranslate("MainWindow", "就绪");
                     }
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    color: AppStyle.colors.textSecondary
+                    Layout.alignment: Qt.AlignVCenter
+                }
 
-                    // BOM导入卡片
-                    BomImportCard {
-                        Layout.fillWidth: true
-                        componentListController: window.componentListController
-                        exportSettingsController: window.exportSettingsController
-                        onOpenBomFileDialog: bomFileDialog.open()
+                // 进度条
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 6
+                    Layout.alignment: Qt.AlignVCenter
+                    radius: 3
+                    color: AppStyle.colors.border
+                    visible: window.exportProgressController && window.exportProgressController.isExporting
+                    Rectangle {
+                        width: parent.width * (window.exportProgressController ? window.exportProgressController.progress / 100 : 0)
+                        height: parent.height
+                        radius: 3
+                        color: AppStyle.colors.primary
+                        Behavior on width {
+                            NumberAnimation {
+                                duration: 100
+                            }
+                        }
                     }
+                }
 
-                    // 元件列表卡片
-                    ComponentListCard {
-                        Layout.fillWidth: true
-                        componentListController: window.componentListController
-                        exportProgressController: window.exportProgressController
+                // 打开目录按钮
+                ModernButton {
+                    objectName: "stickyOpenFolderButton"
+                    text: qsTranslate("MainWindow", "打开目录")
+                    iconName: "folder"
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    backgroundColor: AppStyle.colors.primary
+                    hoverColor: AppStyle.colors.primaryHover
+                    pressedColor: AppStyle.colors.primaryPressed
+                    visible: window.exportProgressController && window.exportProgressController.hasCompletedExport
+                    onClicked: {
+                        if (window.exportProgressController) {
+                            window.exportProgressController.openLastExportedFolder();
+                        }
                     }
+                }
 
-                    // 导出设置卡片
-                    ExportSettingsCard {
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        exportSettingsController: window.exportSettingsController
-                        onOpenOutputFolderDialog: outputFolderDialog.open()
-                        onOpenCacheFolderDialog: cacheFolderDialog.open()
+                // 开始/重试按钮
+                ModernButton {
+                    objectName: "stickyStartButton"
+                    text: {
+                        var pc = window.exportProgressController;
+                        if (pc && pc.isExporting)
+                            return qsTranslate("MainWindow", "转换中");
+                        if (pc && pc.failureCount > 0)
+                            return qsTranslate("MainWindow", "重试");
+                        return qsTranslate("MainWindow", "开始转换");
                     }
-
-                    // 进度显示卡片
-                    ExportProgressCard {
-                        Layout.fillWidth: true
-                        exportProgressController: window.exportProgressController
+                    iconName: "play"
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    Layout.preferredHeight: 40
+                    backgroundColor: {
+                        var pc = window.exportProgressController;
+                        if (pc && pc.isExporting)
+                            return AppStyle.colors.textDisabled;
+                        if (pc && pc.failureCount > 0)
+                            return AppStyle.colors.warning;
+                        return AppStyle.colors.primary;
                     }
-
-                    // 转换结果卡片（延迟加载）
-                    ExportResultsCard {
-                        Layout.fillWidth: true
-                        exportProgressController: window.exportProgressController
+                    hoverColor: {
+                        var pc = window.exportProgressController;
+                        if (pc && pc.failureCount > 0 && !(pc && pc.isExporting))
+                            return AppStyle.colors.warningDark;
+                        return AppStyle.colors.primaryHover;
                     }
-
-                    // 导出统计卡片（仅在导出完成后显示）
-                    ExportStatisticsCard {
-                        Layout.fillWidth: true
-                        exportProgressController: window.exportProgressController
-                        exportSettingsController: window.exportSettingsController
+                    pressedColor: {
+                        var pc = window.exportProgressController;
+                        if (pc && pc.failureCount > 0 && !(pc && pc.isExporting))
+                            return AppStyle.colors.warningDark;
+                        return AppStyle.colors.primaryPressed;
                     }
-
-                    // 导出按钮组
-                    ExportButtonsSection {
-                        Layout.fillWidth: true
-                        exportProgressController: window.exportProgressController
-                        exportSettingsController: window.exportSettingsController
-                        componentListController: window.componentListController
+                    enabled: {
+                        var pc = window.exportProgressController;
+                        var lc = window.componentListController;
+                        var sc = window.exportSettingsController;
+                        if (pc && pc.isExporting)
+                            return false;
+                        if (!lc || lc.componentCount <= 0)
+                            return false;
+                        if (!sc)
+                            return false;
+                        return sc.exportSymbol || sc.exportFootprint || sc.exportModel3D;
                     }
+                    onClicked: {
+                        var pc = window.exportProgressController;
+                        var sc = window.exportSettingsController;
+                        if (pc && pc.failureCount > 0) {
+                            pc.retryFailedComponents();
+                        } else if (pc && sc) {
+                            var idList = window.componentListController ? window.componentListController.getAllComponentIds() : [];
+                            pc.startExport(idList, sc.outputPath || "", sc.libName || "", sc.exportSymbol || false, sc.exportFootprint || false, sc.exportModel3D || false, sc.exportModel3DFormat || 3, sc.exportModel3DPathMode || 0, sc.exportPreviewImages || false, sc.exportDatasheet || false, sc.overwriteExistingFiles || false, (sc.exportMode || 0) === 1, sc.debugMode || false, sc.symbolLibraryDescription || "", sc.footprintLibraryDescription || "", sc.footprintLibraryKeywords || "");
+                        }
+                    }
+                }
 
-                    // 底部边距
-                    Item {
-                        Layout.preferredHeight: ResponsiveHelper.contentMargin
+                // 停止按钮
+                ModernButton {
+                    objectName: "stickyStopButton"
+                    text: (window.exportProgressController && window.exportProgressController.isStopping) ? qsTranslate("MainWindow", "停止中") : qsTranslate("MainWindow", "停止")
+                    iconName: "close"
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    Layout.preferredHeight: 40
+                    backgroundColor: AppStyle.colors.danger
+                    hoverColor: AppStyle.colors.dangerDark
+                    pressedColor: AppStyle.colors.dangerDark
+                    visible: window.exportProgressController && window.exportProgressController.isExporting
+                    enabled: window.exportProgressController ? !window.exportProgressController.isStopping : false
+                    onClicked: {
+                        if (window.exportProgressController) {
+                            window.exportProgressController.cancelExport();
+                        }
                     }
                 }
             }
@@ -336,5 +820,23 @@ Item {
     // 窗口边缘调整大小手柄
     WindowResizeHandles {
         isMaximized: window.isMaximized
+    }
+
+    // ==================== 辅助函数 ====================
+    // Compact 模式滚动状态跟踪（用于 sticky bar 显示/隐藏）
+    function updateCompactScrollState() {
+        var flickable = mainFlickable();
+        if (!flickable || window.isSidebarMode) {
+            compactScrolledPastThreshold = false;
+            stickyBarOpacity = 0;
+            return;
+        }
+        // 仅在内容确实可滚动且超过阈值时激活
+        var canScroll = flickable.contentHeight > flickable.height + 10;
+        var scrolled = canScroll && flickable.contentY > 200;
+        if (scrolled !== compactScrolledPastThreshold) {
+            compactScrolledPastThreshold = scrolled;
+            stickyBarOpacity = scrolled ? 1 : 0;
+        }
     }
 }

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -617,10 +617,13 @@ Item {
                         }
 
                         // 元件列表卡片
+                        // 元件列表卡片
                         ComponentListCard {
+                            id: componentListCardItem
                             Layout.fillWidth: true
                             componentListController: window.componentListController
                             exportProgressController: window.exportProgressController
+                            isExporting: window.exportProgressController ? window.exportProgressController.isExporting : false
                         }
 
                         // ==================== 工作区内容（始终可见） ====================

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -28,6 +28,7 @@ Item {
     readonly property int calculatedMinimumWindowWidth: ResponsiveHelper.minimumWindowWidth
     // 响应式布局模式
     readonly property bool isSidebarMode: ResponsiveHelper.isAtLeastMedium
+    property bool sidebarCollapsed: false
     // 交互状态
     property int inputMode: 0  // 0=单个, 1=BOM
     // 滚动跟踪（用于 compact 模式下的 sticky bar）
@@ -127,11 +128,17 @@ Item {
         property: "isDarkMode"
         value: themeController ? themeController.isDarkMode : false
     }
-    // 将窗口实际宽度写入 ResponsiveHelper，驱动断点系统
+    // 将窗口实际尺寸写入 ResponsiveHelper，驱动断点系统
     Binding {
         target: ResponsiveHelper
         property: "windowWidth"
         value: window.width
+    }
+
+    Binding {
+        target: ResponsiveHelper
+        property: "windowHeight"
+        value: window.height
     }
     // 从 FolderDialog URL 中提取本地路径（跨平台处理）
     function urlToLocalPath(url) {
@@ -259,11 +266,24 @@ Item {
             // ==================== 侧边栏控制面板 ====================
             Loader {
                 id: sidebarLoader
+                z: 1
                 active: window.isSidebarMode
-                Layout.preferredWidth: active ? 360 : 0
+                Layout.preferredWidth: {
+                    if (!active)
+                        return 0;
+                    return window.sidebarCollapsed ? 48 : ResponsiveHelper.sidebarWidth;
+                }
                 Layout.fillHeight: true
+                Behavior on Layout.preferredWidth {
+                    NumberAnimation {
+                        duration: 280
+                        easing.type: Easing.OutQuart
+                    }
+                }
                 sourceComponent: Component {
                     SidebarPanel {
+                        collapsed: window.sidebarCollapsed
+                        onToggleCollapsed: window.sidebarCollapsed = !window.sidebarCollapsed
                         onRequestOutputFolderDialog: outputFolderDialog.open()
                         onRequestCacheFolderDialog: cacheFolderDialog.open()
                     }
@@ -308,58 +328,64 @@ Item {
                             updateChecker: window.updateChecker
                         }
 
-                        // ==================== 数据源输入卡片（合并） ====================
+                        // ==================== 元器件添加方式 ====================
                         Card {
                             Layout.fillWidth: true
-                            title: qsTranslate("MainWindow", "数据源")
+                            title: qsTranslate("MainWindow", "元器件添加方式")
                             ColumnLayout {
                                 width: parent.width
                                 spacing: AppStyle.spacing.lg
-                                // 模式切换标签
-                                RowLayout {
+                                // 滑块式模式切换
+                                Rectangle {
                                     Layout.fillWidth: true
-                                    spacing: AppStyle.spacing.sm
+                                    height: 36
+                                    radius: AppStyle.radius.sm
+                                    color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.06) : Qt.rgba(0, 0, 0, 0.06)
+                                    // 滑块指示器
                                     Rectangle {
-                                        Layout.fillWidth: true
-                                        Layout.preferredHeight: 34
-                                        radius: AppStyle.radius.sm
-                                        color: inputMode === 0 ? AppStyle.colors.primary : "transparent"
-                                        border.color: inputMode === 0 ? AppStyle.colors.primary : AppStyle.colors.border
+                                        width: parent.width / 2
+                                        height: parent.height - 4
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        radius: AppStyle.radius.sm - 1
+                                        color: AppStyle.colors.surface
                                         border.width: AppStyle.borderWidths.thin
-                                        Text {
-                                            anchors.centerIn: parent
-                                            text: qsTranslate("MainWindow", "单个元器件")
-                                            font.pixelSize: AppStyle.fontSizes.sm
-                                            color: inputMode === 0 ? AppStyle.colors.textOnPrimary : AppStyle.colors.textSecondary
-                                            font.bold: inputMode === 0
-                                        }
-
-                                        MouseArea {
-                                            anchors.fill: parent
-                                            cursorShape: Qt.PointingHandCursor
-                                            onClicked: inputMode = 0
+                                        border.color: AppStyle.colors.border
+                                        x: inputMode === 0 ? 2 : parent.width / 2
+                                        Behavior on x {
+                                            NumberAnimation {
+                                                duration: 200
+                                                easing.type: Easing.OutQuart
+                                            }
                                         }
                                     }
 
-                                    Rectangle {
-                                        Layout.fillWidth: true
-                                        Layout.preferredHeight: 34
-                                        radius: AppStyle.radius.sm
-                                        color: inputMode === 1 ? AppStyle.colors.success : "transparent"
-                                        border.color: inputMode === 1 ? AppStyle.colors.success : AppStyle.colors.border
-                                        border.width: AppStyle.borderWidths.thin
-                                        Text {
-                                            anchors.centerIn: parent
-                                            text: qsTranslate("MainWindow", "批量导入 BOM")
-                                            font.pixelSize: AppStyle.fontSizes.sm
-                                            color: inputMode === 1 ? AppStyle.colors.textOnPrimary : AppStyle.colors.textSecondary
-                                            font.bold: inputMode === 1
-                                        }
+                                    Row {
+                                        anchors.fill: parent
+                                        anchors.margins: 2
+                                        Repeater {
+                                            model: [qsTranslate("MainWindow", "手动添加元器件"), qsTranslate("MainWindow", "通过BOM表导入元器件")]
+                                            Item {
+                                                width: parent.width / 2
+                                                height: parent.height
+                                                Text {
+                                                    anchors.centerIn: parent
+                                                    text: modelData
+                                                    font.pixelSize: AppStyle.fontSizes.xs
+                                                    font.bold: index === inputMode
+                                                    color: index === inputMode ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                                                    Behavior on color {
+                                                        ColorAnimation {
+                                                            duration: 200
+                                                        }
+                                                    }
+                                                }
 
-                                        MouseArea {
-                                            anchors.fill: parent
-                                            cursorShape: Qt.PointingHandCursor
-                                            onClicked: inputMode = 1
+                                                MouseArea {
+                                                    anchors.fill: parent
+                                                    cursorShape: Qt.PointingHandCursor
+                                                    onClicked: inputMode = index
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -367,8 +393,14 @@ Item {
                                 // 单个元器件输入 / BOM 导入（带横向滑动切换）
                                 Item {
                                     Layout.fillWidth: true
-                                    Layout.preferredHeight: Math.max(singleInputColumn.implicitHeight, bomImportColumn.implicitHeight)
+                                    Layout.preferredHeight: inputMode === 0 ? singleInputColumn.implicitHeight : bomImportColumn.implicitHeight
                                     clip: true
+                                    Behavior on Layout.preferredHeight {
+                                        NumberAnimation {
+                                            duration: 200
+                                            easing.type: Easing.OutQuart
+                                        }
+                                    }
                                     // 单个元器件输入
                                     ColumnLayout {
                                         id: singleInputColumn
@@ -454,7 +486,7 @@ Item {
                                         }
                                     }
 
-                                    // BOM 导入
+                                    // BOM 导入（拖拽式卡片）
                                     ColumnLayout {
                                         id: bomImportColumn
                                         width: parent.width
@@ -474,105 +506,111 @@ Item {
                                             }
                                         }
 
-                                        RowLayout {
-                                            width: parent.width
-                                            spacing: 12
-                                            ModernButton {
-                                                text: qsTranslate("MainWindow", "选择BOM文件")
-                                                iconName: "upload"
-                                                backgroundColor: AppStyle.colors.success
-                                                hoverColor: AppStyle.colors.successDark
-                                                pressedColor: AppStyle.colors.successDark
-                                                onClicked: {
-                                                    bomFileDialog.open();
-                                                }
-                                            }
+                                        property bool hasFile: window.componentListController && window.componentListController.bomFilePath && window.componentListController.bomFilePath.length > 0
+                                        property string fileName: hasFile ? window.componentListController.bomFilePath.split("/").pop() : ""
+                                        property string bomResult: window.componentListController ? window.componentListController.bomResult : ""
 
-                                            Text {
-                                                Layout.fillWidth: true
-                                                text: window.componentListController && window.componentListController.bomFilePath && window.componentListController.bomFilePath.length > 0 ? window.componentListController.bomFilePath.split("/").pop() : qsTranslate("MainWindow", "未选择文件")
-                                                font.pixelSize: AppStyle.fontSizes.sm
-                                                color: AppStyle.colors.textSecondary
-                                                horizontalAlignment: Text.AlignHCenter
-                                                elide: Text.ElideMiddle
-                                            }
-                                        }
-
-                                        Text {
+                                        // 文件选择区域
+                                        Rectangle {
                                             Layout.fillWidth: true
-                                            Layout.topMargin: AppStyle.spacing.xs
-                                            text: window.componentListController ? window.componentListController.bomResult : ""
-                                            font.pixelSize: AppStyle.fontSizes.sm
-                                            color: AppStyle.colors.success
-                                            horizontalAlignment: Text.AlignHCenter
-                                            visible: window.componentListController && window.componentListController.bomResult && window.componentListController.bomResult.length > 0
-                                        }
-                                    }
-                                }
-
-                                // 弱网络选项（始终可见）
-                                RowLayout {
-                                    Layout.fillWidth: true
-                                    spacing: 12
-                                    CheckBox {
-                                        id: weakNetworkCheckbox
-                                        Layout.fillWidth: false
-                                        text: qsTranslate("MainWindow", "客户端弱网络适配")
-                                        checked: window.exportSettingsController ? window.exportSettingsController.weakNetworkSupport : false
-                                        onCheckedChanged: {
-                                            if (window.exportSettingsController) {
-                                                window.exportSettingsController.setWeakNetworkSupport(checked);
+                                            Layout.minimumHeight: 100
+                                            radius: AppStyle.radius.md
+                                            color: {
+                                                if (bomImportColumn.hasFile)
+                                                    return AppStyle.isDarkMode ? Qt.rgba(34, 197, 94, 0.08) : Qt.rgba(34, 197, 94, 0.06);
+                                                return AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.03) : Qt.rgba(0, 0, 0, 0.02);
                                             }
-                                        }
-                                        font.pixelSize: AppStyle.fontSizes.sm
-                                        ToolTip.visible: hovered
-                                        ToolTip.text: qsTranslate("MainWindow", "仅影响本机网络请求策略，不代表服务器限流；开启后会使用更保守的并发、超时和重试配置")
-                                        ToolTip.delay: 500
-                                        indicator: Rectangle {
-                                            implicitWidth: 22
-                                            implicitHeight: 22
-                                            x: weakNetworkCheckbox.leftPadding
-                                            y: parent.height / 2 - height / 2
-                                            radius: AppStyle.radius.xs
-                                            color: weakNetworkCheckbox.checked ? AppStyle.colors.primary : "transparent"
-                                            border.color: weakNetworkCheckbox.checked ? AppStyle.colors.primary : AppStyle.colors.textSecondary
-                                            border.width: AppStyle.borderWidths.normal
-                                            Behavior on color {
-                                                ColorAnimation {
-                                                    duration: 150
-                                                }
-                                            }
+                                            border.width: bomImportColumn.hasFile ? 2 : 0
+                                            border.color: bomImportColumn.hasFile ? AppStyle.colors.success : "transparent"
                                             Behavior on border.color {
                                                 ColorAnimation {
-                                                    duration: 150
+                                                    duration: AppStyle.durations.fast
+                                                }
+                                            }
+                                            Behavior on color {
+                                                ColorAnimation {
+                                                    duration: AppStyle.durations.fast
                                                 }
                                             }
 
-                                            Text {
+                                            // 虚线边框（未选择文件时显示）
+                                            Canvas {
+                                                id: dashBorder
+                                                anchors.fill: parent
+                                                visible: !bomImportColumn.hasFile
+                                                opacity: bomDropArea.containsMouse ? 0.8 : 0.4
+                                                onPaint: {
+                                                    var ctx = getContext("2d");
+                                                    ctx.clearRect(0, 0, width, height);
+                                                    ctx.strokeStyle = bomDropArea.containsMouse ? AppStyle.colors.primary : AppStyle.colors.textSecondary;
+                                                    ctx.lineWidth = 1.5;
+                                                    ctx.setLineDash([6, 4]);
+                                                    var r = AppStyle.radius.md;
+                                                    ctx.beginPath();
+                                                    ctx.roundedRect(1, 1, width - 2, height - 2, r, r);
+                                                    ctx.stroke();
+                                                }
+                                                Connections {
+                                                    target: bomDropArea
+                                                    function onContainsMouseChanged() {
+                                                        dashBorder.requestPaint();
+                                                    }
+                                                }
+                                            }
+
+                                            ColumnLayout {
                                                 anchors.centerIn: parent
-                                                text: "✓"
-                                                font.pixelSize: AppStyle.fontSizes.sm
-                                                color: AppStyle.colors.textOnPrimary
-                                                visible: weakNetworkCheckbox.checked
+                                                spacing: AppStyle.spacing.sm
+                                                // 文件图标
+                                                Text {
+                                                    Layout.alignment: Qt.AlignHCenter
+                                                    text: bomImportColumn.hasFile ? "📄" : "📁"
+                                                    font.pixelSize: 28
+                                                }
+                                                // 文件名或提示文字
+                                                Text {
+                                                    Layout.alignment: Qt.AlignHCenter
+                                                    text: {
+                                                        if (bomImportColumn.hasFile)
+                                                            return bomImportColumn.fileName;
+                                                        return qsTranslate("MainWindow", "点击选择 BOM 文件");
+                                                    }
+                                                    font.pixelSize: AppStyle.fontSizes.sm
+                                                    font.bold: bomImportColumn.hasFile
+                                                    color: bomImportColumn.hasFile ? AppStyle.colors.textPrimary : AppStyle.colors.textSecondary
+                                                    elide: Text.ElideMiddle
+                                                    Layout.maximumWidth: parent.parent.width - AppStyle.spacing.xl * 2
+                                                }
+                                                // 解析结果
+                                                Text {
+                                                    Layout.alignment: Qt.AlignHCenter
+                                                    text: {
+                                                        if (bomImportColumn.bomResult && bomImportColumn.bomResult.length > 0)
+                                                            return bomImportColumn.bomResult;
+                                                        if (bomImportColumn.hasFile)
+                                                            return qsTranslate("MainWindow", "文件已就绪");
+                                                        return qsTranslate("MainWindow", "支持格式: .xlsx, .csv, .txt");
+                                                    }
+                                                    font.pixelSize: AppStyle.fontSizes.xs
+                                                    color: {
+                                                        if (bomImportColumn.bomResult && bomImportColumn.bomResult.length > 0)
+                                                            return AppStyle.colors.success;
+                                                        if (bomImportColumn.hasFile)
+                                                            return AppStyle.colors.success;
+                                                        return AppStyle.colors.textSecondary;
+                                                    }
+                                                    opacity: 0.8
+                                                }
+                                            }
+
+                                            MouseArea {
+                                                id: bomDropArea
+                                                anchors.fill: parent
+                                                hoverEnabled: true
+                                                cursorShape: Qt.PointingHandCursor
+                                                onClicked: bomFileDialog.open()
                                             }
                                         }
-
-                                        contentItem: Text {
-                                            text: parent.text
-                                            font: parent.font
-                                            color: AppStyle.colors.textPrimary
-                                            verticalAlignment: Text.AlignVCenter
-                                            leftPadding: parent.indicator.width + parent.spacing
-                                        }
-                                    }
-
-                                    Text {
-                                        Layout.fillWidth: true
-                                        text: qsTranslate("MainWindow", "导入 BOM 前可先开启，验证和预览图加载也会使用该策略")
-                                        font.pixelSize: AppStyle.fontSizes.xs
-                                        color: AppStyle.colors.textSecondary
-                                        elide: Text.ElideRight
-                                        verticalAlignment: Text.AlignVCenter
                                     }
                                 }
                             }
@@ -585,19 +623,18 @@ Item {
                             exportProgressController: window.exportProgressController
                         }
 
-                        // ==================== Compact 模式独有内容 ====================
+                        // ==================== 工作区内容（始终可见） ====================
                         // 转换进度
                         ExportProgressCard {
                             Layout.fillWidth: true
                             exportProgressController: window.exportProgressController
-                            visible: !window.isSidebarMode && ((window.exportProgressController && window.exportProgressController.isExporting) || (window.exportProgressController && window.exportProgressController.progress > 0))
+                            visible: (window.exportProgressController && window.exportProgressController.isExporting) || (window.exportProgressController && window.exportProgressController.progress > 0)
                         }
 
                         // 转换结果
                         ExportResultsCard {
                             Layout.fillWidth: true
                             exportProgressController: window.exportProgressController
-                            visible: !window.isSidebarMode
                         }
 
                         // 导出统计
@@ -605,7 +642,6 @@ Item {
                             Layout.fillWidth: true
                             exportProgressController: window.exportProgressController
                             exportSettingsController: window.exportSettingsController
-                            visible: !window.isSidebarMode
                         }
 
                         // 导出设置
@@ -817,6 +853,39 @@ Item {
                             window.exportProgressController.cancelExport();
                         }
                     }
+                }
+            }
+        }
+    }
+
+    // 底部进度指示条（2px 全局进度，z: -1 避免遮挡 resize 手柄）
+    Rectangle {
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 2
+        z: -1
+        color: "transparent"
+        visible: window.exportProgressController && (window.exportProgressController.isExporting || window.exportProgressController.progress > 0)
+        Rectangle {
+            width: parent.width * ((window.exportProgressController ? window.exportProgressController.progress : 0) / 100)
+            height: parent.height
+            color: {
+                var pc = window.exportProgressController;
+                if (pc && pc.isExporting)
+                    return AppStyle.colors.warning;
+                if (pc && pc.failureCount > 0)
+                    return AppStyle.colors.danger;
+                return AppStyle.colors.success;
+            }
+            Behavior on width {
+                NumberAnimation {
+                    duration: 150
+                }
+            }
+            Behavior on color {
+                ColorAnimation {
+                    duration: 300
                 }
             }
         }

--- a/src/ui/qml/MainWindow.qml
+++ b/src/ui/qml/MainWindow.qml
@@ -18,6 +18,10 @@ Item {
     property var exportProgressController: exportProgressViewModel
     property var themeController: themeSettingsViewModel
     property var updateChecker: updateCheckerService
+    // 对话框引用（供 SidebarPanel 等子组件访问）
+    property alias outputFolderDialog: outputFolderDialog
+    property alias cacheFolderDialog: cacheFolderDialog
+    property alias bomFileDialog: bomFileDialog
     // 窗口状态属性
     readonly property bool isMaximized: Window.window ? (Window.window.visibility === Window.Maximized || Window.window.visibility === Window.FullScreen) : false
     readonly property int windowRadius: isMaximized ? 0 : AppStyle.radius.lg
@@ -260,7 +264,8 @@ Item {
                 Layout.fillHeight: true
                 sourceComponent: Component {
                     SidebarPanel {
-                        window: window
+                        onRequestOutputFolderDialog: outputFolderDialog.open()
+                        onRequestCacheFolderDialog: cacheFolderDialog.open()
                     }
                 }
             }

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -17,9 +17,16 @@ Card {
     property string editingDescriptionComponentId: ""
     // 导出状态查找表（由 exportProgressController 驱动）
     property var exportStatusMap: ({})
+    // 外部传入的导出状态（由 MainWindow 绑定）
+    property bool isExporting: false
     title: qsTranslate("MainWindow", "元器件列表")
-    // 默认折叠，只有在有元器件时才展开
     isCollapsed: componentListController ? componentListController.componentCount === 0 : true
+    // 导出开始时自动折叠（结束后保持折叠，用户点击标题可手动展开）
+    onIsExportingChanged: {
+        if (isExporting) {
+            isCollapsed = true;
+        }
+    }
     resources: [
         // 防抖定时器，避免频繁调用 updateFilter()
         Timer {

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -15,6 +15,8 @@ Card {
     readonly property bool showPreviewHint: componentListController ? componentListController.previewReadyHint : false
     readonly property color hintColor: showPreviewHint ? "#31c36b" : (showValidationHint ? "#2f7ef8" : "transparent")
     property string editingDescriptionComponentId: ""
+    // 导出状态查找表（由 exportProgressController 驱动）
+    property var exportStatusMap: ({})
     title: qsTranslate("MainWindow", "元器件列表")
     // 默认折叠，只有在有元器件时才展开
     isCollapsed: componentListController ? componentListController.componentCount === 0 : true
@@ -64,6 +66,16 @@ Card {
                 previewPrefetchTimer.restart();
             }
         },
+        // 监听导出结果变化，更新导出状态查找表
+        Connections {
+            target: componentListCard.exportProgressController
+            function onResultsListChanged() {
+                componentListCard.updateExportStatusMap();
+            }
+            function onIsExportingChanged() {
+                componentListCard.updateExportStatusMap();
+            }
+        },
         Connections {
             target: componentListCard.componentListController
             function onListCleared() {
@@ -104,6 +116,11 @@ Card {
                 // 注意：QAbstractListModel 暴露的角色名为 "itemData"
                 itemData: model.itemData
                 searchText: searchInput.text // 传递搜索词用于高亮
+                // 绑定导出状态（由 ComponentListCard 维护的查找表）
+                exportStatus: {
+                    var id = itemData ? itemData.componentId : "";
+                    return id && componentListCard.exportStatusMap[id] ? componentListCard.exportStatusMap[id] : null;
+                }
                 onDeleteClicked: {
                     if (itemData) {
                         componentListCard.componentListController.removeComponentById(itemData.componentId);
@@ -977,6 +994,22 @@ Card {
             }
         }
         return bestPoint;
+    }
+
+    // 更新导出状态查找表
+    function updateExportStatusMap() {
+        var map = {};
+        var pc = componentListCard.exportProgressController;
+        if (pc && pc.resultsList) {
+            var list = pc.resultsList;
+            for (var i = 0; i < list.length; ++i) {
+                var item = list[i];
+                if (item && item.componentId) {
+                    map[item.componentId] = item;
+                }
+            }
+        }
+        exportStatusMap = map;
     }
 
     // 弹窗显示/隐藏辅助函数（供 delegate 调用）

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -554,7 +554,7 @@ Card {
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.top: emptyChipShape.bottom
                         anchors.topMargin: AppStyle.spacing.sm
-                        text: "无预览图"
+                        text: qsTr("无预览图")
                         font.pixelSize: AppStyle.fontSizes.sm
                         color: AppStyle.colors.textSecondary
                     }

--- a/src/ui/qml/components/ComponentListCard.qml
+++ b/src/ui/qml/components/ComponentListCard.qml
@@ -1057,7 +1057,7 @@ Card {
         GridView {
             id: componentList
             Layout.fillWidth: true
-            Layout.preferredHeight: ResponsiveHelper.responsive(240, 300, 360, 400)
+            Layout.preferredHeight: ResponsiveHelper.isShortWindow ? 200 : ResponsiveHelper.responsive(240, 300, 360, 400)
             Layout.topMargin: AppStyle.spacing.md
             clip: true
             // 启用虚拟化，缓存上下各一屏的项
@@ -1070,7 +1070,7 @@ Card {
                 var c = Math.max(1, Math.floor(w / minCellW));
                 return w / c;
             }
-            cellHeight: 76
+            cellHeight: ResponsiveHelper.isShortWindow ? 60 : 76
             flow: GridView.FlowLeftToRight
             layoutDirection: Qt.LeftToRight
             // 使用 DelegateModel

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -19,7 +19,7 @@ Rectangle {
     signal copyClicked
     signal retryClicked
     signal descriptionEditRequested(string componentId, string description)
-    height: 64 // 增加高度以容纳缩略图和更多信息
+    height: ResponsiveHelper.isShortWindow ? 52 : 64
     // 悬停效果
     color: itemMouseArea.containsMouse ? AppStyle.colors.background : AppStyle.colors.surface
     radius: AppStyle.radius.md

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -10,6 +10,11 @@ Rectangle {
     // 接收 ComponentListItemData 对象
     property var itemData
     property string searchText: ""
+    // 导出状态（由父级传入，来自 ExportProgressViewModel）
+    property var exportStatus: null
+    readonly property bool isExporting: exportStatus && (exportStatus.status === "in_progress" || exportStatus.status === "pending")
+    readonly property bool exportSuccess: exportStatus && exportStatus.status === "success"
+    readonly property bool exportFailed: exportStatus && exportStatus.status === "failed"
     signal deleteClicked
     signal copyClicked
     signal retryClicked
@@ -18,8 +23,77 @@ Rectangle {
     // 悬停效果
     color: itemMouseArea.containsMouse ? AppStyle.colors.background : AppStyle.colors.surface
     radius: AppStyle.radius.md
-    border.color: AppStyle.colors.border
-    border.width: AppStyle.borderWidths.thin
+    border.color: {
+        if (exportSuccess)
+            return AppStyle.colors.success;
+        if (exportFailed)
+            return AppStyle.colors.danger;
+        if (isExporting)
+            return AppStyle.colors.warning;
+        return AppStyle.colors.border;
+    }
+    border.width: exportStatus ? 2 : AppStyle.borderWidths.thin
+    Behavior on border.color {
+        ColorAnimation {
+            duration: AppStyle.durations.fast
+        }
+    }
+
+    // 底部导出状态指示条
+    Rectangle {
+        id: exportStatusBar
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: 1
+        height: 3
+        radius: 1
+        visible: exportStatus !== null
+        color: {
+            if (exportSuccess)
+                return AppStyle.colors.success;
+            if (exportFailed)
+                return AppStyle.colors.danger;
+            if (isExporting)
+                return AppStyle.colors.warning;
+            return AppStyle.colors.border;
+        }
+        clip: true
+        // 导出中：扫光（Shimmer）效果
+        Rectangle {
+            id: shimmerEffect
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: parent.width * 0.4
+            visible: isExporting
+            opacity: 0.6
+            gradient: Gradient {
+                orientation: Gradient.Horizontal
+                GradientStop {
+                    position: 0.0
+                    color: "transparent"
+                }
+                GradientStop {
+                    position: 0.5
+                    color: Qt.rgba(1, 1, 1, 0.8)
+                }
+                GradientStop {
+                    position: 1.0
+                    color: "transparent"
+                }
+            }
+            SequentialAnimation on x {
+                running: isExporting
+                loops: Animation.Infinite
+                NumberAnimation {
+                    from: -shimmerEffect.width
+                    to: exportStatusBar.width
+                    duration: 1200
+                    easing.type: Easing.InOutQuad
+                }
+            }
+        }
+    }
     // 缓存搜索正则以优化性能
     property string cachedSearchText: ""
     property var cachedRegex: null
@@ -411,6 +485,16 @@ Rectangle {
                 text: {
                     if (!itemData)
                         return "";
+                    // 导出状态优先显示
+                    if (exportStatus) {
+                        var s = exportStatus.status || "";
+                        if (s === "in_progress")
+                            return "正在导出...";
+                        if (s === "success")
+                            return "导出完成";
+                        if (s === "failed")
+                            return exportStatus.error || "导出失败";
+                    }
                     // 使用 validationPhase 显示精确状态
                     var phase = itemData.validationPhase || "idle";
                     if (phase === "validating")
@@ -425,7 +509,15 @@ Rectangle {
                     return "";
                 }
                 font.pixelSize: AppStyle.fontSizes.sm
-                color: (itemData && itemData.validationPhase === "failed") ? AppStyle.colors.danger : AppStyle.colors.textSecondary
+                color: {
+                    if (exportFailed)
+                        return AppStyle.colors.danger;
+                    if (exportSuccess)
+                        return AppStyle.colors.success;
+                    if (itemData && itemData.validationPhase === "failed")
+                        return AppStyle.colors.danger;
+                    return AppStyle.colors.textSecondary;
+                }
                 elide: Text.ElideRight
             }
         }

--- a/src/ui/qml/components/ComponentListItem.qml
+++ b/src/ui/qml/components/ComponentListItem.qml
@@ -489,20 +489,20 @@ Rectangle {
                     if (exportStatus) {
                         var s = exportStatus.status || "";
                         if (s === "in_progress")
-                            return "正在导出...";
+                            return qsTr("正在导出...");
                         if (s === "success")
-                            return "导出完成";
+                            return qsTr("导出完成");
                         if (s === "failed")
-                            return exportStatus.error || "导出失败";
+                            return exportStatus.error || qsTr("导出失败");
                     }
                     // 使用 validationPhase 显示精确状态
                     var phase = itemData.validationPhase || "idle";
                     if (phase === "validating")
-                        return "正在验证 CAD 数据...";
+                        return qsTr("正在验证 CAD 数据...");
                     if (phase === "fetching_preview")
-                        return "正在获取预览图...";
+                        return qsTr("正在获取预览图...");
                     if (phase === "failed")
-                        return itemData.errorMessage || "验证失败";
+                        return itemData.errorMessage || qsTr("验证失败");
                     if (phase === "completed" || itemData.isValid) {
                         return itemData.description || itemData.name || "";
                     }

--- a/src/ui/qml/components/ExportResultsCard.qml
+++ b/src/ui/qml/components/ExportResultsCard.qml
@@ -41,8 +41,9 @@ Loader {
             Rectangle {
                 id: filterSegmentedControl
                 objectName: "exportResultsFilterSegmentedControl"
-                Layout.preferredWidth: 560
+                Layout.fillWidth: true
                 Layout.preferredHeight: 40
+                Layout.maximumWidth: 560
                 Layout.alignment: Qt.AlignLeft
                 color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.05) : Qt.rgba(0, 0, 0, 0.05)
                 radius: AppStyle.radius.lg

--- a/src/ui/qml/components/ModernButton.qml
+++ b/src/ui/qml/components/ModernButton.qml
@@ -21,7 +21,6 @@ Button {
     font.bold: true
     implicitHeight: 44
     implicitWidth: contentItem.implicitWidth + AppStyle.spacing.xl * 2
-
     HoverHandler {
         id: pointerTracker
         acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad

--- a/src/ui/qml/components/SidebarPanel.qml
+++ b/src/ui/qml/components/SidebarPanel.qml
@@ -3,19 +3,22 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Effects
 import "../styles"
+import EasyKiconverter_Cpp_Version 1.0
 
 Rectangle {
     id: root
-    property var window: null // Reference to root window for dialogs
     color: "transparent"
-    // 安全代理属性（避免 root.window 为 null 时的 TypeError）
-    readonly property var progressController: root.window ? root.window.exportProgressController : null
-    readonly property var settingsController: root.window ? root.window.exportSettingsController : null
-    readonly property var listController: root.window ? root.window.componentListController : null
+    // 直接使用全局 Context Property（无需通过 window 中转）
+    readonly property var progressController: exportProgressViewModel
+    readonly property var settingsController: exportSettingsViewModel
+    readonly property var listController: componentListViewModel
     readonly property bool isExporting: progressController ? progressController.isExporting : false
     readonly property int progressValue: progressController ? progressController.progress : 0
     readonly property int failureCount: progressController ? progressController.failureCount : 0
     readonly property bool hasCompletedExport: progressController ? progressController.hasCompletedExport : false
+    // 信号：请求打开对话框（由 MainWindow 处理）
+    signal requestOutputFolderDialog
+    signal requestCacheFolderDialog
     // 玻璃态模糊背景（独立层，不模糊内容）
     Rectangle {
         id: glassBg
@@ -72,10 +75,8 @@ Rectangle {
                 SidebarSettingsView {
                     Layout.fillWidth: true
                     exportSettingsController: root.settingsController
-                    onOpenOutputFolderDialog: if (root.window)
-                        root.window.outputFolderDialog.open()
-                    onOpenCacheFolderDialog: if (root.window)
-                        root.window.cacheFolderDialog.open()
+                    onOpenOutputFolderDialog: root.requestOutputFolderDialog()
+                    onOpenCacheFolderDialog: root.requestCacheFolderDialog()
                     // 动感：横向进入
                     opacity: root.visible ? 1 : 0
                     x: root.visible ? 0 : -20
@@ -102,12 +103,12 @@ Rectangle {
                             Layout.fillWidth: true
                             StatItem {
                                 label: qsTranslate("MainWindow", "成功")
-                                value: root.progressController.successCount
+                                value: root.progressController ? root.progressController.successCount : 0
                                 color: AppStyle.colors.success
                             }
                             StatItem {
                                 label: qsTranslate("MainWindow", "失败")
-                                value: root.progressController.failureCount
+                                value: root.progressController ? root.progressController.failureCount : 0
                                 color: AppStyle.colors.danger
                             }
                         }
@@ -150,7 +151,7 @@ Rectangle {
                                 Layout.fillWidth: true
                             }
                             Text {
-                                text: root.progressController.progress + "%"
+                                text: root.progressValue + "%"
                                 font.pixelSize: AppStyle.fontSizes.xs
                                 font.bold: true
                                 color: AppStyle.colors.primary
@@ -162,7 +163,7 @@ Rectangle {
                             radius: 3
                             color: AppStyle.colors.border
                             Rectangle {
-                                width: parent.width * (root.progressController.progress / 100)
+                                width: parent.width * (root.progressValue / 100)
                                 height: parent.height
                                 radius: 3
                                 color: AppStyle.colors.primary
@@ -207,6 +208,15 @@ Rectangle {
                             if (!root.settingsController) return false;
                             return root.settingsController.exportSymbol || root.settingsController.exportFootprint || root.settingsController.exportModel3D;
                         }
+                        ToolTip.visible: hovered && !enabled
+                        ToolTip.text: {
+                            if (root.isExporting) return qsTranslate("MainWindow", "正在导出中...");
+                            if (!root.listController || root.listController.componentCount <= 0) return qsTranslate("MainWindow", "请先添加元器件");
+                            if (!root.settingsController) return "";
+                            if (!root.settingsController.exportSymbol && !root.settingsController.exportFootprint && !root.settingsController.exportModel3D) return qsTranslate("MainWindow", "请至少选择一种导出类型");
+                            return "";
+                        }
+                        ToolTip.delay: 600
                     }
 
                     ModernButton {
@@ -215,7 +225,10 @@ Rectangle {
                         Layout.preferredHeight: 44
                         iconName: "close"
                         backgroundColor: AppStyle.colors.danger
-                        onClicked: root.progressController.cancelExport()
+                        onClicked: {
+                            if (root.progressController)
+                                root.progressController.cancelExport();
+                        }
                     }
                 }
 
@@ -225,7 +238,10 @@ Rectangle {
                     visible: root.hasCompletedExport
                     text: qsTranslate("MainWindow", "查看文件夹")
                     backgroundColor: AppStyle.colors.textSecondary
-                    onClicked: root.progressController.openLastExportedFolder()
+                    onClicked: {
+                        if (root.progressController)
+                            root.progressController.openLastExportedFolder();
+                    }
                 }
             }
         }

--- a/src/ui/qml/components/SidebarPanel.qml
+++ b/src/ui/qml/components/SidebarPanel.qml
@@ -8,18 +8,19 @@ import EasyKiconverter_Cpp_Version 1.0
 Rectangle {
     id: root
     color: "transparent"
-    // 直接使用全局 Context Property（无需通过 window 中转）
+    // 折叠状态
+    property bool collapsed: false
+    signal toggleCollapsed
+    // 直接使用全局 Context Property
     readonly property var progressController: exportProgressViewModel
     readonly property var settingsController: exportSettingsViewModel
     readonly property var listController: componentListViewModel
     readonly property bool isExporting: progressController ? progressController.isExporting : false
-    readonly property int progressValue: progressController ? progressController.progress : 0
     readonly property int failureCount: progressController ? progressController.failureCount : 0
-    readonly property bool hasCompletedExport: progressController ? progressController.hasCompletedExport : false
-    // 信号：请求打开对话框（由 MainWindow 处理）
+    // 信号
     signal requestOutputFolderDialog
     signal requestCacheFolderDialog
-    // 玻璃态模糊背景（独立层，不模糊内容）
+    // 玻璃态模糊背景
     Rectangle {
         id: glassBg
         anchors.fill: parent
@@ -39,19 +40,119 @@ Rectangle {
         }
     }
 
-    // 侧边栏与工作区的分隔线
+    // 分隔线 + 折叠拨片（z: 100 确保在内容层之上）
     Rectangle {
+        id: separator
         anchors.right: parent.right
         width: 1
         height: parent.height
         color: AppStyle.colors.border
+        z: 100
+        // 折叠/展开拨片
+        Rectangle {
+            id: grabber
+            anchors.right: parent.right
+            anchors.rightMargin: -16
+            anchors.verticalCenter: parent.verticalCenter
+            width: 32
+            height: 52
+            radius: 4
+            color: grabberMouse.containsMouse ? AppStyle.colors.primary : (AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.08) : Qt.rgba(0, 0, 0, 0.06))
+            border.width: AppStyle.borderWidths.thin
+            border.color: AppStyle.colors.border
+            Behavior on color {
+                ColorAnimation {
+                    duration: AppStyle.durations.fast
+                }
+            }
+
+            Text {
+                anchors.centerIn: parent
+                text: root.collapsed ? "▶" : "◀"
+                font.pixelSize: 10
+                color: grabberMouse.containsMouse ? AppStyle.colors.textOnPrimary : AppStyle.colors.textSecondary
+                rotation: 0
+            }
+
+            MouseArea {
+                id: grabberMouse
+                anchors.fill: parent
+                anchors.topMargin: -20
+                anchors.bottomMargin: -20
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                preventStealing: true
+                onClicked: root.toggleCollapsed()
+                onDoubleClicked: root.toggleCollapsed()
+            }
+
+            ToolTip.visible: grabberMouse.containsMouse
+            ToolTip.text: root.collapsed ? qsTranslate("MainWindow", "展开侧边栏") : qsTranslate("MainWindow", "收缩侧边栏")
+            ToolTip.delay: 600
+        }
     }
 
+    // ==================== 收缩态：纯导航栏 ====================
     ColumnLayout {
+        id: collapsedColumn
+        anchors.fill: parent
+        anchors.margins: AppStyle.spacing.xs
+        spacing: AppStyle.spacing.sm
+        visible: root.collapsed
+        opacity: root.collapsed ? 1 : 0
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 150
+            }
+        }
+
+        // 设置图标（点击展开）
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 36
+            Layout.margins: 4
+            radius: AppStyle.radius.sm
+            color: settingsIconMouse.containsMouse ? (AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.1) : Qt.rgba(0, 0, 0, 0.06)) : "transparent"
+            Text {
+                anchors.centerIn: parent
+                text: "⚙"
+                font.pixelSize: 18
+                color: AppStyle.colors.textSecondary
+            }
+
+            MouseArea {
+                id: settingsIconMouse
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.toggleCollapsed()
+            }
+
+            ToolTip.visible: settingsIconMouse.containsMouse
+            ToolTip.text: qsTranslate("MainWindow", "导出设置")
+            ToolTip.delay: 400
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+
+    // ==================== 展开态：完整面板 ====================
+    ColumnLayout {
+        id: expandedColumn
         anchors.fill: parent
         anchors.margins: 0
         spacing: 0
-        // ==================== 可滚动区域 ====================
+        visible: !root.collapsed
+        opacity: root.collapsed ? 0 : 1
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 200
+            }
+        }
+
+        // 可滚动区域
         Flickable {
             id: scrollArea
             Layout.fillWidth: true
@@ -77,106 +178,41 @@ Rectangle {
                     exportSettingsController: root.settingsController
                     onOpenOutputFolderDialog: root.requestOutputFolderDialog()
                     onOpenCacheFolderDialog: root.requestCacheFolderDialog()
-                    // 动感：横向进入
-                    opacity: root.visible ? 1 : 0
-                    x: root.visible ? 0 : -20
+                    opacity: root.collapsed ? 0 : 1
+                    x: root.collapsed ? -20 : 0
                     Behavior on opacity {
                         NumberAnimation {
-                            duration: 400
+                            duration: 250
                         }
                     }
                     Behavior on x {
                         NumberAnimation {
-                            duration: 400
-                            easing.type: Easing.OutCubic
-                        }
-                    }
-                }
-
-                // 统计信息卡片 (侧边栏简化版)
-                Loader {
-                    Layout.fillWidth: true
-                    active: root.hasCompletedExport
-                    sourceComponent: SidebarSection {
-                        title: qsTranslate("MainWindow", "执行统计")
-                        RowLayout {
-                            Layout.fillWidth: true
-                            StatItem {
-                                label: qsTranslate("MainWindow", "成功")
-                                value: root.progressController ? root.progressController.successCount : 0
-                                color: AppStyle.colors.success
-                            }
-                            StatItem {
-                                label: qsTranslate("MainWindow", "失败")
-                                value: root.progressController ? root.progressController.failureCount : 0
-                                color: AppStyle.colors.danger
-                            }
+                            duration: 250
+                            easing.type: Easing.OutQuart
                         }
                     }
                 }
             }
         }
 
-        // ==================== 固定底部的控制面板 ====================
+        // 分隔线
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+            color: AppStyle.colors.border
+        }
+
+        // 固定底部控制面板
         Rectangle {
             id: controlPanel
             Layout.fillWidth: true
             implicitHeight: controlColumn.implicitHeight + AppStyle.spacing.lg * 2
             color: AppStyle.isDarkMode ? Qt.rgba(30 / 255, 41 / 255, 59 / 255, 0.5) : Qt.rgba(241 / 255, 245 / 255, 249 / 255, 0.5)
-            Rectangle {
-                anchors.top: parent.top
-                width: parent.width
-                height: 1
-                color: AppStyle.colors.border
-            }
-
             ColumnLayout {
                 id: controlColumn
                 anchors.fill: parent
                 anchors.margins: AppStyle.spacing.lg
                 spacing: AppStyle.spacing.md
-                // 进度条
-                Loader {
-                    Layout.fillWidth: true
-                    active: root.isExporting || root.progressValue > 0
-                    sourceComponent: ColumnLayout {
-                        spacing: 4
-                        RowLayout {
-                            Text {
-                                text: root.isExporting ? qsTranslate("MainWindow", "导出中...") : qsTranslate("MainWindow", "导出完成")
-                                font.pixelSize: AppStyle.fontSizes.xs
-                                color: AppStyle.colors.textSecondary
-                            }
-                            Item {
-                                Layout.fillWidth: true
-                            }
-                            Text {
-                                text: root.progressValue + "%"
-                                font.pixelSize: AppStyle.fontSizes.xs
-                                font.bold: true
-                                color: AppStyle.colors.primary
-                            }
-                        }
-                        Rectangle {
-                            Layout.fillWidth: true
-                            height: 6
-                            radius: 3
-                            color: AppStyle.colors.border
-                            Rectangle {
-                                width: parent.width * (root.progressValue / 100)
-                                height: parent.height
-                                radius: 3
-                                color: AppStyle.colors.primary
-                                Behavior on width {
-                                    NumberAnimation {
-                                        duration: 150
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
                 // 按钮组
                 RowLayout {
                     Layout.fillWidth: true
@@ -203,17 +239,24 @@ Rectangle {
                             }
                         }
                         enabled: {
-                            if (root.isExporting) return false;
-                            if (!root.listController || root.listController.componentCount <= 0) return false;
-                            if (!root.settingsController) return false;
+                            if (root.isExporting)
+                                return false;
+                            if (!root.listController || root.listController.componentCount <= 0)
+                                return false;
+                            if (!root.settingsController)
+                                return false;
                             return root.settingsController.exportSymbol || root.settingsController.exportFootprint || root.settingsController.exportModel3D;
                         }
                         ToolTip.visible: hovered && !enabled
                         ToolTip.text: {
-                            if (root.isExporting) return qsTranslate("MainWindow", "正在导出中...");
-                            if (!root.listController || root.listController.componentCount <= 0) return qsTranslate("MainWindow", "请先添加元器件");
-                            if (!root.settingsController) return "";
-                            if (!root.settingsController.exportSymbol && !root.settingsController.exportFootprint && !root.settingsController.exportModel3D) return qsTranslate("MainWindow", "请至少选择一种导出类型");
+                            if (root.isExporting)
+                                return qsTranslate("MainWindow", "正在导出中...");
+                            if (!root.listController || root.listController.componentCount <= 0)
+                                return qsTranslate("MainWindow", "请先添加元器件");
+                            if (!root.settingsController)
+                                return "";
+                            if (!root.settingsController.exportSymbol && !root.settingsController.exportFootprint && !root.settingsController.exportModel3D)
+                                return qsTranslate("MainWindow", "请至少选择一种导出类型");
                             return "";
                         }
                         ToolTip.delay: 600
@@ -231,40 +274,7 @@ Rectangle {
                         }
                     }
                 }
-
-                ModernButton {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 36
-                    visible: root.hasCompletedExport
-                    text: qsTranslate("MainWindow", "查看文件夹")
-                    backgroundColor: AppStyle.colors.textSecondary
-                    onClicked: {
-                        if (root.progressController)
-                            root.progressController.openLastExportedFolder();
-                    }
-                }
             }
-        }
-    }
-
-    // ==================== 辅助组件 ====================
-    component StatItem: ColumnLayout {
-        property string label: ""
-        property var value: 0
-        property color color: AppStyle.colors.textPrimary
-        spacing: 2
-        Text {
-            text: label
-            font.pixelSize: AppStyle.fontSizes.xs
-            color: AppStyle.colors.textSecondary
-            Layout.alignment: Qt.AlignHCenter
-        }
-        Text {
-            text: value.toString()
-            font.pixelSize: AppStyle.fontSizes.lg
-            font.bold: true
-            color: parent.color
-            Layout.alignment: Qt.AlignHCenter
         }
     }
 }

--- a/src/ui/qml/components/SidebarPanel.qml
+++ b/src/ui/qml/components/SidebarPanel.qml
@@ -1,0 +1,242 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Effects
+import "../styles"
+
+Rectangle {
+    id: root
+    property var window: null // Reference to root window for dialogs
+    color: "transparent"
+    // 玻璃态模糊背景（独立层，不模糊内容）
+    Rectangle {
+        id: glassBg
+        anchors.fill: parent
+        color: AppStyle.isDarkMode ? Qt.rgba(15 / 255, 23 / 255, 42 / 255, 0.55) : Qt.rgba(255, 255, 255, 0.55)
+        z: -1
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            blurEnabled: true
+            blur: 0.6
+            blurMax: 32
+        }
+
+        Behavior on color {
+            ColorAnimation {
+                duration: AppStyle.durations.themeSwitch
+            }
+        }
+    }
+
+    // 侧边栏与工作区的分隔线
+    Rectangle {
+        anchors.right: parent.right
+        width: 1
+        height: parent.height
+        color: AppStyle.colors.border
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 0
+        spacing: 0
+        // ==================== 可滚动区域 ====================
+        Flickable {
+            id: scrollArea
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            contentWidth: width
+            contentHeight: contentColumn.implicitHeight
+            boundsBehavior: Flickable.StopAtBounds
+            ScrollBar.vertical: ScrollBar {
+                policy: ScrollBar.AsNeeded
+            }
+
+            ColumnLayout {
+                id: contentColumn
+                width: parent.width - AppStyle.spacing.lg * 2
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: parent.top
+                anchors.topMargin: AppStyle.spacing.lg
+                spacing: AppStyle.spacing.xl
+                // 侧边栏导出设置
+                SidebarSettingsView {
+                    Layout.fillWidth: true
+                    exportSettingsController: root.window ? root.window.exportSettingsController : null
+                    onOpenOutputFolderDialog: if (root.window)
+                        root.window.outputFolderDialog.open()
+                    onOpenCacheFolderDialog: if (root.window)
+                        root.window.cacheFolderDialog.open()
+                    // 动感：横向进入
+                    opacity: root.visible ? 1 : 0
+                    x: root.visible ? 0 : -20
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: 400
+                        }
+                    }
+                    Behavior on x {
+                        NumberAnimation {
+                            duration: 400
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+                }
+
+                // 统计信息卡片 (侧边栏简化版)
+                Loader {
+                    Layout.fillWidth: true
+                    active: root.window && root.window.exportProgressController && root.window.exportProgressController.hasCompletedExport
+                    sourceComponent: SidebarSection {
+                        title: qsTranslate("MainWindow", "执行统计")
+                        RowLayout {
+                            Layout.fillWidth: true
+                            StatItem {
+                                label: qsTranslate("MainWindow", "成功")
+                                value: root.window.exportProgressController.successCount
+                                color: AppStyle.colors.success
+                            }
+                            StatItem {
+                                label: qsTranslate("MainWindow", "失败")
+                                value: root.window.exportProgressController.failureCount
+                                color: AppStyle.colors.danger
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // ==================== 固定底部的控制面板 ====================
+        Rectangle {
+            id: controlPanel
+            Layout.fillWidth: true
+            implicitHeight: controlColumn.implicitHeight + AppStyle.spacing.lg * 2
+            color: AppStyle.isDarkMode ? Qt.rgba(30 / 255, 41 / 255, 59 / 255, 0.5) : Qt.rgba(241 / 255, 245 / 255, 249 / 255, 0.5)
+            Rectangle {
+                anchors.top: parent.top
+                width: parent.width
+                height: 1
+                color: AppStyle.colors.border
+            }
+
+            ColumnLayout {
+                id: controlColumn
+                anchors.fill: parent
+                anchors.margins: AppStyle.spacing.lg
+                spacing: AppStyle.spacing.md
+                // 进度条
+                Loader {
+                    Layout.fillWidth: true
+                    active: root.window && root.window.exportProgressController && (root.window.exportProgressController.isExporting || root.window.exportProgressController.progress > 0)
+                    sourceComponent: ColumnLayout {
+                        spacing: 4
+                        RowLayout {
+                            Text {
+                                text: root.window.exportProgressController.isExporting ? qsTranslate("MainWindow", "导出中...") : qsTranslate("MainWindow", "导出完成")
+                                font.pixelSize: AppStyle.fontSizes.xs
+                                color: AppStyle.colors.textSecondary
+                            }
+                            Item {
+                                Layout.fillWidth: true
+                            }
+                            Text {
+                                text: root.window.exportProgressController.progress + "%"
+                                font.pixelSize: AppStyle.fontSizes.xs
+                                font.bold: true
+                                color: AppStyle.colors.primary
+                            }
+                        }
+                        Rectangle {
+                            Layout.fillWidth: true
+                            height: 6
+                            radius: 3
+                            color: AppStyle.colors.border
+                            Rectangle {
+                                width: parent.width * (root.window.exportProgressController.progress / 100)
+                                height: parent.height
+                                radius: 3
+                                color: AppStyle.colors.primary
+                                Behavior on width {
+                                    NumberAnimation {
+                                        duration: 150
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // 按钮组
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: AppStyle.spacing.md
+                    ModernButton {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 44
+                        text: {
+                            var pc = root.window.exportProgressController;
+                            if (pc && pc.isExporting)
+                                return qsTranslate("MainWindow", "导出中");
+                            if (pc && pc.failureCount > 0)
+                                return qsTranslate("MainWindow", "重试失败");
+                            return qsTranslate("MainWindow", "开始导出");
+                        }
+                        backgroundColor: (root.window.exportProgressController && root.window.exportProgressController.failureCount > 0) ? AppStyle.colors.warning : AppStyle.colors.primary
+                        onClicked: {
+                            var pc = root.window.exportProgressController;
+                            var sc = root.window.exportSettingsController;
+                            var lc = root.window.componentListController;
+                            if (pc && pc.failureCount > 0) {
+                                pc.retryFailedComponents();
+                            } else if (pc && sc && lc) {
+                                pc.startExport(lc.getAllComponentIds(), sc.outputPath, sc.libName, sc.exportSymbol, sc.exportFootprint, sc.exportModel3D, sc.exportModel3DFormat, sc.exportModel3DPathMode, sc.exportPreviewImages, sc.exportDatasheet, sc.overwriteExistingFiles, sc.exportMode === 1, sc.debugMode);
+                            }
+                        }
+                        enabled: root.window && root.window.exportProgressController && !root.window.exportProgressController.isExporting && root.window.componentListController.componentCount > 0
+                    }
+
+                    ModernButton {
+                        visible: root.window && root.window.exportProgressController && root.window.exportProgressController.isExporting
+                        Layout.preferredWidth: 80
+                        Layout.preferredHeight: 44
+                        iconName: "close"
+                        backgroundColor: AppStyle.colors.danger
+                        onClicked: root.window.exportProgressController.cancelExport()
+                    }
+                }
+
+                ModernButton {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+                    visible: root.window && root.window.exportProgressController && root.window.exportProgressController.hasCompletedExport
+                    text: qsTranslate("MainWindow", "查看文件夹")
+                    backgroundColor: AppStyle.colors.textSecondary
+                    onClicked: root.window.exportProgressController.openLastExportedFolder()
+                }
+            }
+        }
+    }
+
+    // ==================== 辅助组件 ====================
+    component StatItem: ColumnLayout {
+        property string label: ""
+        property var value: 0
+        property color color: AppStyle.colors.textPrimary
+        spacing: 2
+        Text {
+            text: label
+            font.pixelSize: AppStyle.fontSizes.xs
+            color: AppStyle.colors.textSecondary
+            Layout.alignment: Qt.AlignHCenter
+        }
+        Text {
+            text: value.toString()
+            font.pixelSize: AppStyle.fontSizes.lg
+            font.bold: true
+            color: parent.color
+            Layout.alignment: Qt.AlignHCenter
+        }
+    }
+}

--- a/src/ui/qml/components/SidebarPanel.qml
+++ b/src/ui/qml/components/SidebarPanel.qml
@@ -41,56 +41,13 @@ Rectangle {
         }
     }
 
-    // 分隔线 + 折叠拨片（z: 100 确保在内容层之上）
+    // 分隔线（纯视觉，无交互）
     Rectangle {
-        id: separator
         anchors.right: parent.right
         width: 1
         height: parent.height
         color: AppStyle.colors.border
         z: 100
-        // 折叠/展开拨片
-        Rectangle {
-            id: grabber
-            anchors.right: parent.right
-            anchors.rightMargin: -16
-            anchors.verticalCenter: parent.verticalCenter
-            width: 32
-            height: 52
-            radius: 4
-            color: grabberMouse.containsMouse ? AppStyle.colors.primary : (AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.08) : Qt.rgba(0, 0, 0, 0.06))
-            border.width: AppStyle.borderWidths.thin
-            border.color: AppStyle.colors.border
-            Behavior on color {
-                ColorAnimation {
-                    duration: AppStyle.durations.fast
-                }
-            }
-
-            Text {
-                anchors.centerIn: parent
-                text: root.collapsed ? "▶" : "◀"
-                font.pixelSize: 10
-                color: grabberMouse.containsMouse ? AppStyle.colors.textOnPrimary : AppStyle.colors.textSecondary
-                rotation: 0
-            }
-
-            MouseArea {
-                id: grabberMouse
-                anchors.fill: parent
-                anchors.topMargin: -20
-                anchors.bottomMargin: -20
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                preventStealing: true
-                onClicked: root.toggleCollapsed()
-                onDoubleClicked: root.toggleCollapsed()
-            }
-
-            ToolTip.visible: grabberMouse.containsMouse
-            ToolTip.text: root.collapsed ? qsTranslate("MainWindow", "展开侧边栏") : qsTranslate("MainWindow", "收缩侧边栏")
-            ToolTip.delay: 600
-        }
     }
 
     // ==================== 收缩态：纯导航栏 ====================
@@ -130,7 +87,7 @@ Rectangle {
             }
 
             ToolTip.visible: settingsIconMouse.containsMouse
-            ToolTip.text: qsTranslate("MainWindow", "导出设置")
+            ToolTip.text: qsTranslate("MainWindow", "展开设置")
             ToolTip.delay: 400
         }
 
@@ -150,6 +107,60 @@ Rectangle {
         Behavior on opacity {
             NumberAnimation {
                 duration: 200
+            }
+        }
+
+        // 顶部标题栏（标题 + 收起按钮）
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 40
+            color: "transparent"
+            RowLayout {
+                anchors.fill: parent
+                anchors.leftMargin: AppStyle.spacing.md
+                anchors.rightMargin: AppStyle.spacing.xs
+                spacing: AppStyle.spacing.sm
+                Text {
+                    text: qsTranslate("MainWindow", "导出设置")
+                    font.pixelSize: AppStyle.fontSizes.sm
+                    font.bold: true
+                    color: AppStyle.colors.textSecondary
+                    Layout.fillWidth: true
+                }
+
+                // 收起按钮
+                Rectangle {
+                    Layout.preferredWidth: 28
+                    Layout.preferredHeight: 28
+                    radius: AppStyle.radius.sm
+                    color: collapseBtnMouse.containsMouse ? (AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.1) : Qt.rgba(0, 0, 0, 0.06)) : "transparent"
+                    Text {
+                        anchors.centerIn: parent
+                        text: "«"
+                        font.pixelSize: 14
+                        font.bold: true
+                        color: collapseBtnMouse.containsMouse ? AppStyle.colors.textPrimary : AppStyle.colors.textSecondary
+                    }
+
+                    MouseArea {
+                        id: collapseBtnMouse
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.toggleCollapsed()
+                    }
+
+                    ToolTip.visible: collapseBtnMouse.hovered
+                    ToolTip.text: qsTranslate("MainWindow", "收起设置")
+                    ToolTip.delay: 400
+                }
+            }
+            // 底部分隔线
+            Rectangle {
+                anchors.bottom: parent.bottom
+                width: parent.width
+                height: 1
+                color: AppStyle.colors.border
             }
         }
 

--- a/src/ui/qml/components/SidebarPanel.qml
+++ b/src/ui/qml/components/SidebarPanel.qml
@@ -17,6 +17,7 @@ Rectangle {
     readonly property var listController: componentListViewModel
     readonly property bool isExporting: progressController ? progressController.isExporting : false
     readonly property int failureCount: progressController ? progressController.failureCount : 0
+    readonly property bool hasCompletedExport: progressController ? progressController.hasCompletedExport : false
     // 信号
     signal requestOutputFolderDialog
     signal requestCacheFolderDialog
@@ -272,6 +273,20 @@ Rectangle {
                             if (root.progressController)
                                 root.progressController.cancelExport();
                         }
+                    }
+                }
+
+                // 打开导出目录（导出完成后显示）
+                ModernButton {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+                    visible: root.hasCompletedExport
+                    text: qsTranslate("MainWindow", "打开导出目录")
+                    iconName: "folder"
+                    backgroundColor: AppStyle.colors.textSecondary
+                    onClicked: {
+                        if (root.progressController)
+                            root.progressController.openLastExportedFolder();
                     }
                 }
             }

--- a/src/ui/qml/components/SidebarPanel.qml
+++ b/src/ui/qml/components/SidebarPanel.qml
@@ -8,6 +8,14 @@ Rectangle {
     id: root
     property var window: null // Reference to root window for dialogs
     color: "transparent"
+    // 安全代理属性（避免 root.window 为 null 时的 TypeError）
+    readonly property var progressController: root.window ? root.window.exportProgressController : null
+    readonly property var settingsController: root.window ? root.window.exportSettingsController : null
+    readonly property var listController: root.window ? root.window.componentListController : null
+    readonly property bool isExporting: progressController ? progressController.isExporting : false
+    readonly property int progressValue: progressController ? progressController.progress : 0
+    readonly property int failureCount: progressController ? progressController.failureCount : 0
+    readonly property bool hasCompletedExport: progressController ? progressController.hasCompletedExport : false
     // 玻璃态模糊背景（独立层，不模糊内容）
     Rectangle {
         id: glassBg
@@ -63,7 +71,7 @@ Rectangle {
                 // 侧边栏导出设置
                 SidebarSettingsView {
                     Layout.fillWidth: true
-                    exportSettingsController: root.window ? root.window.exportSettingsController : null
+                    exportSettingsController: root.settingsController
                     onOpenOutputFolderDialog: if (root.window)
                         root.window.outputFolderDialog.open()
                     onOpenCacheFolderDialog: if (root.window)
@@ -87,19 +95,19 @@ Rectangle {
                 // 统计信息卡片 (侧边栏简化版)
                 Loader {
                     Layout.fillWidth: true
-                    active: root.window && root.window.exportProgressController && root.window.exportProgressController.hasCompletedExport
+                    active: root.hasCompletedExport
                     sourceComponent: SidebarSection {
                         title: qsTranslate("MainWindow", "执行统计")
                         RowLayout {
                             Layout.fillWidth: true
                             StatItem {
                                 label: qsTranslate("MainWindow", "成功")
-                                value: root.window.exportProgressController.successCount
+                                value: root.progressController.successCount
                                 color: AppStyle.colors.success
                             }
                             StatItem {
                                 label: qsTranslate("MainWindow", "失败")
-                                value: root.window.exportProgressController.failureCount
+                                value: root.progressController.failureCount
                                 color: AppStyle.colors.danger
                             }
                         }
@@ -129,12 +137,12 @@ Rectangle {
                 // 进度条
                 Loader {
                     Layout.fillWidth: true
-                    active: root.window && root.window.exportProgressController && (root.window.exportProgressController.isExporting || root.window.exportProgressController.progress > 0)
+                    active: root.isExporting || root.progressValue > 0
                     sourceComponent: ColumnLayout {
                         spacing: 4
                         RowLayout {
                             Text {
-                                text: root.window.exportProgressController.isExporting ? qsTranslate("MainWindow", "导出中...") : qsTranslate("MainWindow", "导出完成")
+                                text: root.isExporting ? qsTranslate("MainWindow", "导出中...") : qsTranslate("MainWindow", "导出完成")
                                 font.pixelSize: AppStyle.fontSizes.xs
                                 color: AppStyle.colors.textSecondary
                             }
@@ -142,7 +150,7 @@ Rectangle {
                                 Layout.fillWidth: true
                             }
                             Text {
-                                text: root.window.exportProgressController.progress + "%"
+                                text: root.progressController.progress + "%"
                                 font.pixelSize: AppStyle.fontSizes.xs
                                 font.bold: true
                                 color: AppStyle.colors.primary
@@ -154,7 +162,7 @@ Rectangle {
                             radius: 3
                             color: AppStyle.colors.border
                             Rectangle {
-                                width: parent.width * (root.window.exportProgressController.progress / 100)
+                                width: parent.width * (root.progressController.progress / 100)
                                 height: parent.height
                                 radius: 3
                                 color: AppStyle.colors.primary
@@ -176,44 +184,48 @@ Rectangle {
                         Layout.fillWidth: true
                         Layout.preferredHeight: 44
                         text: {
-                            var pc = root.window.exportProgressController;
-                            if (pc && pc.isExporting)
+                            if (root.isExporting)
                                 return qsTranslate("MainWindow", "导出中");
-                            if (pc && pc.failureCount > 0)
+                            if (root.failureCount > 0)
                                 return qsTranslate("MainWindow", "重试失败");
                             return qsTranslate("MainWindow", "开始导出");
                         }
-                        backgroundColor: (root.window.exportProgressController && root.window.exportProgressController.failureCount > 0) ? AppStyle.colors.warning : AppStyle.colors.primary
+                        backgroundColor: root.failureCount > 0 ? AppStyle.colors.warning : AppStyle.colors.primary
                         onClicked: {
-                            var pc = root.window.exportProgressController;
-                            var sc = root.window.exportSettingsController;
-                            var lc = root.window.componentListController;
+                            var pc = root.progressController;
+                            var sc = root.settingsController;
+                            var lc = root.listController;
                             if (pc && pc.failureCount > 0) {
                                 pc.retryFailedComponents();
                             } else if (pc && sc && lc) {
-                                pc.startExport(lc.getAllComponentIds(), sc.outputPath, sc.libName, sc.exportSymbol, sc.exportFootprint, sc.exportModel3D, sc.exportModel3DFormat, sc.exportModel3DPathMode, sc.exportPreviewImages, sc.exportDatasheet, sc.overwriteExistingFiles, sc.exportMode === 1, sc.debugMode);
+                                pc.startExport(lc.getAllComponentIds(), sc.outputPath || "", sc.libName || "", sc.exportSymbol || false, sc.exportFootprint || false, sc.exportModel3D || false, sc.exportModel3DFormat || 3, sc.exportModel3DPathMode || 0, sc.exportPreviewImages || false, sc.exportDatasheet || false, sc.overwriteExistingFiles || false, (sc.exportMode || 0) === 1, sc.debugMode || false, sc.symbolLibraryDescription || "", sc.footprintLibraryDescription || "", sc.footprintLibraryKeywords || "");
                             }
                         }
-                        enabled: root.window && root.window.exportProgressController && !root.window.exportProgressController.isExporting && root.window.componentListController.componentCount > 0
+                        enabled: {
+                            if (root.isExporting) return false;
+                            if (!root.listController || root.listController.componentCount <= 0) return false;
+                            if (!root.settingsController) return false;
+                            return root.settingsController.exportSymbol || root.settingsController.exportFootprint || root.settingsController.exportModel3D;
+                        }
                     }
 
                     ModernButton {
-                        visible: root.window && root.window.exportProgressController && root.window.exportProgressController.isExporting
+                        visible: root.isExporting
                         Layout.preferredWidth: 80
                         Layout.preferredHeight: 44
                         iconName: "close"
                         backgroundColor: AppStyle.colors.danger
-                        onClicked: root.window.exportProgressController.cancelExport()
+                        onClicked: root.progressController.cancelExport()
                     }
                 }
 
                 ModernButton {
                     Layout.fillWidth: true
                     Layout.preferredHeight: 36
-                    visible: root.window && root.window.exportProgressController && root.window.exportProgressController.hasCompletedExport
+                    visible: root.hasCompletedExport
                     text: qsTranslate("MainWindow", "查看文件夹")
                     backgroundColor: AppStyle.colors.textSecondary
-                    onClicked: root.window.exportProgressController.openLastExportedFolder()
+                    onClicked: root.progressController.openLastExportedFolder()
                 }
             }
         }

--- a/src/ui/qml/components/SidebarSection.qml
+++ b/src/ui/qml/components/SidebarSection.qml
@@ -1,0 +1,24 @@
+import QtQuick
+import QtQuick.Layouts
+import "../styles"
+
+ColumnLayout {
+    property string title: ""
+    Layout.fillWidth: true
+    spacing: AppStyle.spacing.sm
+    Text {
+        text: title
+        font.pixelSize: AppStyle.fontSizes.xs
+        font.bold: true
+        color: AppStyle.colors.primary
+        opacity: 0.8
+        Layout.leftMargin: AppStyle.spacing.xs
+    }
+
+    Rectangle {
+        Layout.fillWidth: true
+        height: 1
+        color: AppStyle.colors.border
+        opacity: 0.3
+    }
+}

--- a/src/ui/qml/components/SidebarSegmentedControl.qml
+++ b/src/ui/qml/components/SidebarSegmentedControl.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import "../styles"
 
 ColumnLayout {
+    id: segRoot
     property string label: ""
     property var model: []
     property int currentIndex: 0
@@ -10,8 +11,8 @@ ColumnLayout {
     Layout.fillWidth: true
     spacing: 2
     Text {
-        visible: label !== ""
-        text: label
+        visible: segRoot.label !== ""
+        text: segRoot.label
         font.pixelSize: AppStyle.fontSizes.xs
         color: AppStyle.colors.textSecondary
     }
@@ -23,25 +24,27 @@ ColumnLayout {
         opacity: 0.5
         radius: AppStyle.radius.sm
         Row {
+            id: segRow
             anchors.fill: parent
             anchors.margins: 2
             Repeater {
-                model: parent.parent.model
+                id: segRepeater
+                model: segRoot.model
                 Rectangle {
-                    width: parent.width / parent.parent.model.length
-                    height: parent.height
+                    width: segRow.width / segRepeater.model.length
+                    height: segRow.height
                     radius: AppStyle.radius.xs - 1
-                    color: index === parent.parent.parent.currentIndex ? AppStyle.colors.surface : "transparent"
+                    color: index === segRoot.currentIndex ? AppStyle.colors.surface : "transparent"
                     Text {
                         anchors.centerIn: parent
                         text: modelData
                         font.pixelSize: AppStyle.fontSizes.xs
-                        color: index === parent.parent.parent.parent.currentIndex ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                        color: index === segRoot.currentIndex ? AppStyle.colors.primary : AppStyle.colors.textSecondary
                     }
 
                     MouseArea {
                         anchors.fill: parent
-                        onClicked: parent.parent.parent.parent.indexChanged(index)
+                        onClicked: segRoot.indexChanged(index)
                     }
                 }
             }

--- a/src/ui/qml/components/SidebarSegmentedControl.qml
+++ b/src/ui/qml/components/SidebarSegmentedControl.qml
@@ -1,0 +1,50 @@
+import QtQuick
+import QtQuick.Layouts
+import "../styles"
+
+ColumnLayout {
+    property string label: ""
+    property var model: []
+    property int currentIndex: 0
+    signal indexChanged(int index)
+    Layout.fillWidth: true
+    spacing: 2
+    Text {
+        visible: label !== ""
+        text: label
+        font.pixelSize: AppStyle.fontSizes.xs
+        color: AppStyle.colors.textSecondary
+    }
+
+    Rectangle {
+        Layout.fillWidth: true
+        height: 30
+        color: AppStyle.colors.border
+        opacity: 0.5
+        radius: AppStyle.radius.sm
+        Row {
+            anchors.fill: parent
+            anchors.margins: 2
+            Repeater {
+                model: parent.parent.model
+                Rectangle {
+                    width: parent.width / parent.parent.model.length
+                    height: parent.height
+                    radius: AppStyle.radius.xs - 1
+                    color: index === parent.parent.parent.currentIndex ? AppStyle.colors.surface : "transparent"
+                    Text {
+                        anchors.centerIn: parent
+                        text: modelData
+                        font.pixelSize: AppStyle.fontSizes.xs
+                        color: index === parent.parent.parent.parent.currentIndex ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: parent.parent.parent.parent.indexChanged(index)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/qml/components/SidebarSettingsView.qml
+++ b/src/ui/qml/components/SidebarSettingsView.qml
@@ -1,0 +1,215 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import EasyKiconverter_Cpp_Version.src.ui.qml.styles 1.0
+
+Item {
+    id: root
+    property var exportSettingsController
+    signal openOutputFolderDialog
+    signal openCacheFolderDialog
+    implicitHeight: mainColumn.implicitHeight
+    ColumnLayout {
+        id: mainColumn
+        width: parent.width
+        spacing: AppStyle.spacing.lg
+        // ==================== 导出路径与库名 ====================
+        SidebarSection {
+            title: qsTranslate("MainWindow", "输出配置")
+            SidebarTextField {
+                label: qsTranslate("MainWindow", "输出路径")
+                text: root.exportSettingsController ? root.exportSettingsController.outputPath : ""
+                placeholder: qsTranslate("MainWindow", "选择目录...")
+                onTextEdited: if (root.exportSettingsController)
+                    root.exportSettingsController.setOutputPath(text)
+                browseIcon: "folder"
+                onBrowseClicked: root.openOutputFolderDialog()
+            }
+
+            SidebarTextField {
+                label: qsTranslate("MainWindow", "库名称")
+                text: root.exportSettingsController ? root.exportSettingsController.libName : ""
+                placeholder: "EasyEDA_Lib"
+                onTextEdited: if (root.exportSettingsController)
+                    root.exportSettingsController.setLibName(text)
+            }
+
+            SidebarTextField {
+                label: qsTranslate("MainWindow", "缓存目录")
+                text: root.exportSettingsController ? root.exportSettingsController.cacheDir : ""
+                placeholder: qsTranslate("MainWindow", "选择目录...")
+                onTextEdited: if (root.exportSettingsController)
+                    root.exportSettingsController.setCacheDir(text)
+                browseIcon: "folder"
+                onBrowseClicked: root.openCacheFolderDialog()
+            }
+        }
+
+        // ==================== 导出选项 (带横向收缩动画) ====================
+        SidebarSection {
+            title: qsTranslate("MainWindow", "导出内容")
+            SidebarToggleRow {
+                label: qsTranslate("MainWindow", "符号库")
+                checked: root.exportSettingsController ? root.exportSettingsController.exportSymbol : false
+                onToggled: if (root.exportSettingsController)
+                    root.exportSettingsController.setExportSymbol(checked)
+            }
+
+            SidebarToggleRow {
+                label: qsTranslate("MainWindow", "封装库")
+                checked: root.exportSettingsController ? root.exportSettingsController.exportFootprint : false
+                onToggled: if (root.exportSettingsController)
+                    root.exportSettingsController.setExportFootprint(checked)
+            }
+
+            // 3D 模型 - 带有横向收缩的子选项
+            Column {
+                width: parent.width
+                SidebarToggleRow {
+                    id: model3dToggle
+                    label: qsTranslate("MainWindow", "3D 模型")
+                    checked: root.exportSettingsController ? root.exportSettingsController.exportModel3D : false
+                    onToggled: if (root.exportSettingsController)
+                        root.exportSettingsController.setExportModel3D(checked)
+                }
+
+                // 子选项：横向收缩显示
+                Item {
+                    width: parent.width
+                    height: model3dToggle.checked ? subOptionsColumn.implicitHeight + AppStyle.spacing.sm : 0
+                    clip: true
+                    Behavior on height {
+                        NumberAnimation {
+                            duration: AppStyle.durations.fast
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+
+                    ColumnLayout {
+                        id: subOptionsColumn
+                        width: parent.width
+                        anchors.top: parent.top
+                        anchors.topMargin: AppStyle.spacing.xs
+                        opacity: model3dToggle.checked ? 1 : 0
+                        x: model3dToggle.checked ? 0 : 20 // 横向偏移动画
+                        Behavior on opacity {
+                            NumberAnimation {
+                                duration: AppStyle.durations.fast
+                            }
+                        }
+                        Behavior on x {
+                            NumberAnimation {
+                                duration: AppStyle.durations.fast
+                                easing.type: Easing.OutBack
+                            }
+                        }
+
+                        // 格式选择
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Layout.leftMargin: AppStyle.spacing.xl
+                            spacing: AppStyle.spacing.sm
+                            Text {
+                                text: qsTranslate("MainWindow", "格式:")
+                                color: AppStyle.colors.textSecondary
+                                font.pixelSize: AppStyle.fontSizes.xs
+                            }
+
+                            SidebarSegmentedControl {
+                                Layout.fillWidth: true
+                                model: ["WRL", "STEP", "Both"]
+                                currentIndex: {
+                                    if (!root.exportSettingsController)
+                                        return 0;
+                                    var fmt = root.exportSettingsController.exportModel3DFormat;
+                                    if (fmt === 3)
+                                        return 2;
+                                    if (fmt === 2)
+                                        return 1;
+                                    return 0;
+                                }
+                                onIndexChanged: {
+                                    if (!root.exportSettingsController)
+                                        return;
+                                    var val = index === 2 ? 3 : (index === 1 ? 2 : 1);
+                                    root.exportSettingsController.setExportModel3DFormat(val);
+                                }
+                            }
+                        }
+
+                        // 路径模式
+                        RowLayout {
+                            Layout.fillWidth: true
+                            Layout.leftMargin: AppStyle.spacing.xl
+                            spacing: AppStyle.spacing.sm
+                            Text {
+                                text: qsTranslate("MainWindow", "路径:")
+                                color: AppStyle.colors.textSecondary
+                                font.pixelSize: AppStyle.fontSizes.xs
+                            }
+
+                            SidebarSegmentedControl {
+                                Layout.fillWidth: true
+                                model: [qsTranslate("MainWindow", "相对"), qsTranslate("MainWindow", "绝对")]
+                                currentIndex: root.exportSettingsController ? root.exportSettingsController.exportModel3DPathMode : 0
+                                onIndexChanged: if (root.exportSettingsController)
+                                    root.exportSettingsController.setExportModel3DPathMode(index)
+                            }
+                        }
+                    }
+                }
+            }
+
+            SidebarToggleRow {
+                label: qsTranslate("MainWindow", "预览图")
+                checked: root.exportSettingsController ? root.exportSettingsController.exportPreviewImages : false
+                onToggled: if (root.exportSettingsController)
+                    root.exportSettingsController.setExportPreviewImages(checked)
+            }
+
+            SidebarToggleRow {
+                label: qsTranslate("MainWindow", "数据手册")
+                checked: root.exportSettingsController ? root.exportSettingsController.exportDatasheet : false
+                onToggled: if (root.exportSettingsController)
+                    root.exportSettingsController.setExportDatasheet(checked)
+            }
+        }
+
+        // ==================== 运行策略 ====================
+        SidebarSection {
+            title: qsTranslate("MainWindow", "运行策略")
+            SidebarSegmentedControl {
+                label: qsTranslate("MainWindow", "导出模式")
+                model: [qsTranslate("MainWindow", "追加"), qsTranslate("MainWindow", "覆盖")]
+                currentIndex: root.exportSettingsController ? root.exportSettingsController.exportMode : 0
+                onIndexChanged: if (root.exportSettingsController)
+                    root.exportSettingsController.setExportMode(index)
+            }
+
+            SidebarToggleRow {
+                label: qsTranslate("MainWindow", "弱网模式")
+                checked: root.exportSettingsController ? root.exportSettingsController.weakNetworkSupport : false
+                onToggled: if (root.exportSettingsController)
+                    root.exportSettingsController.setWeakNetworkSupport(checked)
+            }
+        }
+
+        // ==================== 库信息 ====================
+        SidebarSection {
+            title: qsTranslate("MainWindow", "库信息 (可选)")
+            SidebarTextField {
+                label: qsTranslate("MainWindow", "符号库描述")
+                text: root.exportSettingsController ? root.exportSettingsController.symbolLibraryDescription : ""
+                onTextEdited: if (root.exportSettingsController)
+                    root.exportSettingsController.setSymbolLibraryDescription(text)
+            }
+
+            SidebarTextField {
+                label: qsTranslate("MainWindow", "封装库描述")
+                text: root.exportSettingsController ? root.exportSettingsController.footprintLibraryDescription : ""
+                onTextEdited: if (root.exportSettingsController)
+                    root.exportSettingsController.setFootprintLibraryDescription(text)
+            }
+        }
+    }
+}

--- a/src/ui/qml/components/SidebarSettingsView.qml
+++ b/src/ui/qml/components/SidebarSettingsView.qml
@@ -20,7 +20,7 @@ Item {
                 label: qsTranslate("MainWindow", "输出路径")
                 text: root.exportSettingsController ? root.exportSettingsController.outputPath : ""
                 placeholder: qsTranslate("MainWindow", "选择目录...")
-                onTextEdited: (txt) => {
+                onTextEdited: txt => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setOutputPath(txt);
                 }
@@ -32,7 +32,7 @@ Item {
                 label: qsTranslate("MainWindow", "库名称")
                 text: root.exportSettingsController ? root.exportSettingsController.libName : ""
                 placeholder: "EasyEDA_Lib"
-                onTextEdited: (txt) => {
+                onTextEdited: txt => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setLibName(txt);
                 }
@@ -42,7 +42,7 @@ Item {
                 label: qsTranslate("MainWindow", "缓存目录")
                 text: root.exportSettingsController ? root.exportSettingsController.cacheDir : ""
                 placeholder: qsTranslate("MainWindow", "选择目录...")
-                onTextEdited: (txt) => {
+                onTextEdited: txt => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setCacheDir(txt);
                 }
@@ -57,7 +57,7 @@ Item {
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "符号库")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportSymbol : false
-                onToggled: (val) => {
+                onToggled: val => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setExportSymbol(val);
                 }
@@ -66,173 +66,298 @@ Item {
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "封装库")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportFootprint : false
-                onToggled: (val) => {
+                onToggled: val => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setExportFootprint(val);
                 }
             }
 
-            // 3D 模型 - 带有 L 型连接线和背景浸润的子选项
-            Item {
-                width: parent.width
-                height: model3dColumn.implicitHeight
-                Column {
-                    id: model3dColumn
-                    width: parent.width
-                    SidebarToggleRow {
-                        id: model3dToggle
-                        label: qsTranslate("MainWindow", "3D 模型")
-                        checked: root.exportSettingsController ? root.exportSettingsController.exportModel3D : false
-                        onToggled: (val) => {
-                            if (root.exportSettingsController)
-                                root.exportSettingsController.setExportModel3D(val);
+            // 3D 模型 - 扁平化子选项布局
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                SidebarToggleRow {
+                    id: model3dToggle
+                    label: qsTranslate("MainWindow", "3D 模型")
+                    checked: root.exportSettingsController ? root.exportSettingsController.exportModel3D : false
+                    onToggled: val => {
+                        if (root.exportSettingsController)
+                            root.exportSettingsController.setExportModel3D(val);
+                    }
+                }
+
+                // 子选项区域（高度动画 + clip）
+                Item {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: model3dToggle.checked ? subOptionsContainer.implicitHeight + AppStyle.spacing.sm : 0
+                    clip: true
+                    enabled: model3dToggle.checked
+                    Behavior on Layout.preferredHeight {
+                        NumberAnimation {
+                            duration: AppStyle.durations.fast
+                            easing.type: Easing.OutQuart
                         }
                     }
 
-                    // 子选项区域
+                    // L 型连接线（带脉冲动画）
                     Item {
-                        width: parent.width
-                        height: model3dToggle.checked ? subOptionsContainer.implicitHeight + AppStyle.spacing.sm : 0
-                        clip: true
-                        enabled: model3dToggle.checked
-                        Behavior on height {
+                        id: connectorLine
+                        x: AppStyle.spacing.lg + 2
+                        width: 16
+                        height: parent.height
+                        Rectangle {
+                            id: connectorVert
+                            x: 0
+                            y: 0
+                            width: 2
+                            height: parent.height
+                            color: AppStyle.colors.border
+                            opacity: 0.5
+                        }
+                        Rectangle {
+                            id: connectorHoriz
+                            x: 0
+                            y: Math.min(parent.height * 0.35, 28)
+                            width: 12
+                            height: 2
+                            color: AppStyle.colors.border
+                            opacity: 0.5
+                        }
+                        // 脉冲动画：切换格式/路径时触发
+                        SequentialAnimation {
+                            id: connectorPulse
+                            PropertyAction {
+                                targets: [connectorVert, connectorHoriz]
+                                property: "color"
+                                value: AppStyle.colors.primary
+                            }
+                            PropertyAction {
+                                targets: [connectorVert, connectorHoriz]
+                                property: "opacity"
+                                value: 0.9
+                            }
+                            PauseAnimation {
+                                duration: 120
+                            }
+                            ColorAnimation {
+                                targets: [connectorVert, connectorHoriz]
+                                property: "color"
+                                to: AppStyle.colors.border
+                                duration: 400
+                                easing.type: Easing.OutQuart
+                            }
                             NumberAnimation {
-                                duration: AppStyle.durations.fast
+                                targets: [connectorVert, connectorHoriz]
+                                property: "opacity"
+                                to: 0.5
+                                duration: 400
                                 easing.type: Easing.OutQuart
                             }
                         }
+                    }
 
-                        // L 型连接线
-                        Item {
-                            id: connectorLine
-                            x: AppStyle.spacing.lg + 2
-                            width: 16
-                            height: parent.height
-                            // 垂直段
-                            Rectangle {
-                                x: 0
-                                y: 0
-                                width: 2
-                                height: parent.height
-                                color: AppStyle.colors.border
-                                opacity: 0.5
-                            }
-                            // 水平段（在子项中点位置）
-                            Rectangle {
-                                x: 0
-                                y: Math.min(parent.height * 0.35, 28)
-                                width: 12
-                                height: 2
-                                color: AppStyle.colors.border
-                                opacity: 0.5
-                            }
+                    // 子选项内容（Item 容器解耦背景与布局）
+                    Item {
+                        id: subOptionsContainer
+                        anchors.left: connectorLine.right
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.topMargin: AppStyle.spacing.xs
+                        anchors.rightMargin: AppStyle.spacing.xs
+                        implicitHeight: subOptionsColumn.implicitHeight + AppStyle.spacing.sm
+                        // 背景浸润（独立于布局）
+                        Rectangle {
+                            anchors.fill: parent
+                            radius: AppStyle.radius.sm
+                            color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.04) : Qt.rgba(0, 0, 0, 0.04)
+                            border.width: AppStyle.isDarkMode ? 1 : 0
+                            border.color: Qt.rgba(255, 255, 255, 0.06)
+                            z: -1
                         }
 
-                        // 子选项内容（带背景浸润）
-                        Item {
-                            id: subOptionsContainer
-                            anchors.left: connectorLine.right
+                        ColumnLayout {
+                            id: subOptionsColumn
+                            anchors.left: parent.left
                             anchors.right: parent.right
                             anchors.top: parent.top
-                            anchors.topMargin: AppStyle.spacing.xs
-                            implicitHeight: subOptionsColumn.implicitHeight + AppStyle.spacing.sm
-                            // 背景浸润（不参与布局）
-                            Rectangle {
-                                anchors.fill: parent
-                                anchors.rightMargin: AppStyle.spacing.xs
-                                radius: AppStyle.radius.sm
-                                color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.04) : Qt.rgba(0, 0, 0, 0.04)
-                                border.width: AppStyle.isDarkMode ? 1 : 0
-                                border.color: Qt.rgba(255, 255, 255, 0.06)
-                            }
-
+                            anchors.margins: AppStyle.spacing.xs
+                            spacing: AppStyle.spacing.sm
+                            // 格式选择（滑块式）
                             ColumnLayout {
-                                id: subOptionsColumn
-                                width: parent.width
-                                anchors.top: parent.top
-                                anchors.topMargin: AppStyle.spacing.xs
-                                spacing: AppStyle.spacing.sm
-                                // 格式选择（标签在上，控件占满行）
-                                ColumnLayout {
-                                    Layout.fillWidth: true
-                                    Layout.leftMargin: AppStyle.spacing.sm
-                                    Layout.rightMargin: AppStyle.spacing.sm
-                                    spacing: 2
-                                    opacity: model3dToggle.checked ? 1 : 0
-                                    x: model3dToggle.checked ? 0 : 12
-                                    Behavior on opacity {
-                                        NumberAnimation {
-                                            duration: AppStyle.durations.fast
-                                        }
+                                Layout.fillWidth: true
+                                Layout.leftMargin: AppStyle.spacing.sm
+                                Layout.rightMargin: AppStyle.spacing.sm
+                                spacing: 2
+                                opacity: model3dToggle.checked ? 1 : 0
+                                x: model3dToggle.checked ? 0 : 12
+                                Behavior on opacity {
+                                    NumberAnimation {
+                                        duration: AppStyle.durations.fast
                                     }
-                                    Behavior on x {
-                                        NumberAnimation {
-                                            duration: AppStyle.durations.fast
-                                            easing.type: Easing.OutQuart
-                                        }
-                                    }
-
-                                    Text {
-                                        text: qsTranslate("MainWindow", "格式")
-                                        color: AppStyle.colors.textSecondary
-                                        font.pixelSize: AppStyle.fontSizes.xs
-                                    }
-
-                                    SidebarSegmentedControl {
-                                        Layout.fillWidth: true
-                                        model: ["WRL", "STEP", "Both"]
-                                        currentIndex: {
-                                            if (!root.exportSettingsController)
-                                                return 0;
-                                            var fmt = root.exportSettingsController.exportModel3DFormat;
-                                            if (fmt === 3)
-                                                return 2;
-                                            if (fmt === 2)
-                                                return 1;
-                                            return 0;
-                                        }
-                                        onIndexChanged: (idx) => {
-                                            if (!root.exportSettingsController)
-                                                return;
-                                            var val = idx === 2 ? 3 : (idx === 1 ? 2 : 1);
-                                            root.exportSettingsController.setExportModel3DFormat(val);
-                                        }
+                                }
+                                Behavior on x {
+                                    NumberAnimation {
+                                        duration: AppStyle.durations.fast
+                                        easing.type: Easing.OutQuart
                                     }
                                 }
 
-                                // 路径模式（标签在上，控件占满行，交错入场）
-                                ColumnLayout {
+                                Text {
+                                    text: qsTranslate("MainWindow", "格式")
+                                    color: AppStyle.colors.textSecondary
+                                    font.pixelSize: AppStyle.fontSizes.xs
+                                }
+
+                                Rectangle {
                                     Layout.fillWidth: true
-                                    Layout.leftMargin: AppStyle.spacing.sm
-                                    Layout.rightMargin: AppStyle.spacing.sm
-                                    spacing: 2
-                                    opacity: model3dToggle.checked ? 1 : 0
-                                    x: model3dToggle.checked ? 0 : 12
-                                    Behavior on opacity {
-                                        NumberAnimation {
-                                            duration: AppStyle.durations.fast
-                                        }
+                                    height: 30
+                                    radius: AppStyle.radius.sm
+                                    color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.06) : Qt.rgba(0, 0, 0, 0.06)
+                                    property int currentFormatIndex: {
+                                        if (!root.exportSettingsController)
+                                            return 0;
+                                        var fmt = root.exportSettingsController.exportModel3DFormat;
+                                        if (fmt === 3)
+                                            return 2;
+                                        if (fmt === 2)
+                                            return 1;
+                                        return 0;
                                     }
-                                    Behavior on x {
-                                        NumberAnimation {
-                                            duration: AppStyle.durations.fast
-                                            easing.type: Easing.OutQuart
+                                    Rectangle {
+                                        width: parent.width / 3
+                                        height: parent.height - 4
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        radius: AppStyle.radius.sm - 1
+                                        color: AppStyle.colors.surface
+                                        border.width: AppStyle.borderWidths.thin
+                                        border.color: AppStyle.colors.border
+                                        x: parent.currentFormatIndex * (parent.width / 3) + 2
+                                        Behavior on x {
+                                            NumberAnimation {
+                                                duration: 200
+                                                easing.type: Easing.OutQuart
+                                            }
                                         }
                                     }
 
-                                    Text {
-                                        text: qsTranslate("MainWindow", "路径")
-                                        color: AppStyle.colors.textSecondary
-                                        font.pixelSize: AppStyle.fontSizes.xs
+                                    Row {
+                                        anchors.fill: parent
+                                        anchors.margins: 2
+                                        Repeater {
+                                            model: ["WRL", "STEP", "Both"]
+                                            Item {
+                                                width: parent.width / 3
+                                                height: parent.height
+                                                Text {
+                                                    anchors.centerIn: parent
+                                                    text: modelData
+                                                    font.pixelSize: AppStyle.fontSizes.xs - 1
+                                                    font.bold: index === parent.parent.parent.currentFormatIndex
+                                                    color: index === parent.parent.parent.currentFormatIndex ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                                                    Behavior on color {
+                                                        ColorAnimation {
+                                                            duration: 200
+                                                        }
+                                                    }
+                                                }
+
+                                                MouseArea {
+                                                    anchors.fill: parent
+                                                    cursorShape: Qt.PointingHandCursor
+                                                    onClicked: {
+                                                        if (!root.exportSettingsController)
+                                                            return;
+                                                        var val = index === 2 ? 3 : (index === 1 ? 2 : 1);
+                                                        root.exportSettingsController.setExportModel3DFormat(val);
+                                                        connectorPulse.restart();
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // 路径模式（滑块式）
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                Layout.leftMargin: AppStyle.spacing.sm
+                                Layout.rightMargin: AppStyle.spacing.sm
+                                spacing: 2
+                                opacity: model3dToggle.checked ? 1 : 0
+                                x: model3dToggle.checked ? 0 : 12
+                                Behavior on opacity {
+                                    NumberAnimation {
+                                        duration: AppStyle.durations.fast
+                                    }
+                                }
+                                Behavior on x {
+                                    NumberAnimation {
+                                        duration: AppStyle.durations.fast
+                                        easing.type: Easing.OutQuart
+                                    }
+                                }
+
+                                Text {
+                                    text: qsTranslate("MainWindow", "路径")
+                                    color: AppStyle.colors.textSecondary
+                                    font.pixelSize: AppStyle.fontSizes.xs
+                                }
+
+                                Rectangle {
+                                    Layout.fillWidth: true
+                                    height: 30
+                                    radius: AppStyle.radius.sm
+                                    color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.06) : Qt.rgba(0, 0, 0, 0.06)
+                                    property int currentPathIndex: root.exportSettingsController ? root.exportSettingsController.exportModel3DPathMode : 0
+                                    Rectangle {
+                                        width: parent.width / 2
+                                        height: parent.height - 4
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        radius: AppStyle.radius.sm - 1
+                                        color: AppStyle.colors.surface
+                                        border.width: AppStyle.borderWidths.thin
+                                        border.color: AppStyle.colors.border
+                                        x: parent.currentPathIndex * (parent.width / 2) + 2
+                                        Behavior on x {
+                                            NumberAnimation {
+                                                duration: 200
+                                                easing.type: Easing.OutQuart
+                                            }
+                                        }
                                     }
 
-                                    SidebarSegmentedControl {
-                                        Layout.fillWidth: true
-                                        model: [qsTranslate("MainWindow", "相对"), qsTranslate("MainWindow", "绝对")]
-                                        currentIndex: root.exportSettingsController ? root.exportSettingsController.exportModel3DPathMode : 0
-                                        onIndexChanged: (idx) => {
-                                            if (root.exportSettingsController)
-                                                root.exportSettingsController.setExportModel3DPathMode(idx);
+                                    Row {
+                                        anchors.fill: parent
+                                        anchors.margins: 2
+                                        Repeater {
+                                            model: [qsTranslate("MainWindow", "相对"), qsTranslate("MainWindow", "绝对")]
+                                            Item {
+                                                width: parent.width / 2
+                                                height: parent.height
+                                                Text {
+                                                    anchors.centerIn: parent
+                                                    text: modelData
+                                                    font.pixelSize: AppStyle.fontSizes.xs - 1
+                                                    font.bold: index === parent.parent.parent.currentPathIndex
+                                                    color: index === parent.parent.parent.currentPathIndex ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                                                    Behavior on color {
+                                                        ColorAnimation {
+                                                            duration: 200
+                                                        }
+                                                    }
+                                                }
+
+                                                MouseArea {
+                                                    anchors.fill: parent
+                                                    cursorShape: Qt.PointingHandCursor
+                                                    onClicked: {
+                                                        if (root.exportSettingsController)
+                                                            root.exportSettingsController.setExportModel3DPathMode(index);
+                                                        connectorPulse.restart();
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -245,7 +370,7 @@ Item {
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "预览图")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportPreviewImages : false
-                onToggled: (val) => {
+                onToggled: val => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setExportPreviewImages(val);
                 }
@@ -254,7 +379,7 @@ Item {
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "数据手册")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportDatasheet : false
-                onToggled: (val) => {
+                onToggled: val => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setExportDatasheet(val);
                 }
@@ -343,20 +468,21 @@ Item {
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "弱网模式")
                 checked: root.exportSettingsController ? root.exportSettingsController.weakNetworkSupport : false
-                onToggled: (val) => {
+                onToggled: val => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setWeakNetworkSupport(val);
                 }
             }
         }
 
-        // ==================== 库信息 ====================
+        // ==================== 库信息（短窗口时自动隐藏） ====================
         SidebarSection {
             title: qsTranslate("MainWindow", "库信息 (可选)")
+            visible: !ResponsiveHelper.isShortWindow
             SidebarTextField {
                 label: qsTranslate("MainWindow", "符号库描述")
                 text: root.exportSettingsController ? root.exportSettingsController.symbolLibraryDescription : ""
-                onTextEdited: (txt) => {
+                onTextEdited: txt => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setSymbolLibraryDescription(txt);
                 }
@@ -365,7 +491,7 @@ Item {
             SidebarTextField {
                 label: qsTranslate("MainWindow", "封装库描述")
                 text: root.exportSettingsController ? root.exportSettingsController.footprintLibraryDescription : ""
-                onTextEdited: (txt) => {
+                onTextEdited: txt => {
                     if (root.exportSettingsController)
                         root.exportSettingsController.setFootprintLibraryDescription(txt);
                 }

--- a/src/ui/qml/components/SidebarSettingsView.qml
+++ b/src/ui/qml/components/SidebarSettingsView.qml
@@ -20,8 +20,10 @@ Item {
                 label: qsTranslate("MainWindow", "输出路径")
                 text: root.exportSettingsController ? root.exportSettingsController.outputPath : ""
                 placeholder: qsTranslate("MainWindow", "选择目录...")
-                onTextEdited: if (root.exportSettingsController)
-                    root.exportSettingsController.setOutputPath(text)
+                onTextEdited: (txt) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setOutputPath(txt);
+                }
                 browseIcon: "folder"
                 onBrowseClicked: root.openOutputFolderDialog()
             }
@@ -30,130 +32,210 @@ Item {
                 label: qsTranslate("MainWindow", "库名称")
                 text: root.exportSettingsController ? root.exportSettingsController.libName : ""
                 placeholder: "EasyEDA_Lib"
-                onTextEdited: if (root.exportSettingsController)
-                    root.exportSettingsController.setLibName(text)
+                onTextEdited: (txt) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setLibName(txt);
+                }
             }
 
             SidebarTextField {
                 label: qsTranslate("MainWindow", "缓存目录")
                 text: root.exportSettingsController ? root.exportSettingsController.cacheDir : ""
                 placeholder: qsTranslate("MainWindow", "选择目录...")
-                onTextEdited: if (root.exportSettingsController)
-                    root.exportSettingsController.setCacheDir(text)
+                onTextEdited: (txt) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setCacheDir(txt);
+                }
                 browseIcon: "folder"
                 onBrowseClicked: root.openCacheFolderDialog()
             }
         }
 
-        // ==================== 导出选项 (带横向收缩动画) ====================
+        // ==================== 导出选项 ====================
         SidebarSection {
             title: qsTranslate("MainWindow", "导出内容")
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "符号库")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportSymbol : false
-                onToggled: if (root.exportSettingsController)
-                    root.exportSettingsController.setExportSymbol(checked)
+                onToggled: (val) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setExportSymbol(val);
+                }
             }
 
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "封装库")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportFootprint : false
-                onToggled: if (root.exportSettingsController)
-                    root.exportSettingsController.setExportFootprint(checked)
+                onToggled: (val) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setExportFootprint(val);
+                }
             }
 
-            // 3D 模型 - 带有横向收缩的子选项
-            Column {
+            // 3D 模型 - 带有 L 型连接线和背景浸润的子选项
+            Item {
                 width: parent.width
-                SidebarToggleRow {
-                    id: model3dToggle
-                    label: qsTranslate("MainWindow", "3D 模型")
-                    checked: root.exportSettingsController ? root.exportSettingsController.exportModel3D : false
-                    onToggled: if (root.exportSettingsController)
-                        root.exportSettingsController.setExportModel3D(checked)
-                }
-
-                // 子选项：横向收缩显示
-                Item {
+                height: model3dColumn.implicitHeight
+                Column {
+                    id: model3dColumn
                     width: parent.width
-                    height: model3dToggle.checked ? subOptionsColumn.implicitHeight + AppStyle.spacing.sm : 0
-                    clip: true
-                    Behavior on height {
-                        NumberAnimation {
-                            duration: AppStyle.durations.fast
-                            easing.type: Easing.OutCubic
+                    SidebarToggleRow {
+                        id: model3dToggle
+                        label: qsTranslate("MainWindow", "3D 模型")
+                        checked: root.exportSettingsController ? root.exportSettingsController.exportModel3D : false
+                        onToggled: (val) => {
+                            if (root.exportSettingsController)
+                                root.exportSettingsController.setExportModel3D(val);
                         }
                     }
 
-                    ColumnLayout {
-                        id: subOptionsColumn
+                    // 子选项区域
+                    Item {
                         width: parent.width
-                        anchors.top: parent.top
-                        anchors.topMargin: AppStyle.spacing.xs
-                        opacity: model3dToggle.checked ? 1 : 0
-                        x: model3dToggle.checked ? 0 : 20 // 横向偏移动画
-                        Behavior on opacity {
+                        height: model3dToggle.checked ? subOptionsContainer.implicitHeight + AppStyle.spacing.sm : 0
+                        clip: true
+                        enabled: model3dToggle.checked
+                        Behavior on height {
                             NumberAnimation {
                                 duration: AppStyle.durations.fast
-                            }
-                        }
-                        Behavior on x {
-                            NumberAnimation {
-                                duration: AppStyle.durations.fast
-                                easing.type: Easing.OutBack
+                                easing.type: Easing.OutQuart
                             }
                         }
 
-                        // 格式选择
-                        RowLayout {
-                            Layout.fillWidth: true
-                            Layout.leftMargin: AppStyle.spacing.xl
-                            spacing: AppStyle.spacing.sm
-                            Text {
-                                text: qsTranslate("MainWindow", "格式:")
-                                color: AppStyle.colors.textSecondary
-                                font.pixelSize: AppStyle.fontSizes.xs
+                        // L 型连接线
+                        Item {
+                            id: connectorLine
+                            x: AppStyle.spacing.lg + 2
+                            width: 16
+                            height: parent.height
+                            // 垂直段
+                            Rectangle {
+                                x: 0
+                                y: 0
+                                width: 2
+                                height: parent.height
+                                color: AppStyle.colors.border
+                                opacity: 0.5
+                            }
+                            // 水平段（在子项中点位置）
+                            Rectangle {
+                                x: 0
+                                y: Math.min(parent.height * 0.35, 28)
+                                width: 12
+                                height: 2
+                                color: AppStyle.colors.border
+                                opacity: 0.5
+                            }
+                        }
+
+                        // 子选项内容（带背景浸润）
+                        Item {
+                            id: subOptionsContainer
+                            anchors.left: connectorLine.right
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.topMargin: AppStyle.spacing.xs
+                            implicitHeight: subOptionsColumn.implicitHeight + AppStyle.spacing.sm
+                            // 背景浸润（不参与布局）
+                            Rectangle {
+                                anchors.fill: parent
+                                anchors.rightMargin: AppStyle.spacing.xs
+                                radius: AppStyle.radius.sm
+                                color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.04) : Qt.rgba(0, 0, 0, 0.04)
+                                border.width: AppStyle.isDarkMode ? 1 : 0
+                                border.color: Qt.rgba(255, 255, 255, 0.06)
                             }
 
-                            SidebarSegmentedControl {
-                                Layout.fillWidth: true
-                                model: ["WRL", "STEP", "Both"]
-                                currentIndex: {
-                                    if (!root.exportSettingsController)
-                                        return 0;
-                                    var fmt = root.exportSettingsController.exportModel3DFormat;
-                                    if (fmt === 3)
-                                        return 2;
-                                    if (fmt === 2)
-                                        return 1;
-                                    return 0;
+                            ColumnLayout {
+                                id: subOptionsColumn
+                                width: parent.width
+                                anchors.top: parent.top
+                                anchors.topMargin: AppStyle.spacing.xs
+                                spacing: AppStyle.spacing.sm
+                                // 格式选择（标签在上，控件占满行）
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    Layout.leftMargin: AppStyle.spacing.sm
+                                    Layout.rightMargin: AppStyle.spacing.sm
+                                    spacing: 2
+                                    opacity: model3dToggle.checked ? 1 : 0
+                                    x: model3dToggle.checked ? 0 : 12
+                                    Behavior on opacity {
+                                        NumberAnimation {
+                                            duration: AppStyle.durations.fast
+                                        }
+                                    }
+                                    Behavior on x {
+                                        NumberAnimation {
+                                            duration: AppStyle.durations.fast
+                                            easing.type: Easing.OutQuart
+                                        }
+                                    }
+
+                                    Text {
+                                        text: qsTranslate("MainWindow", "格式")
+                                        color: AppStyle.colors.textSecondary
+                                        font.pixelSize: AppStyle.fontSizes.xs
+                                    }
+
+                                    SidebarSegmentedControl {
+                                        Layout.fillWidth: true
+                                        model: ["WRL", "STEP", "Both"]
+                                        currentIndex: {
+                                            if (!root.exportSettingsController)
+                                                return 0;
+                                            var fmt = root.exportSettingsController.exportModel3DFormat;
+                                            if (fmt === 3)
+                                                return 2;
+                                            if (fmt === 2)
+                                                return 1;
+                                            return 0;
+                                        }
+                                        onIndexChanged: (idx) => {
+                                            if (!root.exportSettingsController)
+                                                return;
+                                            var val = idx === 2 ? 3 : (idx === 1 ? 2 : 1);
+                                            root.exportSettingsController.setExportModel3DFormat(val);
+                                        }
+                                    }
                                 }
-                                onIndexChanged: {
-                                    if (!root.exportSettingsController)
-                                        return;
-                                    var val = index === 2 ? 3 : (index === 1 ? 2 : 1);
-                                    root.exportSettingsController.setExportModel3DFormat(val);
+
+                                // 路径模式（标签在上，控件占满行，交错入场）
+                                ColumnLayout {
+                                    Layout.fillWidth: true
+                                    Layout.leftMargin: AppStyle.spacing.sm
+                                    Layout.rightMargin: AppStyle.spacing.sm
+                                    spacing: 2
+                                    opacity: model3dToggle.checked ? 1 : 0
+                                    x: model3dToggle.checked ? 0 : 12
+                                    Behavior on opacity {
+                                        NumberAnimation {
+                                            duration: AppStyle.durations.fast
+                                        }
+                                    }
+                                    Behavior on x {
+                                        NumberAnimation {
+                                            duration: AppStyle.durations.fast
+                                            easing.type: Easing.OutQuart
+                                        }
+                                    }
+
+                                    Text {
+                                        text: qsTranslate("MainWindow", "路径")
+                                        color: AppStyle.colors.textSecondary
+                                        font.pixelSize: AppStyle.fontSizes.xs
+                                    }
+
+                                    SidebarSegmentedControl {
+                                        Layout.fillWidth: true
+                                        model: [qsTranslate("MainWindow", "相对"), qsTranslate("MainWindow", "绝对")]
+                                        currentIndex: root.exportSettingsController ? root.exportSettingsController.exportModel3DPathMode : 0
+                                        onIndexChanged: (idx) => {
+                                            if (root.exportSettingsController)
+                                                root.exportSettingsController.setExportModel3DPathMode(idx);
+                                        }
+                                    }
                                 }
-                            }
-                        }
-
-                        // 路径模式
-                        RowLayout {
-                            Layout.fillWidth: true
-                            Layout.leftMargin: AppStyle.spacing.xl
-                            spacing: AppStyle.spacing.sm
-                            Text {
-                                text: qsTranslate("MainWindow", "路径:")
-                                color: AppStyle.colors.textSecondary
-                                font.pixelSize: AppStyle.fontSizes.xs
-                            }
-
-                            SidebarSegmentedControl {
-                                Layout.fillWidth: true
-                                model: [qsTranslate("MainWindow", "相对"), qsTranslate("MainWindow", "绝对")]
-                                currentIndex: root.exportSettingsController ? root.exportSettingsController.exportModel3DPathMode : 0
-                                onIndexChanged: if (root.exportSettingsController)
-                                    root.exportSettingsController.setExportModel3DPathMode(index)
                             }
                         }
                     }
@@ -163,34 +245,108 @@ Item {
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "预览图")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportPreviewImages : false
-                onToggled: if (root.exportSettingsController)
-                    root.exportSettingsController.setExportPreviewImages(checked)
+                onToggled: (val) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setExportPreviewImages(val);
+                }
             }
 
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "数据手册")
                 checked: root.exportSettingsController ? root.exportSettingsController.exportDatasheet : false
-                onToggled: if (root.exportSettingsController)
-                    root.exportSettingsController.setExportDatasheet(checked)
+                onToggled: (val) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setExportDatasheet(val);
+                }
             }
         }
 
-        // ==================== 运行策略 ====================
+        // ==================== 运行策略（滑块式导出模式选择） ====================
         SidebarSection {
             title: qsTranslate("MainWindow", "运行策略")
-            SidebarSegmentedControl {
-                label: qsTranslate("MainWindow", "导出模式")
-                model: [qsTranslate("MainWindow", "追加"), qsTranslate("MainWindow", "覆盖")]
-                currentIndex: root.exportSettingsController ? root.exportSettingsController.exportMode : 0
-                onIndexChanged: if (root.exportSettingsController)
-                    root.exportSettingsController.setExportMode(index)
+            // 导出模式：滑块式二选一
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 2
+                Text {
+                    text: qsTranslate("MainWindow", "导出模式")
+                    font.pixelSize: AppStyle.fontSizes.xs
+                    color: AppStyle.colors.textSecondary
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    height: 36
+                    radius: AppStyle.radius.sm
+                    color: AppStyle.isDarkMode ? Qt.rgba(255, 255, 255, 0.06) : Qt.rgba(0, 0, 0, 0.06)
+                    // 滑块指示器
+                    Rectangle {
+                        id: modeSlider
+                        width: parent.width / 2
+                        height: parent.height - 4
+                        anchors.verticalCenter: parent.verticalCenter
+                        radius: AppStyle.radius.sm - 1
+                        color: AppStyle.colors.surface
+                        border.width: AppStyle.borderWidths.thin
+                        border.color: AppStyle.colors.border
+                        x: (root.exportSettingsController ? root.exportSettingsController.exportMode : 0) === 0 ? 2 : parent.width / 2
+                        Behavior on x {
+                            NumberAnimation {
+                                duration: 200
+                                easing.type: Easing.OutQuart
+                            }
+                        }
+                    }
+
+                    Row {
+                        anchors.fill: parent
+                        anchors.margins: 2
+                        Repeater {
+                            model: [qsTranslate("MainWindow", "追加"), qsTranslate("MainWindow", "覆盖")]
+                            Item {
+                                width: parent.width / 2
+                                height: parent.height
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: modelData
+                                    font.pixelSize: AppStyle.fontSizes.xs
+                                    font.bold: index === (root.exportSettingsController ? root.exportSettingsController.exportMode : 0)
+                                    color: index === (root.exportSettingsController ? root.exportSettingsController.exportMode : 0) ? AppStyle.colors.primary : AppStyle.colors.textSecondary
+                                    Behavior on color {
+                                        ColorAnimation {
+                                            duration: 200
+                                        }
+                                    }
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        if (root.exportSettingsController)
+                                            root.exportSettingsController.setExportMode(index);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    text: (root.exportSettingsController ? root.exportSettingsController.exportMode : 0) === 0 ? qsTranslate("MainWindow", "保留已有元器件，追加新的") : qsTranslate("MainWindow", "覆盖已有元器件，追加新的")
+                    font.pixelSize: AppStyle.fontSizes.xs - 1
+                    color: AppStyle.colors.textSecondary
+                    opacity: 0.7
+                }
             }
 
             SidebarToggleRow {
                 label: qsTranslate("MainWindow", "弱网模式")
                 checked: root.exportSettingsController ? root.exportSettingsController.weakNetworkSupport : false
-                onToggled: if (root.exportSettingsController)
-                    root.exportSettingsController.setWeakNetworkSupport(checked)
+                onToggled: (val) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setWeakNetworkSupport(val);
+                }
             }
         }
 
@@ -200,15 +356,19 @@ Item {
             SidebarTextField {
                 label: qsTranslate("MainWindow", "符号库描述")
                 text: root.exportSettingsController ? root.exportSettingsController.symbolLibraryDescription : ""
-                onTextEdited: if (root.exportSettingsController)
-                    root.exportSettingsController.setSymbolLibraryDescription(text)
+                onTextEdited: (txt) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setSymbolLibraryDescription(txt);
+                }
             }
 
             SidebarTextField {
                 label: qsTranslate("MainWindow", "封装库描述")
                 text: root.exportSettingsController ? root.exportSettingsController.footprintLibraryDescription : ""
-                onTextEdited: if (root.exportSettingsController)
-                    root.exportSettingsController.setFootprintLibraryDescription(text)
+                onTextEdited: (txt) => {
+                    if (root.exportSettingsController)
+                        root.exportSettingsController.setFootprintLibraryDescription(txt);
+                }
             }
         }
     }

--- a/src/ui/qml/components/SidebarTextField.qml
+++ b/src/ui/qml/components/SidebarTextField.qml
@@ -1,0 +1,46 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "../styles"
+
+ColumnLayout {
+    property string label: ""
+    property string text: ""
+    property string placeholder: ""
+    property string browseIcon: ""
+    signal browseClicked
+    signal textEdited(string text)
+    Layout.fillWidth: true
+    spacing: 2
+    Text {
+        text: label
+        font.pixelSize: AppStyle.fontSizes.xs
+        color: AppStyle.colors.textSecondary
+    }
+
+    RowLayout {
+        spacing: AppStyle.spacing.xs
+        TextField {
+            id: tf
+            Layout.fillWidth: true
+            text: parent.parent.text
+            placeholderText: parent.parent.placeholder
+            font.pixelSize: AppStyle.fontSizes.sm
+            color: AppStyle.colors.textPrimary
+            onTextChanged: parent.parent.textEdited(text)
+            background: Rectangle {
+                color: AppStyle.colors.surface
+                border.color: tf.focus ? AppStyle.colors.primary : AppStyle.colors.border
+                radius: AppStyle.radius.sm
+            }
+        }
+        ModernButton {
+            visible: browseIcon !== ""
+            iconName: browseIcon
+            Layout.preferredWidth: 32
+            Layout.preferredHeight: 32
+            backgroundColor: AppStyle.colors.border
+            onClicked: parent.parent.browseClicked()
+        }
+    }
+}

--- a/src/ui/qml/components/SidebarTextField.qml
+++ b/src/ui/qml/components/SidebarTextField.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts
 import "../styles"
 
 ColumnLayout {
+    id: fieldRoot
     property string label: ""
     property string text: ""
     property string placeholder: ""
@@ -13,7 +14,7 @@ ColumnLayout {
     Layout.fillWidth: true
     spacing: 2
     Text {
-        text: label
+        text: fieldRoot.label
         font.pixelSize: AppStyle.fontSizes.xs
         color: AppStyle.colors.textSecondary
     }
@@ -23,11 +24,15 @@ ColumnLayout {
         TextField {
             id: tf
             Layout.fillWidth: true
-            text: parent.parent.text
-            placeholderText: parent.parent.placeholder
+            text: fieldRoot.text
+            placeholderText: fieldRoot.placeholder
             font.pixelSize: AppStyle.fontSizes.sm
             color: AppStyle.colors.textPrimary
-            onTextChanged: parent.parent.textEdited(text)
+            onTextChanged: {
+                if (tf.activeFocus) {
+                    fieldRoot.textEdited(text);
+                }
+            }
             background: Rectangle {
                 color: AppStyle.colors.surface
                 border.color: tf.focus ? AppStyle.colors.primary : AppStyle.colors.border
@@ -35,12 +40,12 @@ ColumnLayout {
             }
         }
         ModernButton {
-            visible: browseIcon !== ""
-            iconName: browseIcon
+            visible: fieldRoot.browseIcon !== ""
+            iconName: fieldRoot.browseIcon
             Layout.preferredWidth: 32
             Layout.preferredHeight: 32
             backgroundColor: AppStyle.colors.border
-            onClicked: parent.parent.browseClicked()
+            onClicked: fieldRoot.browseClicked()
         }
     }
 }

--- a/src/ui/qml/components/SidebarToggleRow.qml
+++ b/src/ui/qml/components/SidebarToggleRow.qml
@@ -1,0 +1,45 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import "../styles"
+
+RowLayout {
+    property string label: ""
+    property bool checked: false
+    signal toggled(bool checked)
+    Layout.fillWidth: true
+    height: 32
+    Text {
+        text: label
+        Layout.fillWidth: true
+        font.pixelSize: AppStyle.fontSizes.sm
+        color: AppStyle.colors.textPrimary
+    }
+
+    Switch {
+        id: sw
+        checked: parent.checked
+        onToggled: parent.toggled(checked)
+        indicator: Rectangle {
+            implicitWidth: 36
+            implicitHeight: 20
+            x: sw.leftPadding
+            y: parent.height / 2 - height / 2
+            radius: 10
+            color: sw.checked ? AppStyle.colors.primary : AppStyle.colors.border
+            Rectangle {
+                x: sw.checked ? parent.width - width - 2 : 2
+                width: 16
+                height: 16
+                radius: 8
+                color: "white"
+                anchors.verticalCenter: parent.verticalCenter
+                Behavior on x {
+                    NumberAnimation {
+                        duration: 150
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/qml/styles/ResponsiveHelper.qml
+++ b/src/ui/qml/styles/ResponsiveHelper.qml
@@ -4,6 +4,7 @@ import QtQuick
 QtObject {
     // 窗口宽度 — 由 MainWindow 通过 Binding 写入，singleton 自身无法感知 Window
     property int windowWidth: 1200
+    property int windowHeight: 800
     // 断点系统
     enum Breakpoint {
         Compact,
@@ -28,8 +29,19 @@ QtObject {
     readonly property bool isExtraWide: breakpoint === ResponsiveHelper.Breakpoint.ExtraWide
     readonly property bool isAtLeastMedium: breakpoint >= ResponsiveHelper.Breakpoint.Medium
     readonly property bool isAtLeastWide: breakpoint >= ResponsiveHelper.Breakpoint.Wide
+    // 辅助判断
+    readonly property bool isSmallScreen: windowWidth < 1000 || windowHeight < 650
+    readonly property bool isUltraWide: windowWidth > 1920
+    readonly property bool isShortWindow: windowHeight < 700
     // 兼容旧接口（移除 DPI 缩放，固定为 1.0）
     readonly property real scaleFactor: 1.0
+    // 流式侧边栏宽度（比例 + 约束）
+    readonly property int sidebarWidth: {
+        var proportional = Math.floor(windowWidth * 0.26);
+        return Math.max(280, Math.min(proportional, 420));
+    }
+    // 动态外边距（大屏留白多，小屏紧凑）
+    readonly property int dynamicContentMargin: windowWidth > 1400 ? responsive(16, 24, 32, 40) : responsive(8, 12, 16, 20)
     // 自适应间距（逻辑像素，根据断点插值）
     readonly property var spacing: QtObject {
         readonly property int xs: responsive(2, 4, 4, 4)
@@ -42,10 +54,10 @@ QtObject {
     }
 
     // 自适应边距
-    readonly property int contentMargin: responsive(12, 24, 32, 40)
-    readonly property int cardSpacing: responsive(16, 24, 30, 30)
-    // 内容最大宽度（4K 下不无限拉宽）
-    readonly property int contentMaxWidth: 1320
+    readonly property int contentMargin: dynamicContentMargin
+    readonly property int cardSpacing: responsive(12, 16, 20, 24)
+    // 内容最大宽度（超宽屏下按比例，常规屏固定）
+    readonly property int contentMaxWidth: isUltraWide ? Math.floor(windowWidth * 0.65) : 1320
     // 导出选项布局
     readonly property int exportOptionColumns: isCompact ? 3 : isMedium ? 4 : 6
     // 兼容旧接口

--- a/src/ui/viewmodels/ComponentListViewModel.cpp
+++ b/src/ui/viewmodels/ComponentListViewModel.cpp
@@ -887,7 +887,7 @@ void ComponentListViewModel::handleFetchError(const QString& componentId, const 
                 item->setRetryable(!nonRetryable);
                 if (error.contains("No result", Qt::CaseInsensitive) ||
                     error.contains("not found", Qt::CaseInsensitive) || error.contains("404", Qt::CaseInsensitive)) {
-                    item->setErrorMessage(QStringLiteral("元器件不存在（404）"));
+                    item->setErrorMessage(tr("元器件不存在（404）"));
                 } else if (nonRetryable) {
                     item->setErrorMessage(error);
                 } else {
@@ -901,14 +901,14 @@ void ComponentListViewModel::handleFetchError(const QString& componentId, const 
                 // 只更新错误消息，不改变验证状态
                 if (error.contains("Request timeout", Qt::CaseInsensitive) ||
                     error.contains("timeout", Qt::CaseInsensitive)) {
-                    item->setErrorMessage("预览图获取超时（网络不稳定）");
+                    item->setErrorMessage(tr("预览图获取超时（网络不稳定）"));
                 } else if (error.contains("No result", Qt::CaseInsensitive) || error.contains("404") ||
                            error.contains("not found", Qt::CaseInsensitive)) {
-                    item->setErrorMessage("预览图不存在");
+                    item->setErrorMessage(tr("预览图不存在"));
                 } else if (error.contains("403")) {
-                    item->setErrorMessage("预览图获取被拒绝");
+                    item->setErrorMessage(tr("预览图获取被拒绝"));
                 } else {
-                    item->setErrorMessage("预览图获取失败");
+                    item->setErrorMessage(tr("预览图获取失败"));
                 }
             }
         } else {

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -633,6 +633,15 @@ bool ExportProgressViewModel::openLastExportedFolder() {
 }
 
 void ExportProgressViewModel::clearCache() {
+    // 中止进行中的导出
+    if (m_isExporting) {
+        cancelExport();
+    }
+    // 重置 ComponentService 批处理状态
+    if (m_componentService) {
+        m_componentService->abortBatchFetch();
+    }
+    // 清空 L1 内存 + L2 磁盘缓存
     ComponentCacheService::instance()->clearAllCache();
 }
 

--- a/src/ui/viewmodels/ExportProgressViewModel.cpp
+++ b/src/ui/viewmodels/ExportProgressViewModel.cpp
@@ -752,6 +752,16 @@ void ExportProgressViewModel::removeResult(const QString& componentId) {
     }
 }
 
+QVariantMap ExportProgressViewModel::getComponentExportStatus(const QString& componentId) const {
+    if (m_idToIndexMap.contains(componentId)) {
+        int index = m_idToIndexMap[componentId];
+        if (index >= 0 && index < m_resultsList.size()) {
+            return m_resultsList[index].toMap();
+        }
+    }
+    return {};
+}
+
 void ExportProgressViewModel::setStatus(const QString& status) {
     if (m_status != status) {
         m_status = status;

--- a/src/ui/viewmodels/ExportProgressViewModel.h
+++ b/src/ui/viewmodels/ExportProgressViewModel.h
@@ -141,6 +141,7 @@ public:
     Q_INVOKABLE void retryComponent(const QString& componentId);
     Q_INVOKABLE void retryFailedComponents();
     Q_INVOKABLE void removeResult(const QString& componentId);
+    Q_INVOKABLE QVariantMap getComponentExportStatus(const QString& componentId) const;
 
 public slots:
     void startExport(const QStringList& componentIds,

--- a/src/ui/viewmodels/SystemTrayManager.cpp
+++ b/src/ui/viewmodels/SystemTrayManager.cpp
@@ -70,7 +70,7 @@ void SystemTrayManager::initialize() {
     m_trayIcon->setIcon(appIcon);
     qDebug() << "System tray icon set successfully";
 
-    m_trayIcon->setToolTip(QStringLiteral("EasyKiConverter - LCSC 转换工具"));
+    m_trayIcon->setToolTip(tr("EasyKiConverter - LCSC 转换工具"));
 
     setupContextMenu();
     setupConnections();
@@ -91,14 +91,14 @@ void SystemTrayManager::setupContextMenu() {
     m_contextMenu = new QMenu();
     m_contextMenu->setWindowFlags(m_contextMenu->windowFlags() | Qt::Popup);
 
-    QAction* showAction = m_contextMenu->addAction(QStringLiteral("显示窗口"));
+    QAction* showAction = m_contextMenu->addAction(tr("显示窗口"));
     connect(showAction, &QAction::triggered, this, [this]() {
         qDebug() << "Show window action triggered";
         QTimer::singleShot(0, m_contextMenu, &QMenu::close);
         emit showWindowRequested();
     });
 
-    QAction* quitAction = m_contextMenu->addAction(QStringLiteral("退出"));
+    QAction* quitAction = m_contextMenu->addAction(tr("退出"));
     connect(quitAction, &QAction::triggered, this, [this]() {
         qDebug() << "Quit action triggered";
         QTimer::singleShot(0, m_contextMenu, &QMenu::close);
@@ -138,7 +138,7 @@ void SystemTrayManager::showExportNotification(int successCount,
     QSystemTrayIcon::MessageIcon iconType = QSystemTrayIcon::Information;
 
     if (failureCount > 0) {
-        title = QStringLiteral("导出完成");
+        title = tr("导出完成");
 
         double successRate = 0.0;
         if (successCount + failureCount > 0) {
@@ -147,36 +147,32 @@ void SystemTrayManager::showExportNotification(int successCount,
 
         if (successCount == 0) {
             iconType = QSystemTrayIcon::Critical;
-            message = QStringLiteral("导出失败：%1 个元器件全部失败").arg(successCount + failureCount);
+            message = tr("导出失败：%1 个元器件全部失败").arg(successCount + failureCount);
         } else if (successRate < 50.0) {
             iconType = QSystemTrayIcon::Warning;
-            message = QStringLiteral("成功 %1 个，失败 %2 个").arg(successCount).arg(failureCount);
+            message = tr("成功 %1 个，失败 %2 个").arg(successCount).arg(failureCount);
         } else {
-            message = QStringLiteral("成功 %1 个，失败 %2 个").arg(successCount).arg(failureCount);
+            message = tr("成功 %1 个，失败 %2 个").arg(successCount).arg(failureCount);
         }
 
         if (successCount > 0) {
-            message += QStringLiteral("\n输出：符号 %1 · 封装 %2 · 3D %3")
-                           .arg(symbolCount)
-                           .arg(footprintCount)
-                           .arg(model3DCount);
+            message += tr("\n输出：符号 %1 · 封装 %2 · 3D %3").arg(symbolCount).arg(footprintCount).arg(model3DCount);
         }
     } else {
         iconType = QSystemTrayIcon::Information;
-        title = QStringLiteral("导出完成");
+        title = tr("导出完成");
 
         if (successCount == 1) {
-            message = QStringLiteral("成功导出 1 个元器件");
+            message = tr("成功导出 1 个元器件");
         } else {
-            message = QStringLiteral("成功导出 %1 个元器件").arg(successCount);
+            message = tr("成功导出 %1 个元器件").arg(successCount);
         }
 
         QStringList stats;
-        stats
-            << QStringLiteral("输出：符号 %1 · 封装 %2 · 3D %3").arg(symbolCount).arg(footprintCount).arg(model3DCount);
+        stats << tr("输出：符号 %1 · 封装 %2 · 3D %3").arg(symbolCount).arg(footprintCount).arg(model3DCount);
 
         if (!duration.isEmpty()) {
-            stats << QStringLiteral("耗时：%1").arg(duration);
+            stats << tr("耗时：%1").arg(duration);
         }
 
         message += "\n" + stats.join("\n");

--- a/tests/unit/test_component_cache_service.cpp
+++ b/tests/unit/test_component_cache_service.cpp
@@ -66,6 +66,91 @@ private slots:
         QCOMPARE(loadedData->previewImages().value(0), QStringLiteral("https://image.lceda.cn/components/c.jpg"));
     }
 
+    // 回归测试：removeCache tombstone 阻止旧写入，但 clearTombstone 后允许新写入
+    void testRemoveCacheTombstoneBlocksStaleWrites() {
+        const QString componentId = QStringLiteral("C99999");
+        ComponentData data;
+        data.setLcscId(componentId);
+        data.setName(QStringLiteral("Tombstoned Component"));
+
+        // 先正常写入
+        m_cache->saveComponentMetadata(componentId, data);
+        QSharedPointer<ComponentData> loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded != nullptr);
+        QCOMPARE(loaded->name(), QStringLiteral("Tombstoned Component"));
+
+        // removeCache 会设置 tombstone
+        m_cache->removeCache(componentId);
+        loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded == nullptr);
+
+        // tombstone 状态下，带 generation 的写入应被阻止
+        const uint64_t staleGen = m_cache->currentGeneration();
+        data.setName(QStringLiteral("Should Not Write"));
+        m_cache->saveComponentMetadata(componentId, data, staleGen);
+        loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded == nullptr);  // tombstone 阻止了写入
+
+        // clearTombstone 后，新写入应成功
+        m_cache->clearTombstone(componentId);
+        data.setName(QStringLiteral("Should Write Now"));
+        m_cache->saveComponentMetadata(componentId, data);
+        loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded != nullptr);
+        QCOMPARE(loaded->name(), QStringLiteral("Should Write Now"));
+    }
+
+    // 回归测试：clearAllCache 全局 tombstone 阻止所有写入，clearGlobalTombstone 解除
+    void testGlobalTombstoneBlocksAllWrites() {
+        const QString componentId = QStringLiteral("C88888");
+        ComponentData data;
+        data.setLcscId(componentId);
+        data.setName(QStringLiteral("Global Tombstone Test"));
+
+        // clearAllCache 设置全局 tombstone
+        m_cache->clearAllCache();
+
+        // 带 generation 的写入应被阻止
+        const uint64_t gen = m_cache->currentGeneration();
+        m_cache->saveComponentMetadata(componentId, data, gen);
+        QSharedPointer<ComponentData> loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded == nullptr);  // 全局 tombstone 阻止了写入
+
+        // clearGlobalTombstone 后，新写入应成功
+        m_cache->clearGlobalTombstone();
+        m_cache->saveComponentMetadata(componentId, data);
+        loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded != nullptr);
+        QCOMPARE(loaded->name(), QStringLiteral("Global Tombstone Test"));
+    }
+
+    // 回归测试：generation 不匹配时写入被丢弃
+    void testStaleGenerationBlocksWrite() {
+        const QString componentId = QStringLiteral("C77777");
+        ComponentData data;
+        data.setLcscId(componentId);
+        data.setName(QStringLiteral("Stale Gen Test"));
+
+        // 捕获当前 generation
+        const uint64_t oldGen = m_cache->currentGeneration();
+
+        // clearAllCache 递增 generation
+        m_cache->clearAllCache();
+        m_cache->clearGlobalTombstone();  // 解除全局 tombstone
+
+        // 用旧 generation 写入应被丢弃
+        m_cache->saveComponentMetadata(componentId, data, oldGen);
+        QSharedPointer<ComponentData> loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded == nullptr);  // generation 不匹配，写入被丢弃
+
+        // 用新 generation 写入应成功
+        const uint64_t newGen = m_cache->currentGeneration();
+        m_cache->saveComponentMetadata(componentId, data, newGen);
+        loaded = m_cache->loadComponentData(componentId);
+        QVERIFY(loaded != nullptr);
+        QCOMPARE(loaded->name(), QStringLiteral("Stale Gen Test"));
+    }
+
     void testCacheDirMigrationPreservesExistingCache() {
         const QString componentId = QStringLiteral("C24680");
         ComponentData data;


### PR DESCRIPTION
改动目的

  本次改动解决两个核心问题：
  1. UI 布局效率低 — 原单列流式布局在宽屏下浪费空间，导出设置和操作按钮被推到屏幕外，用户需要反复滚动
  2. 缓存写入竞态 — 清空缓存后旧异步回调仍可能写回脏数据，导致"半成品"缓存目录复活，引发导出失败

  主要变更

  UI 布局重构（15 个文件，~2000 行）：
  - 新增响应式双列布局：宽屏（≥900px）左侧工作区 + 右侧毛玻璃侧边栏，窄屏自动退回单列
  - 侧边栏采用扁平化属性面板设计：Switch 替代 CheckBox、滑块式分段选择器替代 RadioButton
  - 侧边栏支持折叠/展开（顶部齿轮图标 + 侧边拨片），折叠态仅保留 48px 图标栏
  - 合并 ComponentInputCard + BomImportCard 为统一的"数据源"卡片，支持单个/批量标签切换
  - BOM 导入改为拖拽式卡片 UI（虚线边框 + Canvas 虚线渲染 + 状态感知）
  - 元器件列表支持搜索过滤、导出时自动折叠、导出状态原位显示（边框变色 + 底部状态条 + 扫光动画）
  - 窗口底部 2px 全局进度指示条，Compact 模式浮动操作栏
  - Canvas 背景替换为 Image + MultiEffect GPU 渲染
  - High DPI 适配：PassThrough 缩放策略

  缓存写入保护（8 个文件，~800 行）：
  - 新增 m_cacheGeneration 代次机制：clearAllCache() 递增代次，所有异步/同步写入在磁盘写锁内校验代次
  - 新增 per-component tombstone + 全局 tombstone：removeCache() 标记组件，clearAllCache() 全局阻止写入
  - m_diskWriteMutex 串行化所有磁盘写入与 clearAllCache()，消除竞态窗口
  - 所有缓存写入路径（metadata、CAD JSON、预览图、数据手册、3D 模型）统一传递 request-time generation token
  - ComponentService 内 generation 从 FetchingComponent.cacheGeneration 读取，不使用 fallback
  - 孤儿回调（无 FetchingComponent）直接丢弃，不再 fallback 到 currentGeneration()
  - 导出前从 ComponentService 刷新最新组件数据，确保用户 UI 编辑生效
  - 导出预加载严格校验：isValid() && symbolData && footprintData
  - 新增 3 个回归测试覆盖 tombstone、global tombstone、generation guard 场景